### PR TITLE
fixes added for clang compile on mac

### DIFF
--- a/tardis/cmontecarlo.c
+++ b/tardis/cmontecarlo.c
@@ -1,5 +1,12 @@
 #include "cmontecarlo.h"
 
+rk_state mt_state;
+
+void initialize_random_kit(unsigned long seed)
+{
+    rk_seed(seed, &mt_state);
+}
+
 inline tardis_error_t line_search(double *nu, double nu_insert, int64_t number_of_lines, int64_t *result)
 {
   tardis_error_t ret_val = TARDIS_ERROR_OK;

--- a/tardis/cmontecarlo.h
+++ b/tardis/cmontecarlo.h
@@ -13,8 +13,6 @@
 #define C 29979245800.0
 #define INVERSE_C 3.33564095198152e-11
 
-rk_state mt_state;
-
 typedef enum
   {
     TARDIS_ERROR_OK = 0,
@@ -258,6 +256,8 @@ inline void rpacket_set_status(rpacket_t *packet, rpacket_status_t status);
 inline void rpacket_reset_tau_event(rpacket_t *packet);
 
 tardis_error_t rpacket_init(rpacket_t *packet, storage_model_t *storage, int packet_index, int virtual_packet_flag);
+
+void initialize_random_kit(unsigned long seed);
 
 #endif // TARDIS_CMONTECARLO_H
 

--- a/tardis/montecarlo.pyx
+++ b/tardis/montecarlo.pyx
@@ -89,23 +89,9 @@ cdef extern from "cmontecarlo.h":
     int rpacket_init(rpacket_t *packet, storage_model_t *storage, int packet_index, int virtual_packet_flag)
     double rpacket_get_nu(rpacket_t *packet)
     double rpacket_get_energy(rpacket_t *packet)
+    void initialize_random_kit(unsigned long seed)
 
-cdef extern from "randomkit.h":
-    ctypedef struct rk_state:
-        unsigned long key[624]
-        int pos
-        int has_gauss
-        double gauss
 
-    ctypedef enum rk_error:
-        RK_NOERR = 0
-        RK_ENODEV = 1
-        RK_ERR_MAX = 2
-
-    void rk_seed(unsigned long seed, rk_state *state)
-    double rk_double(rk_state *state)
-
-cdef extern rk_state mt_state
 
 def montecarlo_radial1d(model, int_type_t virtual_packet_flag=0):
     """
@@ -137,7 +123,7 @@ def montecarlo_radial1d(model, int_type_t virtual_packet_flag=0):
     """
     cdef storage_model_t storage
     cdef rpacket_t packet
-    rk_seed(model.tardis_config.montecarlo.seed, &mt_state)
+    initialize_random_kit(model.tardis_config.montecarlo.seed)
     cdef np.ndarray[double, ndim=1] packet_nus = model.packet_src.packet_nus
     storage.packet_nus = <double*> packet_nus.data
     cdef np.ndarray[double, ndim=1] packet_mus = model.packet_src.packet_mus


### PR DESCRIPTION
Fixes compilation problems on mac, by moving `mt_state` completely to the c-part of the code. The api is now a c-function called `initialize-random-kit` that is called form the cython library (thanks to @orbitfold )
