### PR TITLE
Moved tests over, questionable transfer of 'class TestParsePaper1Conf… 

### DIFF
--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -24,33 +24,6 @@ def test_config_namespace_attribute_test():
     with pytest.raises(AttributeError):
         assert namespace.param2 == 1
 
-"""
-class TestParsePaper1Config:
-
-    def setup(self):
-        #general parsing of the paper config
-        self.config = config_reader.TARDISConfiguration.from_yaml(data_path('paper1_tardis_configv1.yml'),
-                                                                  test_parser=True)
-        self.yaml_data = yaml.load(open(data_path('paper1_tardis_configv1.yml')))
-
-
-
-    def test_abundances(self):
-        oxygen_abundance = self.yaml_data['model']['abundances']['O']
-        assert_array_almost_equal(oxygen_abundance, self.config.abundances.ix[8].values)
-
-        assert True
-
-    def test_velocities(self):
-        assert_almost_equal(parse_quantity(self.yaml_data['model']['structure']['velocity']['start']),
-                            self.config.structure.v_inner[0])
-        assert_almost_equal(parse_quantity(self.yaml_data['model']['structure']['velocity']['stop']),
-                    self.config.structure.v_outer[-1])
-        assert len(self.config.structure.v_outer) == self.yaml_data['model']['structure']['velocity']['num']
-
-    def test_densities(self):
-        pass
-"""
 
 class TestParseConfigV1ASCIIDensity:
 

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -44,14 +44,7 @@ def test_element_symbol_reformatter():
     for unformatted_element_string, formatted_element_string in data:
         yield _test_element_symbol_reformatter, unformatted_element_string, formatted_element_string
 
-"""
-replaced with test found in test_config_reader
-NOTED FROM "Srinath R" posting on issue in github
 
-
-def test_element_symbol2atomic_number():
-    assert util.element_symbol2atomic_number('Si') == 14
-"""
 def test_element_symbol2atomic_number():
     atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
     def _test_element_symbol2atomic_number(element_string, atomic_number):


### PR DESCRIPTION
resolving issue #88

Transferred functions, classes, and necessary libraries that were dependent on one another.

Questionable deletion of two functions that were named the same:
_test_element_symbol2atomic_number():_
Note: function version in test_config_reader was transferred

Questionable transfer:
_class TestParsePaper1Config:_
Note: transferred from test_config_reader to test_util
