### PR TITLE
Test of model_reader.py

### DIFF
--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -192,7 +192,7 @@ def read_artis_density(fname):
 
 
     velocity = u.Quantity(artis_model['velocities'], 'km/s').to('cm/s')
-    mean_density = u.Quantity(10 ** artis_model['mean_densities_0'], 'g/cm^3')
+    mean_density = u.Quantity(10 ** artis_model['mean_densities_0'], 'g/cm^3')[1:]
     v_inner, v_outer = velocity[:-1], velocity[1:]
 
     return time_of_model, artis_model['index'], v_inner, v_outer, mean_density

--- a/tardis/io/tests/test_model_reader.py
+++ b/tardis/io/tests/test_model_reader.py
@@ -1,0 +1,6 @@
+from tardis.io.model_reader import read_artis_density
+
+import pytest
+
+def test_simple_read_artis_density():
+    assert True

--- a/tardis/io/tests/test_model_reader.py
+++ b/tardis/io/tests/test_model_reader.py
@@ -1,6 +1,25 @@
+import tardis
 from tardis.io.model_reader import read_artis_density
+
+from astropy import units as u
+import numpy as np
 
 import pytest
 
-def test_simple_read_artis_density():
-    assert True
+import os
+
+data_path = os.path.join(tardis.__path__[0], 'io', 'tests', 'data')
+
+@pytest.fixture
+def artis_density_fname():
+    return os.path.join(data_path, 'artis_model.dat')
+
+def test_simple_read_artis_density(artis_density_fname):
+    (time_of_model, index, v_inner, v_outer,
+     mean_density) = read_artis_density(artis_density_fname)
+
+    assert np.isclose(0.00114661 * u.day, time_of_model, atol=1e-7 * u.day)
+    assert len(mean_density) == 69
+    assert len(mean_density) == len(v_inner)
+
+

--- a/tardis/io/tests/test_model_reader.py
+++ b/tardis/io/tests/test_model_reader.py
@@ -1,5 +1,6 @@
 import tardis
-from tardis.io.model_reader import read_artis_density
+from tardis.io.model_reader import (read_artis_density,
+read_simple_ascii_abundances)
 
 from astropy import units as u
 import numpy as np
@@ -13,13 +14,25 @@ data_path = os.path.join(tardis.__path__[0], 'io', 'tests', 'data')
 @pytest.fixture
 def artis_density_fname():
     return os.path.join(data_path, 'artis_model.dat')
+@pytest.fixture
+def artis_abundances_fname():
+    return os.path.join(data_path, 'artis_abundances.dat')
 
 def test_simple_read_artis_density(artis_density_fname):
     (time_of_model, index, v_inner, v_outer,
      mean_density) = read_artis_density(artis_density_fname)
 
     assert np.isclose(0.00114661 * u.day, time_of_model, atol=1e-7 * u.day)
+    assert np.isclose(mean_density[23], 0.2250048 * u.g / u.cm**3, atol=1.e-6 * 
+        u.g / u.cm**3)
     assert len(mean_density) == 69
     assert len(mean_density) == len(v_inner)
+
+#Artis files are currently read with read ascii files function
+def test_read_simple_ascii_abundances(artis_abundances_fname):
+    index, abundances = read_simple_ascii_abundances(artis_abundances_fname)
+    assert len(abundances.columns) == 69
+    assert np.isclose(abundances[23].ix[2], 2.672351e-08 , atol=1.e-12)
+
 
 


### PR DESCRIPTION
@wkerzendorf Continuing on from PRs #292 and #297. Just added another few lines to the test to check that the zone parameters were being matched correctly between the model and abundance files. This was an issue with a previous version so it's a good thing to check. 