### PR TITLE
Added tests for plasma ion population properties related to LTE mode

### DIFF
--- a/tardis/plasma/tests/conftest.py
+++ b/tardis/plasma/tests/conftest.py
@@ -1,19 +1,27 @@
 import numpy as np
 import pandas as pd
 from astropy import units as u
-
 import pytest
-from tardis.plasma.standard_plasmas import LTEPlasma
 
+from tardis.plasma.properties.ion_population import (PhiSahaLTE,
+IonNumberDensity)
+from tardis.plasma.properties.general import (BetaRadiation, GElectron,
+NumberDensity)
+from tardis.plasma.properties.partition_function import (LevelBoltzmannFactor,
+LTEPartitionFunction)
+from tardis.plasma.properties.atomic import Levels, AtomicMass, IonizationData
+from tardis.plasma.standard_plasmas import LTEPlasma
 
 @pytest.fixture
 def number_of_cells():
     return 20
 
 @pytest.fixture
-def abundance(number_of_cells):
-    selected_atoms = [2]
-    abundances = [1.0]
+def selected_atoms():
+    return [2]
+
+@pytest.fixture
+def abundance(number_of_cells, selected_atoms):
     return pd.DataFrame(data=1.0, index=selected_atoms,
                         columns=range(20), dtype=np.float64)
 
@@ -34,9 +42,63 @@ def time_explosion():
 def t_rad(number_of_cells):
     return np.ones(number_of_cells) * 10000
 
-
 @pytest.fixture
 def standard_lte_plasma_he_db(t_rad, abundance, density, time_explosion,
                               included_he_atomic_data):
     return LTEPlasma(t_rad, abundance, density, time_explosion,
                      included_he_atomic_data)
+
+@pytest.fixture
+def beta_rad(t_rad):
+    beta_rad_module = BetaRadiation(None)
+    return beta_rad_module.calculate(t_rad)
+
+@pytest.fixture
+def g_electron(beta_rad):
+    g_electron_module = GElectron(None)
+    return g_electron_module.calculate(beta_rad)
+
+@pytest.fixture
+def levels(included_he_atomic_data, selected_atoms):
+    levels_module = Levels(None)
+    selected_atoms = [2]
+    return levels_module.calculate(included_he_atomic_data, selected_atoms)
+
+@pytest.fixture
+def level_boltzmann_factor(levels, beta_rad):
+    level_boltzmann_factor_module = LevelBoltzmannFactor(None)
+    return level_boltzmann_factor_module.calculate(levels, beta_rad)
+
+@pytest.fixture
+def partition_function(levels, level_boltzmann_factor):
+    partition_function_module = LTEPartitionFunction(None)
+    return partition_function_module.calculate(levels, level_boltzmann_factor)
+
+@pytest.fixture
+def ionization_data(included_he_atomic_data, selected_atoms):
+    ionization_data_module = IonizationData(None)
+    return ionization_data_module.calculate(included_he_atomic_data,
+        selected_atoms)
+
+@pytest.fixture
+def phi_saha_lte(g_electron, beta_rad, partition_function, ionization_data):
+    phi_module = PhiSahaLTE(None)
+    return phi_module.calculate(g_electron, beta_rad, partition_function,
+        ionization_data)
+
+@pytest.fixture
+def atomic_mass(included_he_atomic_data, selected_atoms):
+    atomic_mass_module = AtomicMass(None)
+    return atomic_mass_module.calculate(included_he_atomic_data,
+        selected_atoms)
+
+@pytest.fixture
+def number_density(atomic_mass, abundance, density):
+    number_density_module = NumberDensity(None)
+    return number_density_module.calculate(atomic_mass, abundance, density)
+
+@pytest.fixture
+def ion_number_density(phi_saha_lte, partition_function, number_density):
+    ion_number_density_module = IonNumberDensity(None)
+    return ion_number_density_module.calculate(phi_saha_lte,
+        partition_function, number_density)

--- a/tardis/plasma/tests/test_property_atomic.py
+++ b/tardis/plasma/tests/test_property_atomic.py
@@ -4,41 +4,30 @@ import tardis
 from tardis.plasma.properties.atomic import (Levels, Lines, 
 LinesLowerLevelIndex, LinesUpperLevelIndex, AtomicMass, IonizationData)
 
-def test_levels_property(included_he_atomic_data):
-    levels_module = Levels(None)
-    selected_atoms = [2]
-    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
+def test_levels_property(levels, selected_atoms, included_he_atomic_data):
     assert np.isclose(levels.ix[2].ix[0].ix[1]['energy'], 3.17545416e-11)
 
-def test_lines_property(included_he_atomic_data):
+def test_lines_property(included_he_atomic_data, selected_atoms):
     lines_module = Lines(None)
-    selected_atoms = [2]
     lines = lines_module.calculate(included_he_atomic_data, selected_atoms)
     assert np.isclose(lines.ix[564954]['wavelength'], 10833.307)
 
