### PR TITLE
how to get constant density? broken?

### DIFF
--- a/tardis/data/tardis_config_definition.yml
+++ b/tardis/data/tardis_config_definition.yml
@@ -180,7 +180,8 @@ model:
             property_type: container-property
             type:
                 property_type: container-declaration
-                containers: ['branch85_w7','exponential','power_law']
+                containers: ['branch85_w7','exponential','power_law', 'uniform']
+                _uniform: ['value']
                 _branch85_w7: []
                 +branch85_w7: ['w7_time_0', 'w7_rho_0', 'w7_v_0']
                 _power_law: ['time_0', 'rho_0', 'v_0', 'exponent']
@@ -227,6 +228,12 @@ model:
                 default: None
                 mandatory: True
                 help: exponent for exponential density profile
+
+            value:
+                property_type: quantity
+                default: None
+                mandatory: True
+                help: value for uniform density
 
     abundances:
         property_type: container-property

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -389,8 +389,7 @@ def parse_density_section(density_dict, v_inner, v_outer, time_explosion):
     #Parse density uniform
     def parse_uniform(density_dict, v_inner, v_outer, time_explosion):
         no_of_shells = len(v_inner)
-        return parse_quantity(density_dict['value']).to('g cm^-3') * \
-               np.ones(no_of_shells)
+        return density_dict['value'].to('g cm^-3') * np.ones(no_of_shells)
 
     density_parser['uniform'] = parse_uniform
 

--- a/tardis/io/tests/data/tardis_configv1_uniform_density.yml
+++ b/tardis/io/tests/data/tardis_configv1_uniform_density.yml
@@ -1,0 +1,62 @@
+tardis_config_version: v1.0
+supernova:
+    luminosity_requested: 9.44 log_lsun
+    time_explosion: 13 day
+
+atom_data: kurucz_cd23_chianti_H_He.h5
+
+
+model:
+
+    structure:
+        type: specific
+
+        velocity:
+            start : 11000 km/s
+            stop : 20000 km/s
+            num: 20
+
+        density:
+            type : uniform
+            value: 1.e-14 g/cm3
+
+    abundances:
+        type: uniform
+        O: 0.19
+        Mg: 0.03
+        Si: 0.52
+        S: 0.19
+        Ar: 0.04
+        Ca: 0.03
+
+plasma:
+    ionization: nebular
+    excitation: dilute-lte
+    radiative_rates_type: dilute-blackbody
+    line_interaction_type: scatter
+
+montecarlo:
+    seed: 23111963
+    no_of_packets : 1.0e+5
+    iterations: 10
+
+    black_body_sampling:
+        start: 1 angstrom
+        stop: 1000000 angstrom
+        num: 1.e+6
+    last_no_of_packets: 1.e+5
+    no_of_virtual_packets: 10
+
+    convergence_criteria:
+        type: specific
+        damping_constant: 1.0
+        threshold: 0.05
+        fraction: 0.8
+        hold: 3
+        t_inner:
+            damping_constant: 1.0
+
+spectrum:
+    start : 500 angstrom
+    stop : 20000 angstrom
+    num: 10000

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -211,7 +211,23 @@ class TestParseConfigV1ArtisDensityAbundancesVSlice:
     def test_abundances(self):
         assert_almost_equal(self.config.abundances.ix[14, 31], 2.156751e-01)
 
-        
+
+class TestParseConfigV1UniformDensity:
+
+    def setup(self):
+        #general parsing of the paper config
+        filename = 'tardis_configv1_uniform_density.yml'
+
+        self.yaml_data = yaml.load(open(data_path(filename)))
+
+        self.config = config_reader.Configuration.from_config_dict(self.yaml_data,
+                                                                  test_parser=True)
+
+    def test_density(self):
+        assert_array_almost_equal(self.config.structure.mean_densities,
+                                  1.e-14 * u.Unit('g / cm3'))
+
+
 class TestParseConfigV1ArtisDensityAbundancesAllAscii:
 
     def setup(self):


### PR DESCRIPTION
What has become of:

```
        density:
            type : uniform
            value: 1.e-14 g/cm3
```

we want that to work e.g. for the comparison with syn++. But that type of density doesn't work now. @wkerzendorf @mklauser I assume this got lost (or the way we specify it changed?) as a result of the config validator changes?
