### PR TITLE
Fix for Issue #88: Moved test functions for tardis.util from test_config_reader

### DIFF
--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -1,6 +1,5 @@
 # tests for the config reader module
 
-from tardis import atomic
 from tardis.io import config_reader
 from astropy import units as u
 import os
@@ -8,28 +7,11 @@ import pytest
 import yaml
 
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
-from tardis.util import species_string_to_tuple, parse_quantity, element_symbol2atomic_number, reformat_element_symbol, MalformedQuantityError
-
+from tardis.util import parse_quantity
 
 def data_path(filename):
     data_dir = os.path.dirname(__file__)
     return os.path.join(data_dir, 'data', filename)
-
-
-
-def test_quantity_parser_normal():
-    q1 = parse_quantity('5 km/s')
-    assert q1.value == 5.
-    assert q1.unit == u.Unit('km/s')
-
-def test_quantity_parser_malformed_quantity1():
-    with pytest.raises(MalformedQuantityError):
-        q1 = parse_quantity('abcd')
-
-def test_quantity_parser_malformed_quantity2():
-    with pytest.raises(MalformedQuantityError):
-        q1 = parse_quantity('5 abcd')
-
 
 def test_config_namespace_attribute_test():
     namespace = config_reader.TARDISConfigurationNameSpace({'param1':1})
@@ -40,54 +22,12 @@ def test_config_namespace_attribute_test():
     with pytest.raises(AttributeError):
         assert namespace.param2 == 1
 
-
-def test_element_symbol_reformatter():
-    def _test_element_symbol_reformatter(unformatted_element_string, formatted_element_string):
-        assert reformat_element_symbol(unformatted_element_string) == formatted_element_string
-
-    data = [('si', 'Si'),
-            ('sI', 'Si'),
-            ('Si', 'Si'),
-            ('c', 'C'),
-            ('C', 'C'),
-            ]
-
-    for unformatted_element_string, formatted_element_string in data:
-        yield _test_element_symbol_reformatter, unformatted_element_string, formatted_element_string
-
-
-def test_element_symbol2atomic_number():
-    atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
-    def _test_element_symbol2atomic_number(element_string, atomic_number):
-        assert element_symbol2atomic_number(element_string) == atomic_number
-
-    data = [('sI', 14),
-            ('ca', 20),
-            ('Fe', 26)]
-
-    for element_symbol, atomic_number in data:
-        yield _test_element_symbol2atomic_number, element_symbol, atomic_number
-
 def test_quantity_linspace():
     quantity_linspace_dict = dict(start='1.1e4 km/s', stop='2e4 cm/h', num=1000)
     quantity_linspace = config_reader.parse_quantity_linspace(quantity_linspace_dict)
     assert_almost_equal(quantity_linspace[0].value, 1.1e4)
     assert_almost_equal(quantity_linspace[-1].to('cm/h').value, 2e4)
     assert len(quantity_linspace) == 1001
-
-
-def test_species_string_to_species():
-    atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
-    def _test_species_string_to_species_tuple(species_string, species_tuple):
-        assert species_string_to_tuple(species_string) == species_tuple
-
-    data = [('si ii', (14, 1) ),
-            ('si 2', (14, 1)),
-            ('si ix', (14, 8)),
-            ]
-
-    for species_string, species_tuple in data:
-        yield _test_species_string_to_species_tuple, species_string, species_tuple
 
 class TestParsePaper1Config:
 

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -1,8 +1,61 @@
-from tardis import util
+#tests for util module
 
+import pytest
+from astropy import units as u
+from tardis import atomic
+from tardis.util import species_string_to_tuple, parse_quantity, element_symbol2atomic_number, atomic_number2element_symbol, reformat_element_symbol, MalformedQuantityError
+
+def test_quantity_parser_normal():
+    q1 = parse_quantity('5 km/s')
+    assert q1.value == 5.
+    assert q1.unit == u.Unit('km/s')
+
+def test_quantity_parser_malformed_quantity1():
+    with pytest.raises(MalformedQuantityError):
+        q1 = parse_quantity('abcd')
+
+def test_quantity_parser_malformed_quantity2():
+    with pytest.raises(MalformedQuantityError):
+        q1 = parse_quantity('5 abcd')
 
 def test_atomic_number2element_symbol():
-    assert util.atomic_number2element_symbol(14) == 'Si'
+    assert atomic_number2element_symbol(14) == 'Si'
 
 def test_element_symbol2atomic_number():
-    assert util.element_symbol2atomic_number('Si') == 14
+    atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
+    def _test_element_symbol2atomic_number(element_string, atomic_number):
+        assert element_symbol2atomic_number(element_string) == atomic_number
+
+    data = [('sI', 14),
+            ('ca', 20),
+            ('Fe', 26)]
+
+    for element_symbol, atomic_number in data:
+        yield _test_element_symbol2atomic_number, element_symbol, atomic_number
+
+def test_element_symbol_reformatter():
+    def _test_element_symbol_reformatter(unformatted_element_string, formatted_element_string):
+        assert reformat_element_symbol(unformatted_element_string) == formatted_element_string
+
+    data = [('si', 'Si'),
+            ('sI', 'Si'),
+            ('Si', 'Si'),
+            ('c', 'C'),
+            ('C', 'C'),
+            ]
+
+    for unformatted_element_string, formatted_element_string in data:
+        yield _test_element_symbol_reformatter, unformatted_element_string, formatted_element_string
+
+def test_species_string_to_species():
+    atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
+    def _test_species_string_to_species_tuple(species_string, species_tuple):
+        assert species_string_to_tuple(species_string) == species_tuple
+
+    data = [('si ii', (14, 1) ),
+            ('si 2', (14, 1)),
+            ('si ix', (14, 8)),
+            ]
+
+    for species_string, species_tuple in data:
+        yield _test_species_string_to_species_tuple, species_string, species_tuple


### PR DESCRIPTION
@wkerzendorf - Moved test functions for tardis.util from test_config_reader