-def test_lines_lower_level_index_property(included_he_atomic_data):
-    selected_atoms = [2]
-    levels_module = Levels(None)
+def test_lines_lower_level_index_property(included_he_atomic_data,
+        selected_atoms, levels):
     lines_module = Lines(None)
-    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
     lines = lines_module.calculate(included_he_atomic_data, selected_atoms)
     lines_lower_module = LinesLowerLevelIndex(None)
     lines_lower_level_index = lines_lower_module.calculate(levels, lines)
     assert lines_lower_level_index[9] == 0
 
-def test_lines_upper_level_index_property(included_he_atomic_data):
-    selected_atoms = [2]
-    levels_module = Levels(None)
+def test_lines_upper_level_index_property(included_he_atomic_data,
+        selected_atoms, levels):
     lines_module = Lines(None)
-    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
     lines = lines_module.calculate(included_he_atomic_data, selected_atoms)
     lines_upper_module = LinesUpperLevelIndex(None)
     lines_upper_level_index = lines_upper_module.calculate(levels, lines)
     assert lines_upper_level_index[9] == 30
 
-def test_ionization_data_property(included_he_atomic_data):
-    ionization_data_module = IonizationData(None)
-    selected_atoms = [2]
-    ionization_data = ionization_data_module.calculate(included_he_atomic_data,
-        selected_atoms)
+def test_ionization_data_property(included_he_atomic_data,
+        ionization_data):
     assert np.isclose(float(ionization_data.ix[2].ix[1]), 3.9393336e-11)

--- a/tardis/plasma/tests/test_property_ion_population.py
+++ b/tardis/plasma/tests/test_property_ion_population.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 
 from tardis.plasma.properties.ion_population import (PhiSahaLTE,
@@ -8,68 +10,20 @@ from tardis.plasma.properties.partition_function import (LevelBoltzmannFactor,
 LTEPartitionFunction)
 from tardis.plasma.properties.atomic import Levels, AtomicMass, IonizationData
 
-def test_phi_saha_lte(t_rad, included_he_atomic_data):
-    beta_rad_module = BetaRadiation(None)
-    beta_rad = beta_rad_module.calculate(t_rad)
-    g_electron_module = GElectron(None)
-    g_electron = g_electron_module.calculate(beta_rad)
-    levels_module = Levels(None)
-    selected_atoms = [2]
-    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
-    level_boltzmann_factor_module = LevelBoltzmannFactor(None)
-    level_boltzmann_factor = level_boltzmann_factor_module.calculate(levels,
-        beta_rad)
-    partition_function_module = LTEPartitionFunction(None)
-    partition_function = partition_function_module.calculate(levels,
-        level_boltzmann_factor)
-    ionization_data_module = IonizationData(None)
-    ionization_data = ionization_data_module.calculate(included_he_atomic_data,
-        selected_atoms)
-    phi_module = PhiSahaLTE(None)
-    phi = phi_module.calculate(g_electron, beta_rad, partition_function,
-        ionization_data)
-    assert(phi.shape == (2,20))
+def test_phi_saha_lte(t_rad, beta_rad, g_electron, ionization_data,
+        phi_saha_lte):
+    assert(phi_saha_lte.shape == (2,20))
     assert np.all(np.isclose(g_electron * 4 * np.exp(
         -ionization_data.ionization_energy.ix[2].ix[1] * beta_rad),
-        phi.ix[2].ix[1]))
+        phi_saha_lte.ix[2].ix[1]))
 
-def test_ion_number_density(t_rad, abundance, density,
-        included_he_atomic_data):
-    beta_rad_module = BetaRadiation(None)
-    beta_rad = beta_rad_module.calculate(t_rad)
-    g_electron_module = GElectron(None)
-    g_electron = g_electron_module.calculate(beta_rad)
-    selected_atoms = [2]
-    atomic_mass_module = AtomicMass(None)
-    atomic_mass = atomic_mass_module.calculate(included_he_atomic_data,
-        selected_atoms)
-    number_density_module = NumberDensity(None)
-    number_density = number_density_module.calculate(atomic_mass,
-        abundance, density)
-    levels_module = Levels(None)
-    selected_atoms = [2]
-    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
-    level_boltzmann_factor_module = LevelBoltzmannFactor(None)
-    level_boltzmann_factor = level_boltzmann_factor_module.calculate(levels,
-        beta_rad)
-    partition_function_module = LTEPartitionFunction(None)
-    partition_function = partition_function_module.calculate(levels,
-        level_boltzmann_factor)
-    ionization_data_module = IonizationData(None)
-    ionization_data = ionization_data_module.calculate(included_he_atomic_data,
-        selected_atoms)
-    phi_module = PhiSahaLTE(None)
-    phi = phi_module.calculate(g_electron, beta_rad, partition_function,
-        ionization_data)
-    ion_number_density_module = IonNumberDensity(None)
-    ion_number_density = ion_number_density_module.calculate(phi,
-        partition_function, number_density)
+def test_ion_number_density(phi_saha_lte, ion_number_density):
     ion_numbers = ion_number_density.index.get_level_values(1).values
     ion_numbers = ion_numbers.reshape((ion_numbers.shape[0], 1))
     n_electron_from_ions = (ion_number_density.values * ion_numbers).sum(
         axis=0)
     n_electron_from_saha = (ion_number_density.ix[2].ix[0]/
-        ion_number_density.ix[2].ix[1]) * phi.ix[2].ix[1]
+        ion_number_density.ix[2].ix[1]) * phi_saha_lte.ix[2].ix[1]
     tolerance = 0.01 * n_electron_from_ions
     assert np.allclose(n_electron_from_ions, n_electron_from_saha,
         atol=tolerance)

