### PR TITLE
Table headers now showing

### DIFF
--- a/tardis/gui.py
+++ b/tardis/gui.py
@@ -497,7 +497,7 @@ class SimpleTableModel(QtCore.QAbstractTableModel):
                     return self.headerdata[1][0] + str(self.index_info[section])
             else:
                 return self.headerdata[1][section]
-        return ""
+        return None
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
         if not index.isValid():


### PR DESCRIPTION
The table headers are now showing. The problem was in the method
headerdata(). The returned data type was not the right type.