### PR TITLE
renamed Config to ConfigurationValidator

### DIFF
--- a/docs/configuration/config_validator.rst
+++ b/docs/configuration/config_validator.rst
@@ -66,11 +66,11 @@ If the type declaration for this container is finished you can specify all conta
 How to use
 ^^^^^^^^^^
                 
-To use the default parser create a new config object form the class Config by either from a dictionaries or from yaml files::
+To use the default parser create a new config object form the class ConfigurationValidator by either from a dictionaries or from yaml files::
 
-    My_config = Config(default configuration dictionary, user configuration dictionary)
+    My_config = ConfigurationValidator(default configuration dictionary, user configuration dictionary)
 
 or
-- My_config = Config.from_yaml(default configuration file, user configuration file)
+- My_config = ConfigurationValidator.from_yaml(default configuration file, user configuration file)
 To access the configuration for tardis use the method get_config 
 

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -12,7 +12,7 @@ import yaml
 import tardis
 from tardis.io.model_reader import read_density_file, \
     calculate_density_after_time, read_abundances_file
-from tardis.io.config_validator import Config
+from tardis.io.config_validator import ConfigurationValidator
 from tardis import atomic
 from tardis.util import species_string_to_tuple, parse_quantity, \
     element_symbol2atomic_number
@@ -773,7 +773,7 @@ class Configuration(ConfigurationNameSpace):
 
         config_definition = yaml.load(open(config_definition_file))
 
-        validated_config_dict = Config(config_definition,
+        validated_config_dict = ConfigurationValidator(config_definition,
                                        config_dict).get_config()
 
         #First let's see if we can find an atom_db anywhere:

--- a/tardis/io/config_validator.py
+++ b/tardis/io/config_validator.py
@@ -821,7 +821,7 @@ class DefaultParser(object):
         Returns
         -------
         value
-                Config value.
+                ConfigurationValidator value.
         """
         if self.__config_value is not None:
             if self.__type.check_type(self.__config_value):
@@ -1139,9 +1139,9 @@ class Container(DefaultParser):
             return self.__conf
 
 
-class Config(object):
+class ConfigurationValidator(object):
     """
-    An configuration object represents the parsed configuration.
+    An configuration validator parses an input dictionary with a default schema.
 
     Creates the configuration object.
     Parameters

--- a/tardis/io/tests/test_config_validator.py
+++ b/tardis/io/tests/test_config_validator.py
@@ -4,7 +4,7 @@ from glob import glob
 from astropy import units as u
 import pytest
 
-from tardis.io.config_validator import DefaultParser, Config, ConfigValueError
+from tardis.io.config_validator import DefaultParser, ConfigurationValidator, ConfigValueError
 
 
 existing_configs = glob(os.path.join('docs', 'examples', '*.yml'))
@@ -19,11 +19,11 @@ existing_configs.remove(test_config)
 
 @pytest.mark.parametrize("config_filename", existing_configs)
 def test_configread(config_filename):
-    config = Config.from_yaml(config_filename, config_definition)
+    config = ConfigurationValidator.from_yaml(config_filename, config_definition)
 
 
 def test_configread_test_config():
-    config = Config.from_yaml(test_config, test_config_definition)
+    config = ConfigurationValidator.from_yaml(test_config, test_config_definition)
 
 
 def default_parser_helper(test_dic, default, wdefault, value, wvalue, container, mandatory, return_default=None,

--- a/tardis/io/tests/test_configuration_namespace.py
+++ b/tardis/io/tests/test_configuration_namespace.py
@@ -1,5 +1,5 @@
 from tardis.io.config_reader import ConfigurationNameSpace
-from tardis.io.config_validator import Config
+from tardis.io.config_validator import ConfigurationValidator
 
 from astropy import units as u
 import os


### PR DESCRIPTION
This is the result of @ssim being confused by the nomenclature of the class names. All tests pass with it. As this is mainly your brainchild @mklauser, is this good to merge?