--- a/tardis/plasma/tests/test_property_ion_population.py
+++ b/tardis/plasma/tests/test_property_ion_population.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+from tardis.plasma.properties.ion_population import (PhiSahaLTE,
+IonNumberDensity)
+from tardis.plasma.properties.general import (BetaRadiation, GElectron,
+NumberDensity)
+from tardis.plasma.properties.partition_function import (LevelBoltzmannFactor,
+LTEPartitionFunction)
+from tardis.plasma.properties.atomic import Levels, AtomicMass, IonizationData
+
+def test_phi_saha_lte(t_rad, included_he_atomic_data):
+    beta_rad_module = BetaRadiation(None)
+    beta_rad = beta_rad_module.calculate(t_rad)
+    g_electron_module = GElectron(None)
+    g_electron = g_electron_module.calculate(beta_rad)
+    levels_module = Levels(None)
+    selected_atoms = [2]
+    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
+    level_boltzmann_factor_module = LevelBoltzmannFactor(None)
+    level_boltzmann_factor = level_boltzmann_factor_module.calculate(levels,
+        beta_rad)
+    partition_function_module = LTEPartitionFunction(None)
+    partition_function = partition_function_module.calculate(levels,
+        level_boltzmann_factor)
+    ionization_data_module = IonizationData(None)
+    ionization_data = ionization_data_module.calculate(included_he_atomic_data,
+        selected_atoms)
+    phi_module = PhiSahaLTE(None)
+    phi = phi_module.calculate(g_electron, beta_rad, partition_function,
+        ionization_data)
+    assert(phi.shape == (2,20))
+    assert np.all(np.isclose(g_electron * 4 * np.exp(
+        -ionization_data.ionization_energy.ix[2].ix[1] * beta_rad),
+        phi.ix[2].ix[1]))
+
+def test_ion_number_density(t_rad, abundance, density,
+        included_he_atomic_data):
+    beta_rad_module = BetaRadiation(None)
+    beta_rad = beta_rad_module.calculate(t_rad)
+    g_electron_module = GElectron(None)
+    g_electron = g_electron_module.calculate(beta_rad)
+    selected_atoms = [2]
+    atomic_mass_module = AtomicMass(None)
+    atomic_mass = atomic_mass_module.calculate(included_he_atomic_data,
+        selected_atoms)
+    number_density_module = NumberDensity(None)
+    number_density = number_density_module.calculate(atomic_mass,
+        abundance, density)
+    levels_module = Levels(None)
+    selected_atoms = [2]
+    levels = levels_module.calculate(included_he_atomic_data, selected_atoms)
+    level_boltzmann_factor_module = LevelBoltzmannFactor(None)
+    level_boltzmann_factor = level_boltzmann_factor_module.calculate(levels,
+        beta_rad)
+    partition_function_module = LTEPartitionFunction(None)
+    partition_function = partition_function_module.calculate(levels,
+        level_boltzmann_factor)
+    ionization_data_module = IonizationData(None)
+    ionization_data = ionization_data_module.calculate(included_he_atomic_data,
+        selected_atoms)
+    phi_module = PhiSahaLTE(None)
+    phi = phi_module.calculate(g_electron, beta_rad, partition_function,
+        ionization_data)
+    ion_number_density_module = IonNumberDensity(None)
+    ion_number_density = ion_number_density_module.calculate(phi,
+        partition_function, number_density)
+    ion_numbers = ion_number_density.index.get_level_values(1).values
+    ion_numbers = ion_numbers.reshape((ion_numbers.shape[0], 1))
+    n_electron_from_ions = (ion_number_density.values * ion_numbers).sum(
+        axis=0)
+    n_electron_from_saha = (ion_number_density.ix[2].ix[0]/
+        ion_number_density.ix[2].ix[1]) * phi.ix[2].ix[1]
+    tolerance = 0.01 * n_electron_from_ions
+    assert np.allclose(n_electron_from_ions, n_electron_from_saha,
+        atol=tolerance)


### PR DESCRIPTION
This PR includes two tests. The first tests the calculation of 'phi' for an LTE plasma. The second checks that the ion populations (number densities) have been converged correctly, by checking that the electron density calculated from the ion populations is close to that obtained from the Saha equation. I'm focusing on testing the properties relevant to a simple LTE plasma for now because I'd like to be able to start working on that soon.