### PR TITLE
Prliminary test using wrappers

### DIFF
--- a/tardis/montecarlo/wrappers/get_test_wrapper.pyx
+++ b/tardis/montecarlo/wrappers/get_test_wrapper.pyx
@@ -1,0 +1,34 @@
+import numpy as np
+cimport numpy as np
+
+ctypedef np.int64_t int_type_t
+
+cdef extern from "../src/cmontecarlo.h":
+    ctypedef enum rpacket_status_t:
+        TARDIS_PACKET_STATUS_IN_PROCESS = 0
+        TARDIS_PACKET_STATUS_EMITTED = 1
+        TARDIS_PACKET_STATUS_REABSORBED = 2
+
+    ctypedef struct rpacket_t:
+        double nu
+        double mu
+        double energy
+        double r
+        double tau_event
+        double nu_line
+        int_type_t current_shell_id
+        int_type_t next_line_id
+        int_type_t last_line
+        int_type_t close_line
+        int_type_t recently_crossed_boundary
+        int_type_t virtual_packet_flag
+        int_type_t virtual_packet
+        double d_line
+        double d_electron
+        double d_boundary
+        rpacket_status_t next_shell_id
+
+def getit(x):
+    return x
+    
+

--- a/tardis/montecarlo/wrappers/get_test_wrapper.pyx
+++ b/tardis/montecarlo/wrappers/get_test_wrapper.pyx
@@ -28,7 +28,19 @@ cdef extern from "../src/cmontecarlo.h":
         double d_boundary
         rpacket_status_t next_shell_id
 
+    double rpacket_get_nu(rpacket_t *packet)
+    void rpacket_set_nu(rpacket_t *packet, double nu)
+
 def getit(x):
     return x
+
+def get_rpacket_nu_value(nu_value):
+    cdef rpacket_t packet
+    rpacket_set_nu(&packet, nu_value)
+    ret_nu_value = rpacket_get_nu(&packet)
+    return ret_nu_value
+    
+
+
     
 

--- a/tardis/montecarlo/wrappers/setup_package.py
+++ b/tardis/montecarlo/wrappers/setup_package.py
@@ -8,9 +8,9 @@ from glob import glob
 def get_extensions():
     sources = ['tardis/montecarlo/wrappers/get_test_wrapper.pyx']
     sources += [os.path.relpath(fname) for fname in glob(
-        os.path.join(os.path.dirname(__file__), 'src', '*.c'))]
+        os.path.join(os.path.dirname(__file__), '..', 'src', '*.c'))]
     sources += [os.path.relpath(fname) for fname in glob(
-        os.path.join(os.path.dirname(__file__), 'src/randomkit', '*.c'))]
+        os.path.join(os.path.dirname(__file__), '..', 'src', 'randomkit', '*.c'))]
 
     return [Extension('tardis.montecarlo.wrappers.get_test_wrapper', sources,
                       include_dirs=['tardis/montecarlo/src',

--- a/tardis/montecarlo/wrappers/setup_package.py
+++ b/tardis/montecarlo/wrappers/setup_package.py
@@ -1,0 +1,19 @@
+from setuptools import Extension
+import numpy as np
+import os
+
+from glob import glob
+
+
+def get_extensions():
+    sources = ['tardis/montecarlo/wrappers/get_test_wrapper.pyx']
+    sources += [os.path.relpath(fname) for fname in glob(
+        os.path.join(os.path.dirname(__file__), 'src', '*.c'))]
+    sources += [os.path.relpath(fname) for fname in glob(
+        os.path.join(os.path.dirname(__file__), 'src/randomkit', '*.c'))]
+
+    return [Extension('tardis.montecarlo.wrappers.get_test_wrapper', sources,
+                      include_dirs=['tardis/montecarlo/src',
+                                    'tardis/montecarlo/src/randomkit',
+                                    np.get_include()])]
+

--- a/tardis/tests/test_montecarlo.py
+++ b/tardis/tests/test_montecarlo.py
@@ -10,6 +10,10 @@ def test_preliminary():
     y = get_test_wrapper.getit(3)
     assert y == 3
 
+def test_rpacket_get_nu():
+    nu_value = get_test_wrapper.get_rpacket_nu_value(1.456)
+    assert nu_value == 1.456
+
 # @pytest.mark.parametrize(("insert_value", "expected_insert_position"), [
 #     (9.5, 0),
 #     (8.5, 1),

--- a/tardis/tests/test_montecarlo.py
+++ b/tardis/tests/test_montecarlo.py
@@ -4,6 +4,12 @@ import pytest
 
 test_line_list = np.array([10, 9, 8, 7, 6, 5, 5, 4, 3, 2, 1]).astype(np.float64)
 
+from tardis.montecarlo.wrappers import get_test_wrapper
+
+def test_preliminary():
+    y = get_test_wrapper.getit(3)
+    assert y == 3
+
 # @pytest.mark.parametrize(("insert_value", "expected_insert_position"), [
 #     (9.5, 0),
 #     (8.5, 1),


### PR DESCRIPTION
@wkerzendorf  I tried just some preliminary tests(for a check). But I was unable to build extensions for the files inside the wrappers directory like the way in which extensions get built for the montecarlo files using montecarlo.pyx and setup_package.py.  Though I made a setup_package.py for the wrappers extension as well but this did not have built the extensions when I built tardis again.