### PR TITLE
importing problems with new C functions?

### DIFF
--- a/tardis/cmontecarlo.c
+++ b/tardis/cmontecarlo.c
@@ -49,12 +49,12 @@ npy_int64 binary_search(npy_float64 *x, npy_float64 x_insert, npy_int64 imin, np
   return imin;
 }
 
-inline npy_float64 compute_distance2outer(npy_float64 r, npy_float64 mu, npy_float64 r_outer)
+npy_float64 compute_distance2outer(npy_float64 r, npy_float64 mu, npy_float64 r_outer)
 {
   return sqrt(r_outer * r_outer + ((mu * mu - 1.0) * r * r)) - (r * mu);
 }
 
-inline npy_float64 compute_distance2inner(npy_float64 r, npy_float64 mu, npy_float64 r_inner)
+npy_float64 compute_distance2inner(npy_float64 r, npy_float64 mu, npy_float64 r_inner)
 {
   npy_float64 check = r_inner * r_inner + (r * r * (mu * mu - 1.0));
   if (check < 0.0) 
@@ -67,7 +67,7 @@ inline npy_float64 compute_distance2inner(npy_float64 r, npy_float64 mu, npy_flo
     }
 }
 
-inline npy_float64 compute_distance2line(npy_float64 r, npy_float64 mu, npy_float64 nu, npy_float64 nu_line, npy_float64 t_exp, npy_float64 inverse_t_exp, npy_float64 last_line, npy_float64 next_line, npy_int64 cur_zone_id)
+npy_float64 compute_distance2line(npy_float64 r, npy_float64 mu, npy_float64 nu, npy_float64 nu_line, npy_float64 t_exp, npy_float64 inverse_t_exp, npy_float64 last_line, npy_float64 next_line, npy_int64 cur_zone_id)
 {
   npy_float64 comov_nu, doppler_factor;
   doppler_factor = 1.0 - mu * r * inverse_t_exp * INVERSE_C;
@@ -91,7 +91,7 @@ inline npy_float64 compute_distance2line(npy_float64 r, npy_float64 mu, npy_floa
   return ((comov_nu - nu_line) / nu) * C * t_exp;
 }
 
-inline npy_float64 compute_distance2electron(npy_float64 r, npy_float64 mu, npy_float64 tau_event, npy_float64 inverse_ne)
+npy_float64 compute_distance2electron(npy_float64 r, npy_float64 mu, npy_float64 tau_event, npy_float64 inverse_ne)
 {
   return tau_event * inverse_ne;
 }

--- a/tardis/cmontecarlo.h
+++ b/tardis/cmontecarlo.h
@@ -85,7 +85,7 @@ npy_int64 line_search(npy_float64 *nu, npy_float64 nu_insert, npy_int64 number_o
  *
  * @return distance to the outer boundary
  */
-inline npy_float64 compute_distance2outer(npy_float64 r, npy_float64 mu, npy_float64 r_outer);
+npy_float64 compute_distance2outer(npy_float64 r, npy_float64 mu, npy_float64 r_outer);
 
 /** Calculate the distance to the inner boundary.
  *
@@ -95,7 +95,7 @@ inline npy_float64 compute_distance2outer(npy_float64 r, npy_float64 mu, npy_flo
  *
  * @return distance to the inner boundary
  */
-inline npy_float64 compute_distance2inner(npy_float64 r, npy_float64 mu, npy_float64 r_inner);
+npy_float64 compute_distance2inner(npy_float64 r, npy_float64 mu, npy_float64 r_inner);
 
 /** Calculate the distance the packet has to travel until it redshifts to the first spectral line.
  *
@@ -110,7 +110,7 @@ inline npy_float64 compute_distance2inner(npy_float64 r, npy_float64 mu, npy_flo
  *
  * @return distance to the next spectral line
  */
-inline npy_float64 compute_distance2line(npy_float64 r, npy_float64 mu, npy_float64 nu, npy_float64 nu_line, npy_float64 t_exp, npy_float64 inverse_t_exp, npy_float64 last_line, npy_float64 next_line, npy_int64 cur_zone_id);
+npy_float64 compute_distance2line(npy_float64 r, npy_float64 mu, npy_float64 nu, npy_float64 nu_line, npy_float64 t_exp, npy_float64 inverse_t_exp, npy_float64 last_line, npy_float64 next_line, npy_int64 cur_zone_id);
 
 /** Calculate the distance to the Thomson scatter event.
  * @param r distance from the center to the packet
@@ -120,6 +120,6 @@ inline npy_float64 compute_distance2line(npy_float64 r, npy_float64 mu, npy_floa
  *
  * @return distance to the Thomson scatter event in centimeters
  */
-inline npy_float64 compute_distance2electron(npy_float64 r, npy_float64 mu, npy_float64 tau_event, npy_float64 inverse_ne);
+npy_float64 compute_distance2electron(npy_float64 r, npy_float64 mu, npy_float64 tau_event, npy_float64 inverse_ne);
 
 #endif // TARDIS_CMONTECARLO_H


### PR DESCRIPTION
Hello

@orbitfold @wkerzendorf 

I'm having trouble with import (this is with latest master branch of code):

```
In [1]: from tardis.tests import montecarlo_test_wrappers
WARNING: ConfigurationDefaultMissingWarning: Requested default configuration file /Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tardis.cfg is not a file. Cannot install default profile. If you are importing from source, this is expected. [tardis._astropy_init]
ERROR: ImportError: dlopen(/Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tests/montecarlo_test_wrappers.so, 2): Symbol not found: _compute_distance2electron
  Referenced from: /Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tests/montecarlo_test_wrappers.so
  Expected in: flat namespace
 in /Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tests/montecarlo_test_wrappers.so [IPython.core.interactiveshell]
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-155ec909d77a> in <module>()
----> 1 from tardis.tests import montecarlo_test_wrappers

ImportError: dlopen(/Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tests/montecarlo_test_wrappers.so, 2): Symbol not found: _compute_distance2electron
  Referenced from: /Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tests/montecarlo_test_wrappers.so
  Expected in: flat namespace
 in /Users/stuartsim/Tardis/tardis/build/lib.macosx-10.9-x86_64-2.7/tardis/tests/montecarlo_test_wrappers.so
```

This problem means that the test suite doesn't work for me just now. Since it's complaining about computedistance2electon, I wonder if it's something to do with having moved those functions to C? Any suggestions?
