### PR TITLE
gui.py and running.rst edited for PyQt4 and PySide

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -55,6 +55,34 @@ This model can then be used for inspecting the run as described
 Graphical User Interface
 ========================
 
-A graphical user interface is being developed for this code using QT.
-We envision to have this available in the next few minor releases.
+**To run the GUI(under development) follow these steps:**
 
+The gui can use one of two python bindings for qt, namely PyQt4
+and PySide. You can choose which binding is used by setting the
+environment variable QT_API in your bash.
+
+**1**. Choosing between PySide and PyQt4 (optional)
+
+.. code-block:: none
+
+	#To choose PySide
+	export QT_API=pyside
+	
+	#To go back to PyQt4
+	unset QT_API
+
+**2**. An example of creating a model and GUI
+
+As of now, the GUI can be started from the ipython shell.  Currently there is no way to work completely from inside the GUI. 
+
+.. code-block:: none
+
+	ipython --pylab=qt4
+
+.. code-block:: python
+
+	>>> from tardis import run_tardis
+	>>> mdl = run_tardis('tardis_example.yml', 'kurucz_cd23_chianti_H_He.h5')
+	>>> from tardis import gui
+	>>> mdviewer = gui.ModelViewer()
+	>>> mdviewer.show_model(mdl)

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -61,7 +61,15 @@ The gui can use one of two python bindings for qt, namely PyQt4
 and PySide. You can choose which binding is used by setting the
 environment variable QT_API in your bash.
 
-**1**. Choosing between PySide and PyQt4 (optional)
+**1**. Installing required packages
+
+.. code-block:: none
+	
+	source activate tardis
+	conda install ipython=3.0.0 pyside=1.2.1 shiboken=1.2.1
+
+
+**2**. Choosing between PySide and PyQt4 (optional)
 
 .. code-block:: none
 
@@ -71,7 +79,7 @@ environment variable QT_API in your bash.
 	#To go back to PyQt4
 	unset QT_API
 
-**2**. An example of creating a model and GUI
+**3**. An example of creating a model and GUI
 
 As of now, the GUI can be started from the ipython shell.  Currently there is no way to work completely from inside the GUI. 
 

--- a/tardis/gui.py
+++ b/tardis/gui.py
@@ -8,7 +8,12 @@ from matplotlib.patches import Circle
 from matplotlib.figure import *
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt4 import NavigationToolbar2QT as NavigationToolbar
-from PySide import QtGui, QtCore
+import os
+if os.environ.get('QT_API', None) is None:
+    from PyQt4 import QtGui, QtCore
+else:
+    from PySide import QtGui, QtCore
+    
 from astropy import units as u
 from tardis import analysis, util
 


### PR DESCRIPTION
gui.py will now import PyQt4 or PySide depending on which is available and chosen (see documentation). So it is compatible with both bindings now. 

Details on how to choose a binding is added in running.rst.