### PR TITLE
One character added: fix to artis read of density?

### DIFF
--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -192,7 +192,7 @@ def read_artis_density(fname):
 
 
     velocity = u.Quantity(artis_model['velocities'], 'km/s').to('cm/s')
-    mean_density = u.Quantity(10 ** artis_model['mean_densities_0'], 'g/cm^3')
+    mean_density = u.Quantity(10 ** artis_model['mean_densities_0'], 'g/cm^3')[1:]
     v_inner, v_outer = velocity[:-1], velocity[1:]
 
     return time_of_model, artis_model['index'], v_inner, v_outer, mean_density


### PR DESCRIPTION
Fixes #290. 

Have been checking that the file reads work in the current version - looking for correct reading of artis files and consistency with reading of ascii files. 

It seems to me that the mean_density read for artis files is current mis-indexed by 1. This pull request is a suggested fix. 

@wkerzendorf What do you think? We should put in a test for this, but I forgot how to do that. Can you help with that sometime when you have a mo.