### PR TITLE
More work on cmontecarlo.c and the unit tests

### DIFF
--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -23,7 +23,7 @@ initialize_random_kit (unsigned long seed)
  */
 static tardis_error_t
 reverse_binary_search (const double *x, double x_insert,
-		       int64_t imin, int64_t imax, int64_t * result)
+                       int64_t imin, int64_t imax, int64_t * result)
 {
   /*
      Have in mind that *x points to a reverse sorted array.
@@ -384,7 +384,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
   double doppler_factor_ratio;
   double weight;
   int64_t virt_id_nu;
-  int64_t reabsorbed;
+  int64_t reabsorbed=-1;
   if (virtual_mode == 0)
     {
       reabsorbed = montecarlo_one_packet_loop (storage, packet, 0);
@@ -396,7 +396,6 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 	  for (i = 0; i < rpacket_get_virtual_packet_flag (packet); i++)
 	    {
               virt_packet = *packet;
-//	      memcpy ((void *) &virt_packet, (void *) packet, sizeof (rpacket_t));
 	      if (rpacket_get_r(&virt_packet) > storage->r_inner[0])
 		{
 		  mu_min =
@@ -428,6 +427,8 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 		default:
 		  fprintf (stderr, "Something has gone horribly wrong!\n");
                   // FIXME MR: we need to somehow signal an error here
+                  // I'm adding an exit() here to inform the compiler about the impossible path
+                  exit(1);
 		}
 	      doppler_factor_ratio =
 		rpacket_doppler_factor (packet, storage) /
@@ -711,6 +712,7 @@ montecarlo_compute_distances (rpacket_t * packet, storage_model_t * storage)
 			      compute_distance2boundary (packet, storage));
       double d_line;
       compute_distance2line (packet, storage, &d_line);
+      // FIXME MR: return status of compute_distance2line() is ignored
       rpacket_set_d_line (packet, d_line);
       compute_distance2continuum (packet, storage);
     }

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -12,13 +12,63 @@ initialize_random_kit (unsigned long seed)
   rk_seed (seed, &mt_state);
 }
 
-tardis_error_t line_search (double *nu, double nu_insert, int64_t number_of_lines,
+/** Look for a place to insert a value in an inversely sorted float array.
+ *
+ * @param x an inversely (largest to lowest) sorted float array
+ * @param x_insert a value to insert
+ * @param imin lower bound
+ * @param imax upper bound
+ *
+ * @return index of the next boundary to the left
+ */
+static tardis_error_t
+reverse_binary_search (const double *x, double x_insert,
+		       int64_t imin, int64_t imax, int64_t * result)
+{
+  /*
+     Have in mind that *x points to a reverse sorted array.
+     That is large values will have small indices and small ones
+     will have large indices.
+   */
+  tardis_error_t ret_val = TARDIS_ERROR_OK;
+  if (x_insert > x[imin] || x_insert < x[imax])
+    {
+      ret_val = TARDIS_ERROR_BOUNDS_ERROR;
+    }
+  else
+    {
+      int imid = (imin + imax)>>1;
+      while (imax - imin > 2)
+	{
+	  if (x[imid] < x_insert)
+	    {
+	      imax = imid + 1;
+	    }
+	  else
+	    {
+	      imin = imid;
+	    }
+	  imid = (imin + imax)>>1;
+	}
+      if (imax - imin == 2 && x_insert < x[imin + 1])
+	{
+	  *result = imin + 1;
+	}
+      else
+	{
+	  *result = imin;
+	}
+    }
+  return ret_val;
+}
+
+tardis_error_t
+line_search (const double *nu, double nu_insert, int64_t number_of_lines,
 	     int64_t * result)
 {
   tardis_error_t ret_val = TARDIS_ERROR_OK;
-  int64_t imin, imax;
-  imin = 0;
-  imax = number_of_lines - 1;
+  int64_t imin = 0;
+  int64_t imax = number_of_lines - 1;
   if (nu_insert > nu[imin])
     {
       *result = imin;
@@ -35,94 +85,8 @@ tardis_error_t line_search (double *nu, double nu_insert, int64_t number_of_line
   return ret_val;
 }
 
-tardis_error_t
-reverse_binary_search (double *x, double x_insert,
-		       int64_t imin, int64_t imax, int64_t * result)
-{
-  /*
-     Have in mind that *x points to a reverse sorted array.
-     That is large values will have small indices and small ones
-     will have large indices.
-   */
-  tardis_error_t ret_val = TARDIS_ERROR_OK;
-  if (x_insert > x[imin] || x_insert < x[imax])
-    {
-      ret_val = TARDIS_ERROR_BOUNDS_ERROR;
-    }
-  else
-    {
-      int imid = (imin + imax) / 2;
-      while (imax - imin > 2)
-	{
-	  if (x[imid] < x_insert)
-	    {
-	      imax = imid + 1;
-	    }
-	  else
-	    {
-	      imin = imid;
-	    }
-	  imid = (imin + imax) / 2;
-	}
-      if (imax - imin == 2 && x_insert < x[imin + 1])
-	{
-	  *result = imin + 1;
-	}
-      else
-	{
-	  *result = imin;
-	}
-    }
-  return ret_val;
-}
-
-tardis_error_t
-binary_search (double *x, double x_insert, int64_t imin,
-	       int64_t imax, int64_t * result)
-{
-  /*
-     Have in mind that *x points to a sorted array.
-     Like [1,2,3,4,5,...]
-   */
-  int imid;
-  tardis_error_t ret_val = TARDIS_ERROR_OK;
-  if (x_insert < x[imin] || x_insert > x[imax])
-    {
-      ret_val = TARDIS_ERROR_BOUNDS_ERROR;
-    }
-  else
-    {
-      while (imax >= imin)
-	{
-	  imid = (imin + imax) / 2;
-	  if (x[imid] == x_insert)
-	    {
-	      *result = imid;
-	      break;
-	    }
-	  else if (x[imid] < x_insert)
-	    {
-	      imin = imid + 1;
-	    }
-	  else
-	    {
-	      imax = imid - 1;
-	    }
-	}
-      if (imax - imid == 2 && x_insert < x[imin + 1])
-	{
-	  *result = imin;
-	}
-      else
-	{
-	  *result = imin;
-	}
-    }
-  return ret_val;
-}
-
 double
-rpacket_doppler_factor (rpacket_t * packet, storage_model_t * storage)
+rpacket_doppler_factor (const rpacket_t *packet, const storage_model_t *storage)
 {
   return 1.0 -
     rpacket_get_mu (packet) * rpacket_get_r (packet) *
@@ -132,39 +96,36 @@ rpacket_doppler_factor (rpacket_t * packet, storage_model_t * storage)
 /* Methods for calculating continuum opacities */
 
 double
-bf_cross_section(storage_model_t * storage, int64_t continuum_id, double comov_nu)
+bf_cross_section(const storage_model_t * storage, int64_t continuum_id, double comov_nu)
 {
+// FIXME MR: this seems like it should not be used in production!
   /* Temporary hardcoded values */
-  double chi_bf_partial = 0.25e-15;
-  double cont_chi_bf[] = {chi_bf_partial, 0.0, 2.0 * chi_bf_partial, 0.3 * chi_bf_partial, 2.0 * chi_bf_partial};
+#define chi_bf_partial 0.25e-15
+  static const double cont_chi_bf[] = {chi_bf_partial, 0.0, 2.0 * chi_bf_partial, 0.3 * chi_bf_partial, 2.0 * chi_bf_partial};
+#undef chi_bf_partial
   /* End of temporary hardcoded values */
 
   double sigma_bf = cont_chi_bf[continuum_id]; //storage->bf_cross_sections[continuum_id]
-  return sigma_bf * pow((storage->continuum_list_nu[continuum_id] / comov_nu), 3);
+  double tmp=storage->continuum_list_nu[continuum_id] / comov_nu;
+  return sigma_bf * tmp*tmp*tmp;
 }
 
 void calculate_chi_bf(rpacket_t * packet, storage_model_t * storage)
 {
-  double bf_helper = 0;
-  double comov_nu, doppler_factor;
-  double T;
-  double boltzmann_factor;
-  int64_t shell_id;
-  int64_t current_continuum_id;
-  int64_t i;
+  double doppler_factor = rpacket_doppler_factor (packet, storage);
+  double comov_nu = rpacket_get_nu (packet) * doppler_factor;
+
   int64_t no_of_continuum_edges = storage->no_of_edges;
-
-  doppler_factor = rpacket_doppler_factor (packet, storage);
-  comov_nu = rpacket_get_nu (packet) * doppler_factor;
-
+  int64_t current_continuum_id;
   line_search(storage->continuum_list_nu, comov_nu, no_of_continuum_edges, &current_continuum_id);
   rpacket_set_current_continuum_id(packet, current_continuum_id);
 
-  shell_id = rpacket_get_current_shell_id(packet);
-  T = storage->t_electrons[shell_id];
-  boltzmann_factor = exp(-(H * comov_nu) / KB / T);
+  int64_t shell_id = rpacket_get_current_shell_id(packet);
+  double T = storage->t_electrons[shell_id];
+  double boltzmann_factor = exp(-(H * comov_nu) / KB / T);
 
-  for(i = current_continuum_id; i < no_of_continuum_edges; i++)
+  double bf_helper = 0;
+  for(int64_t i = current_continuum_id; i < no_of_continuum_edges; i++)
   {
     // get the levelpopulation for the level ijk in the current shell:
     double l_pop = storage->l_pop[shell_id * no_of_continuum_edges + i];
@@ -179,7 +140,7 @@ void calculate_chi_bf(rpacket_t * packet, storage_model_t * storage)
 }
 
 double
-compute_distance2boundary (rpacket_t * packet, storage_model_t * storage)
+compute_distance2boundary (rpacket_t * packet, const storage_model_t * storage)
 {
   double r = rpacket_get_r (packet);
   double mu = rpacket_get_mu (packet);
@@ -219,7 +180,7 @@ compute_distance2boundary (rpacket_t * packet, storage_model_t * storage)
 }
 
 tardis_error_t
-compute_distance2line (rpacket_t * packet, storage_model_t * storage,
+compute_distance2line (const rpacket_t * packet, const storage_model_t * storage,
 		       double *result)
 {
   tardis_error_t ret_val = TARDIS_ERROR_OK;
@@ -236,9 +197,8 @@ compute_distance2line (rpacket_t * packet, storage_model_t * storage,
       double t_exp = storage->time_explosion;
       double inverse_t_exp = storage->inverse_time_explosion;
       int64_t cur_zone_id = rpacket_get_current_shell_id (packet);
-      double comov_nu, doppler_factor;
-      doppler_factor = 1.0 - mu * r * inverse_t_exp * INVERSE_C;
-      comov_nu = nu * doppler_factor;
+      double doppler_factor = 1.0 - mu * r * inverse_t_exp * INVERSE_C;
+      double comov_nu = nu * doppler_factor;
       if (comov_nu < nu_line)
 	{
 	  if (rpacket_get_next_line_id (packet) == storage->no_of_lines - 1)
@@ -287,14 +247,14 @@ compute_distance2line (rpacket_t * packet, storage_model_t * storage,
 void
 compute_distance2continuum(rpacket_t * packet, storage_model_t * storage)
 {
-  double chi_boundfree, chi_freefree, chi_electron, chi_continuum, d_continuum;
+  double chi_freefree, chi_electron, chi_continuum, d_continuum;
 
   if (storage->cont_status == CONTINUUM_ON)
   {
     calculate_chi_bf(packet, storage);
-    chi_boundfree = rpacket_get_chi_boundfree(packet);
+    double chi_boundfree = rpacket_get_chi_boundfree(packet);
     rpacket_set_chi_freefree(packet, 0.0);
-    chi_freefree = rpacket_get_chi_freefree(packet);
+    chi_freefree = rpacket_get_chi_freefree(packet); // MR ?? this is always zero
     chi_electron = storage->electron_densities[rpacket_get_current_shell_id(packet)] * storage->sigma_thomson *
        rpacket_doppler_factor (packet, storage);
     chi_continuum = chi_boundfree + chi_freefree + chi_electron;
@@ -302,6 +262,7 @@ compute_distance2continuum(rpacket_t * packet, storage_model_t * storage)
   }
   else
   {
+// FIXME MR: an assignment to chi_freefree seems to be missing here
     chi_electron = storage->electron_densities[rpacket_get_current_shell_id(packet)] * storage->sigma_thomson;
     chi_continuum = chi_electron;
     d_continuum = storage->inverse_electron_densities[rpacket_get_current_shell_id (packet)] *
@@ -335,17 +296,16 @@ compute_distance2continuum(rpacket_t * packet, storage_model_t * storage)
 }
 
 int64_t
-macro_atom (rpacket_t * packet, storage_model_t * storage)
+macro_atom (const rpacket_t * packet, const storage_model_t * storage)
 {
   int emit = 0, i = 0;
-  double p, event_random;
   int activate_level =
     storage->line2macro_level_upper[rpacket_get_next_line_id (packet) - 1];
   while (emit != -1)
     {
-      event_random = rk_double (&mt_state);
+      double event_random = rk_double (&mt_state);
       i = storage->macro_block_references[activate_level] - 1;
-      p = 0.0;
+      double p = 0.0;
       do
 	{
 	  p +=
@@ -364,12 +324,11 @@ macro_atom (rpacket_t * packet, storage_model_t * storage)
 double
 move_packet (rpacket_t * packet, storage_model_t * storage, double distance)
 {
-  double new_r, doppler_factor, comov_energy, comov_nu;
-  doppler_factor = rpacket_doppler_factor (packet, storage);
+  double doppler_factor = rpacket_doppler_factor (packet, storage);
   if (distance > 0.0)
     {
       double r = rpacket_get_r (packet);
-      new_r =
+      double new_r =
 	sqrt (r * r + distance * distance +
 	      2.0 * r * distance * rpacket_get_mu (packet));
       rpacket_set_mu (packet,
@@ -377,8 +336,8 @@ move_packet (rpacket_t * packet, storage_model_t * storage, double distance)
       rpacket_set_r (packet, new_r);
       if (rpacket_get_virtual_packet (packet) <= 0)
 	{
-	  comov_energy = rpacket_get_energy (packet) * doppler_factor;
-	  comov_nu = rpacket_get_nu (packet) * doppler_factor;
+	  double comov_energy = rpacket_get_energy (packet) * doppler_factor;
+	  double comov_nu = rpacket_get_nu (packet) * doppler_factor;
 #ifdef WITHOPENMP
 #pragma omp atomic
 #endif
@@ -395,18 +354,17 @@ move_packet (rpacket_t * packet, storage_model_t * storage, double distance)
 }
 
 void
-increment_j_blue_estimator (rpacket_t * packet, storage_model_t * storage,
+increment_j_blue_estimator (const rpacket_t * packet, storage_model_t * storage,
 			    double d_line, int64_t j_blue_idx)
 {
-  double comov_energy, r_interaction, mu_interaction, doppler_factor;
   double r = rpacket_get_r (packet);
-  r_interaction =
+  double r_interaction =
     sqrt (r * r + d_line * d_line +
 	  2.0 * r * d_line * rpacket_get_mu (packet));
-  mu_interaction = (rpacket_get_mu (packet) * r + d_line) / r_interaction;
-  doppler_factor = 1.0 - mu_interaction * r_interaction *
+  double mu_interaction = (rpacket_get_mu (packet) * r + d_line) / r_interaction;
+  double doppler_factor = 1.0 - mu_interaction * r_interaction *
     storage->inverse_time_explosion * INVERSE_C;
-  comov_energy = rpacket_get_energy (packet) * doppler_factor;
+  double comov_energy = rpacket_get_energy (packet) * doppler_factor;
 #ifdef WITHOPENMP
 #pragma omp atomic
 #endif
@@ -436,7 +394,8 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 	{
 	  for (i = 0; i < rpacket_get_virtual_packet_flag (packet); i++)
 	    {
-	      memcpy ((void *) &virt_packet, (void *) packet, sizeof (rpacket_t));
+              virt_packet = *packet;
+//	      memcpy ((void *) &virt_packet, (void *) packet, sizeof (rpacket_t));
 	      if (rpacket_get_r(&virt_packet) > storage->r_inner[0])
 		{
 		  mu_min =
@@ -467,6 +426,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 		  break;
 		default:
 		  fprintf (stderr, "Something has gone horribly wrong!\n");
+                  // FIXME MR: we need to somehow signal an error here
 		}
 	      doppler_factor_ratio =
 		rpacket_doppler_factor (packet, storage) /
@@ -515,7 +475,6 @@ void
 move_packet_across_shell_boundary (rpacket_t * packet,
 				   storage_model_t * storage, double distance)
 {
-  double comov_energy, doppler_factor, comov_nu, inverse_doppler_factor;
   move_packet (packet, storage, distance);
   if (rpacket_get_virtual_packet (packet) > 0)
     {
@@ -551,11 +510,11 @@ move_packet_across_shell_boundary (rpacket_t * packet,
     }
   else
     {
-      doppler_factor = rpacket_doppler_factor (packet, storage);
-      comov_nu = rpacket_get_nu (packet) * doppler_factor;
-      comov_energy = rpacket_get_energy (packet) * doppler_factor;
+      double doppler_factor = rpacket_doppler_factor (packet, storage);
+      double comov_nu = rpacket_get_nu (packet) * doppler_factor;
+      double comov_energy = rpacket_get_energy (packet) * doppler_factor;
       rpacket_set_mu (packet, rk_double (&mt_state));
-      inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
+      double inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
       rpacket_set_nu (packet, comov_nu * inverse_doppler_factor);
       rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
       rpacket_set_recently_crossed_boundary (packet, 1);
@@ -570,12 +529,11 @@ void
 montecarlo_thomson_scatter (rpacket_t * packet, storage_model_t * storage,
 			    double distance)
 {
-  double comov_energy, doppler_factor, comov_nu, inverse_doppler_factor;
-  doppler_factor = move_packet (packet, storage, distance);
-  comov_nu = rpacket_get_nu (packet) * doppler_factor;
-  comov_energy = rpacket_get_energy (packet) * doppler_factor;
+  double doppler_factor = move_packet (packet, storage, distance);
+  double comov_nu = rpacket_get_nu (packet) * doppler_factor;
+  double comov_energy = rpacket_get_energy (packet) * doppler_factor;
   rpacket_set_mu (packet, 2.0 * rk_double (&mt_state) - 1.0);
-  inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
+  double inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
   rpacket_set_nu (packet, comov_nu * inverse_doppler_factor);
   rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
   rpacket_reset_tau_event (packet);
@@ -592,17 +550,16 @@ montecarlo_bound_free_scatter (rpacket_t * packet, storage_model_t * storage, do
 {
   /* current position in list of continuum edges -> indicates which bound-free processes are possible */
   int64_t current_continuum_id = rpacket_get_current_continuum_id(packet);
-  int64_t ccontinuum; /* continuum_id of the continuum in which bf-absorption occurs */
 
-  double zrand, zrand_x_chibf, chi_bf, nu;
   // Determine in which continuum the bf-absorption occurs
-  nu = rpacket_get_nu(packet);
-  chi_bf = rpacket_get_chi_boundfree(packet);
+  double nu = rpacket_get_nu(packet);
+  double chi_bf = rpacket_get_chi_boundfree(packet);
   // get new zrand
-  zrand = (rk_double(&mt_state));
-  zrand_x_chibf = zrand * chi_bf;
+  double zrand = rk_double(&mt_state);
+  double zrand_x_chibf = zrand * chi_bf;
 
-  ccontinuum = current_continuum_id;
+  int64_t ccontinuum = current_continuum_id; /* continuum_id of the continuum in which bf-absorption occurs */
+
   while (storage->chi_bf_tmp_partial[ccontinuum] <= zrand_x_chibf)
   {
     ccontinuum++;
@@ -615,7 +572,7 @@ montecarlo_bound_free_scatter (rpacket_t * packet, storage_model_t * storage, do
 //      ccontinuum = current_continuum_id;
 //   }
 
-  zrand = (rk_double(&mt_state));
+  zrand = rk_double(&mt_state);
   if (zrand < storage->continuum_list_nu[ccontinuum] / nu)
   {
 	// go to ionization energy
@@ -640,14 +597,6 @@ void
 montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
 			 double distance)
 {
-  double comov_energy = 0.0;
-  int64_t emission_line_id = 0;
-  double old_doppler_factor = 0.0;
-  double inverse_doppler_factor = 0.0;
-  double tau_line = 0.0;
-  double tau_continuum = 0.0;
-  double tau_combined = 0.0;
-  bool virtual_close_line = false;
   int64_t j_blue_idx = -1;
   if (rpacket_get_virtual_packet (packet) == 0)
     {
@@ -656,12 +605,12 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
 	storage->line_lists_j_blues_nd + rpacket_get_next_line_id (packet);
       increment_j_blue_estimator (packet, storage, distance, j_blue_idx);
     }
-  tau_line =
+  double tau_line =
     storage->line_lists_tau_sobolevs[rpacket_get_current_shell_id (packet) *
 				     storage->line_lists_tau_sobolevs_nd +
 				     rpacket_get_next_line_id (packet)];
-  tau_continuum = rpacket_get_chi_continuum(packet) * distance;
-  tau_combined = tau_line + tau_continuum;
+  double tau_continuum = rpacket_get_chi_continuum(packet) * distance;
+  double tau_combined = tau_line + tau_continuum;
   rpacket_set_next_line_id (packet, rpacket_get_next_line_id (packet) + 1);
   if (rpacket_get_next_line_id (packet) == storage->no_of_lines)
     {
@@ -674,16 +623,17 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
     }
   else if (rpacket_get_tau_event (packet) < tau_combined)
     {
-      old_doppler_factor = move_packet (packet, storage, distance);
+      double old_doppler_factor = move_packet (packet, storage, distance);
       rpacket_set_mu (packet, 2.0 * rk_double (&mt_state) - 1.0);
-      inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
-      comov_energy = rpacket_get_energy (packet) * old_doppler_factor;
+      double inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
+      double comov_energy = rpacket_get_energy (packet) * old_doppler_factor;
       rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
       storage->last_line_interaction_in_id[rpacket_get_id (packet)] =
 	rpacket_get_next_line_id (packet) - 1;
       storage->last_line_interaction_shell_id[rpacket_get_id (packet)] =
 	rpacket_get_current_shell_id (packet);
       storage->last_interaction_type[rpacket_get_id (packet)] = 2;
+      int64_t emission_line_id = 0;
       if (storage->line_interaction_id == 0)
 	{
 	  emission_line_id = rpacket_get_next_line_id (packet) - 1;
@@ -703,7 +653,7 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
       rpacket_set_recently_crossed_boundary (packet, 0);
       if (rpacket_get_virtual_packet_flag (packet) > 0)
 	{
-	  virtual_close_line = false;
+	  bool virtual_close_line = false;
 	  if (!rpacket_get_last_line (packet) &&
 	      fabs (storage->line_list_nu[rpacket_get_next_line_id (packet)] -
 		    rpacket_get_nu_line (packet)) /
@@ -759,11 +709,10 @@ static montecarlo_event_handler_t
 get_event_handler (rpacket_t * packet, storage_model_t * storage,
 		   double *distance)
 {
-  double d_boundary, d_continuum, d_line;
   montecarlo_compute_distances (packet, storage);
-  d_boundary = rpacket_get_d_boundary (packet);
-  d_continuum = rpacket_get_d_continuum (packet);
-  d_line = rpacket_get_d_line (packet);
+  double d_boundary = rpacket_get_d_boundary (packet);
+  double d_continuum = rpacket_get_d_continuum (packet);
+  double d_line = rpacket_get_d_line (packet);
   montecarlo_event_handler_t handler;
   if (d_line <= d_boundary && d_line <= d_continuum)
     {
@@ -792,11 +741,9 @@ montecarlo_continuum_event_handler(rpacket_t * packet, storage_model_t * storage
     }
   else
     {
-  double zrand, normaliz_cont_th, normaliz_cont_bf, normaliz_cont_ff;
-  zrand = (rk_double(&mt_state));
-  normaliz_cont_th = rpacket_get_chi_electron(packet)/rpacket_get_chi_continuum(packet);
-  normaliz_cont_bf = rpacket_get_chi_boundfree(packet)/rpacket_get_chi_continuum(packet);
-  normaliz_cont_ff = rpacket_get_chi_freefree(packet)/rpacket_get_chi_continuum(packet);
+  double zrand = (rk_double(&mt_state));
+  double normaliz_cont_th = rpacket_get_chi_electron(packet)/rpacket_get_chi_continuum(packet);
+  double normaliz_cont_bf = rpacket_get_chi_boundfree(packet)/rpacket_get_chi_continuum(packet);
 
   if (zrand < normaliz_cont_th)
     {
@@ -863,13 +810,12 @@ montecarlo_one_packet_loop (storage_model_t * storage, rpacket_t * packet,
 void
 montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int nthreads, unsigned long seed)
 {
-  int64_t packet_index;
   storage->virt_packet_nus = (double *)malloc(sizeof(double) * storage->no_of_packets);
   storage->virt_packet_energies = (double *)malloc(sizeof(double) * storage->no_of_packets);
   storage->virt_packet_count = 0;
   storage->virt_array_size = storage->no_of_packets;
 #ifdef WITHOPENMP
-  fprintf(stderr, "Running with OpenMP - %d threads", nthreads);
+  fprintf(stderr, "Running with OpenMP - %d threads\n", nthreads);
   omp_set_dynamic(0);
   omp_set_num_threads(nthreads);
 #pragma omp parallel
@@ -877,10 +823,10 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
     initialize_random_kit(seed + omp_get_thread_num());
 #pragma omp for
 #else
-  fprintf(stderr, "Running without OpenMP");
+  fprintf(stderr, "Running without OpenMP\n");
   initialize_random_kit(seed);
 #endif
-  for (packet_index = 0; packet_index < storage->no_of_packets; packet_index++)
+  for (int64_t packet_index = 0; packet_index < storage->no_of_packets; packet_index++)
     {
       int reabsorbed = 0;
       rpacket_t packet;

--- a/tardis/montecarlo/src/cmontecarlo.h
+++ b/tardis/montecarlo/src/cmontecarlo.h
@@ -16,32 +16,7 @@ typedef void (*montecarlo_event_handler_t) (rpacket_t * packet,
 					    storage_model_t * storage,
 					    double distance);
 
-/** Look for a place to insert a value in an inversely sorted float array.
- *
- * @param x an inversely (largest to lowest) sorted float array
- * @param x_insert a value to insert
- * @param imin lower bound
- * @param imax upper bound
- *
- * @return index of the next boundary to the left
- */
-tardis_error_t reverse_binary_search (double *x, double x_insert,
-					     int64_t imin, int64_t imax,
-					     int64_t * result);
-
-/** Look for a place to insert a value in a sorted float array.
- *
- * @param x a (lowest to largest) sorted float array
- * @param x_insert a value to insert
- * @param imin lower bound
- * @param imax upper bound
- *
- * @return index of the next boundary to the left
- */
-tardis_error_t binary_search (double *x, double x_insert, int64_t imin,
-				     int64_t imax, int64_t * result);
-
-double rpacket_doppler_factor(rpacket_t * packet, storage_model_t * storage);
+double rpacket_doppler_factor(const rpacket_t *packet, const storage_model_t *storage);
 
 /** Calculate the distance to shell boundary.
  *
@@ -51,7 +26,7 @@ double rpacket_doppler_factor(rpacket_t * packet, storage_model_t * storage);
  * @return distance to shell boundary
  */
 double compute_distance2boundary (rpacket_t * packet,
-					 storage_model_t * storage);
+					 const storage_model_t * storage);
 
 /** Calculate the distance the packet has to travel until it redshifts to the first spectral line.
  *
@@ -60,19 +35,9 @@ double compute_distance2boundary (rpacket_t * packet,
  *
  * @return distance to the next spectral line
  */
-tardis_error_t compute_distance2line (rpacket_t * packet,
-						    storage_model_t * storage,
+tardis_error_t compute_distance2line (const rpacket_t * packet,
+						    const storage_model_t * storage,
 						    double *result);
-
-/** Calculate the distance to the Thomson scatter event.
- *
- * @param packet rpacket structure with packet information
- * @param storage storage model data
- *
- * @return distance to the Thomson scatter event in centimeters
- */
-double compute_distance2electron (rpacket_t * packet,
-					 storage_model_t * storage);
 
 /** Calculate the distance to the next continuum event, which can be a Thomson scattering, bound-free absorption or
     free-free transition.
@@ -84,12 +49,12 @@ double compute_distance2electron (rpacket_t * packet,
  */
 void compute_distance2continuum (rpacket_t * packet, storage_model_t * storage);
 
-int64_t macro_atom (rpacket_t * packet, storage_model_t * storage);
+int64_t macro_atom (const rpacket_t * packet, const storage_model_t * storage);
 
 double move_packet (rpacket_t * packet, storage_model_t * storage,
 			   double distance);
 
-void increment_j_blue_estimator (rpacket_t * packet,
+void increment_j_blue_estimator (const rpacket_t * packet,
 					storage_model_t * storage,
 					double d_line, int64_t j_blue_idx);
 
@@ -100,9 +65,9 @@ int64_t montecarlo_one_packet_loop (storage_model_t * storage,
 				    rpacket_t * packet,
 				    int64_t virtual_packet);
 
-void montecarlo_main_loop(storage_model_t * storage, 
+void montecarlo_main_loop(storage_model_t * storage,
 			  int64_t virtual_packet_flag,
-			  int nthreads, 
+			  int nthreads,
 			  unsigned long seed);
 
 /* New handlers for continuum implementation */
@@ -114,7 +79,7 @@ void montecarlo_free_free_scatter (rpacket_t * packet, storage_model_t * storage
 void montecarlo_bound_free_scatter (rpacket_t * packet, storage_model_t * storage, double distance);
 
 double
-bf_cross_section(storage_model_t * storage, int64_t continuum_id, double comov_nu);
+bf_cross_section(const storage_model_t * storage, int64_t continuum_id, double comov_nu);
 
 void calculate_chi_bf(rpacket_t * packet, storage_model_t * storage);
 

--- a/tardis/montecarlo/src/cmontecarlo1.h
+++ b/tardis/montecarlo/src/cmontecarlo1.h
@@ -9,7 +9,7 @@
  *
  * @return index of the next line ot the red. If the key value is redder than the reddest line returns number_of_lines.
  */
-tardis_error_t line_search (double *nu, double nu_insert,
+tardis_error_t line_search (const double *nu, double nu_insert,
        int64_t number_of_lines, int64_t * result);
 
 extern rk_state mt_state;

--- a/tardis/montecarlo/src/rpacket.h
+++ b/tardis/montecarlo/src/rpacket.h
@@ -69,7 +69,7 @@ typedef struct RPacket
   double chi_bf; /**< Opacity due to bound-free processes */
 } rpacket_t;
 
-static inline double rpacket_get_nu (rpacket_t * packet)
+static inline double rpacket_get_nu (const rpacket_t * packet)
 {
   return packet->nu;
 }
@@ -79,7 +79,7 @@ static inline void rpacket_set_nu (rpacket_t * packet, double nu)
   packet->nu = nu;
 }
 
-static inline double rpacket_get_mu (rpacket_t * packet)
+static inline double rpacket_get_mu (const rpacket_t * packet)
 {
   return packet->mu;
 }
@@ -89,7 +89,7 @@ static inline void rpacket_set_mu (rpacket_t * packet, double mu)
   packet->mu = mu;
 }
 
-static inline double rpacket_get_energy (rpacket_t * packet)
+static inline double rpacket_get_energy (const rpacket_t * packet)
 {
   return packet->energy;
 }
@@ -99,7 +99,7 @@ static inline void rpacket_set_energy (rpacket_t * packet, double energy)
   packet->energy = energy;
 }
 
-static inline double rpacket_get_r (rpacket_t * packet)
+static inline double rpacket_get_r (const rpacket_t * packet)
 {
   return packet->r;
 }
@@ -109,7 +109,7 @@ static inline void rpacket_set_r (rpacket_t * packet, double r)
   packet->r = r;
 }
 
-static inline double rpacket_get_tau_event (rpacket_t * packet)
+static inline double rpacket_get_tau_event (const rpacket_t * packet)
 {
   return packet->tau_event;
 }
@@ -119,7 +119,7 @@ static inline void rpacket_set_tau_event (rpacket_t * packet, double tau_event)
   packet->tau_event = tau_event;
 }
 
-static inline double rpacket_get_nu_line (rpacket_t * packet)
+static inline double rpacket_get_nu_line (const rpacket_t * packet)
 {
   return packet->nu_line;
 }
@@ -129,7 +129,7 @@ static inline void rpacket_set_nu_line (rpacket_t * packet, double nu_line)
   packet->nu_line = nu_line;
 }
 
-static inline unsigned int rpacket_get_current_shell_id (rpacket_t * packet)
+static inline unsigned int rpacket_get_current_shell_id (const rpacket_t * packet)
 {
   return packet->current_shell_id;
 }
@@ -140,7 +140,7 @@ static inline void rpacket_set_current_shell_id (rpacket_t * packet,
   packet->current_shell_id = current_shell_id;
 }
 
-static inline unsigned int rpacket_get_next_line_id (rpacket_t * packet)
+static inline unsigned int rpacket_get_next_line_id (const rpacket_t * packet)
 {
   return packet->next_line_id;
 }
@@ -151,7 +151,7 @@ static inline void rpacket_set_next_line_id (rpacket_t * packet,
   packet->next_line_id = next_line_id;
 }
 
-static inline bool rpacket_get_last_line (rpacket_t * packet)
+static inline bool rpacket_get_last_line (const rpacket_t * packet)
 {
   return packet->last_line;
 }
@@ -161,7 +161,7 @@ static inline void rpacket_set_last_line (rpacket_t * packet, bool last_line)
   packet->last_line = last_line;
 }
 
-static inline bool rpacket_get_close_line (rpacket_t * packet)
+static inline bool rpacket_get_close_line (const rpacket_t * packet)
 {
   return packet->close_line;
 }
@@ -171,7 +171,7 @@ static inline void rpacket_set_close_line (rpacket_t * packet, bool close_line)
   packet->close_line = close_line;
 }
 
-static inline int rpacket_get_recently_crossed_boundary (rpacket_t * packet)
+static inline int rpacket_get_recently_crossed_boundary (const rpacket_t * packet)
 {
   return packet->recently_crossed_boundary;
 }
@@ -182,7 +182,7 @@ static inline void rpacket_set_recently_crossed_boundary (rpacket_t * packet,
   packet->recently_crossed_boundary = recently_crossed_boundary;
 }
 
-static inline int rpacket_get_virtual_packet_flag (rpacket_t * packet)
+static inline int rpacket_get_virtual_packet_flag (const rpacket_t * packet)
 {
   return packet->virtual_packet_flag;
 }
@@ -193,7 +193,7 @@ static inline void rpacket_set_virtual_packet_flag (rpacket_t * packet,
   packet->virtual_packet_flag = virtual_packet_flag;
 }
 
-static inline int rpacket_get_virtual_packet (rpacket_t * packet)
+static inline int rpacket_get_virtual_packet (const rpacket_t * packet)
 {
   return packet->virtual_packet;
 }
@@ -204,7 +204,7 @@ static inline void rpacket_set_virtual_packet (rpacket_t * packet,
   packet->virtual_packet = virtual_packet;
 }
 
-static inline double rpacket_get_d_boundary (rpacket_t * packet)
+static inline double rpacket_get_d_boundary (const rpacket_t * packet)
 {
   return packet->d_boundary;
 }
@@ -214,7 +214,7 @@ static inline void rpacket_set_d_boundary (rpacket_t * packet, double d_boundary
   packet->d_boundary = d_boundary;
 }
 
-static inline double rpacket_get_d_electron (rpacket_t * packet)
+static inline double rpacket_get_d_electron (const rpacket_t * packet)
 {
   return packet->d_electron;
 }
@@ -224,7 +224,7 @@ static inline void rpacket_set_d_electron (rpacket_t * packet, double d_electron
   packet->d_electron = d_electron;
 }
 
-static inline double rpacket_get_d_line (rpacket_t * packet)
+static inline double rpacket_get_d_line (const rpacket_t * packet)
 {
   return packet->d_line;
 }
@@ -234,7 +234,7 @@ static inline void rpacket_set_d_line (rpacket_t * packet, double d_line)
   packet->d_line = d_line;
 }
 
-static inline int rpacket_get_next_shell_id (rpacket_t * packet)
+static inline int rpacket_get_next_shell_id (const rpacket_t * packet)
 {
   return packet->next_shell_id;
 }
@@ -244,7 +244,7 @@ static inline void rpacket_set_next_shell_id (rpacket_t * packet, int next_shell
   packet->next_shell_id = next_shell_id;
 }
 
-static inline rpacket_status_t rpacket_get_status (rpacket_t * packet)
+static inline rpacket_status_t rpacket_get_status (const rpacket_t * packet)
 {
   return packet->status;
 }
@@ -254,7 +254,7 @@ static inline void rpacket_set_status (rpacket_t * packet, rpacket_status_t stat
   packet->status = status;
 }
 
-static inline int rpacket_get_id (rpacket_t * packet)
+static inline int rpacket_get_id (const rpacket_t * packet)
 {
   return packet->id;
 }
@@ -279,7 +279,7 @@ static inline void rpacket_set_d_continuum (rpacket_t * packet, double d_continu
   packet->d_cont = d_continuum;
 }
 
-static inline double rpacket_get_d_continuum (rpacket_t * packet)
+static inline double rpacket_get_d_continuum (const rpacket_t * packet)
 {
   return packet->d_cont;
 }
@@ -289,7 +289,7 @@ static inline void rpacket_set_chi_electron (rpacket_t * packet, double chi_elec
   packet->chi_th = chi_electron;
 }
 
-static inline double rpacket_get_chi_electron (rpacket_t * packet)
+static inline double rpacket_get_chi_electron (const rpacket_t * packet)
 {
   return packet->chi_th;
 }
@@ -299,7 +299,7 @@ static inline void rpacket_set_chi_continuum (rpacket_t * packet, double chi_con
   packet->chi_cont = chi_continuum;
 }
 
-static inline double rpacket_get_chi_continuum (rpacket_t * packet)
+static inline double rpacket_get_chi_continuum (const rpacket_t * packet)
 {
   return packet->chi_cont;
 }
@@ -309,7 +309,7 @@ static inline void rpacket_set_chi_freefree (rpacket_t * packet, double chi_free
   packet->chi_ff = chi_freefree;
 }
 
-static inline double rpacket_get_chi_freefree (rpacket_t * packet)
+static inline double rpacket_get_chi_freefree (const rpacket_t * packet)
 {
   return packet->chi_ff;
 }
@@ -319,12 +319,12 @@ static inline void rpacket_set_chi_boundfree (rpacket_t * packet, double chi_bou
   packet->chi_bf = chi_boundfree;
 }
 
-static inline double rpacket_get_chi_boundfree (rpacket_t * packet)
+static inline double rpacket_get_chi_boundfree (const rpacket_t * packet)
 {
   return packet->chi_bf;
 }
 
-static inline unsigned int rpacket_get_current_continuum_id (rpacket_t * packet)
+static inline unsigned int rpacket_get_current_continuum_id (const rpacket_t * packet)
 {
   return packet->current_continuum_id;
 }

--- a/tardis/montecarlo/src/test_cmontecarlo.c
+++ b/tardis/montecarlo/src/test_cmontecarlo.c
@@ -22,6 +22,7 @@ double test_compute_distance2line(void);
 double test_compute_distance2continuum(void);
 double test_rpacket_doppler_factor(void);
 double test_move_packet(void);
+bool test_move_packet_across_shell_boundary(void);
 int64_t test_montecarlo_one_packet(void);
 int64_t test_montecarlo_one_packet_loop(void);
 bool test_montecarlo_line_scatter(void);
@@ -171,58 +172,61 @@ init_storage_model(void){
 	sm->t_electrons[0] = 2;
 	sm->t_electrons[1] = 2;
 
-// MR: these memsets are wrong: memset() operates on raw bytes!
 	sm->l_pop = (double *) malloc(sizeof(double )*20000);
-// MR: the sizeof() argument looks suspicious!
-	memset(sm->l_pop, 2, sizeof(sm->l_pop));
+        for (size_t i=0; i<20000; ++i)
+          sm->l_pop[i]=2;
 
 	sm->l_pop_r = (double *) malloc(sizeof(double )* 20000);
-	memset(sm->l_pop_r, 3, sizeof(double)*20000);
+        for (size_t i=0; i<20000; ++i)
+          sm->l_pop_r[i]=3;
 
 	sm->continuum_list_nu = (double *) malloc(sizeof(double )* 20000);
-	memset(sm->continuum_list_nu, 1e13, sizeof(double)*20000);
+        for (size_t i=0; i<20000; ++i)
+          sm->continuum_list_nu[i]=1e13;
 
 	sm->no_of_edges = 100;
 
 	sm->chi_bf_tmp_partial = (double *) malloc(sizeof(double )* 20000);
-	memset(sm->chi_bf_tmp_partial, 160, sizeof(double)*20000);
+        for (size_t i=0; i<20000; ++i)
+          sm->chi_bf_tmp_partial[i]=160;
 
 }
 
 double
-test_compute_distance2boundary(){
+test_compute_distance2boundary(void){
 	double D_BOUNDARY = compute_distance2boundary(rp, sm);
 	rpacket_set_d_boundary(rp, D_BOUNDARY);
 	return D_BOUNDARY;
 }
 
 double
-test_compute_distance2line(){
+test_compute_distance2line(void){
 	double *D_LINE = (double *) malloc(sizeof(double));
+        // FIXME MR: return status of compute_distance2line() is ignored
 	compute_distance2line(rp, sm, D_LINE);
 	rpacket_set_d_line(rp, *D_LINE);
 	return *D_LINE;
 }
 
 double
-test_compute_distance2continuum(){
+test_compute_distance2continuum(void){
 	compute_distance2continuum(rp, sm);
 	return rp->d_cont;
 }
 
 double
-test_rpacket_doppler_factor(){
+test_rpacket_doppler_factor(void){
 	return rpacket_doppler_factor(rp, sm);
 }
 
 double
-test_move_packet(){
+test_move_packet(void){
 	double DISTANCE = 1e13;
 	return move_packet(rp, sm, DISTANCE);
 }
 
 double
-test_increment_j_blue_estimator(){
+test_increment_j_blue_estimator(void){
 	int64_t j_blue_idx = 0;
 	double d_line = rpacket_get_d_line(rp);
 	increment_j_blue_estimator(rp, sm, d_line, j_blue_idx);
@@ -230,21 +234,21 @@ test_increment_j_blue_estimator(){
 }
 
 bool
-test_montecarlo_line_scatter(){
+test_montecarlo_line_scatter(void){
 	double DISTANCE = 1e13;
 	montecarlo_line_scatter(rp, sm, DISTANCE);
 	return true;
 }
 
 bool
-test_montecarlo_thomson_scatter(){
+test_montecarlo_thomson_scatter(void){
 	double DISTANCE = 1e13;
 	montecarlo_thomson_scatter(rp, sm, DISTANCE);
 	return true;
 }
 
 bool
-test_move_packet_across_shell_boundary(){
+test_move_packet_across_shell_boundary(void){
 	double DISTANCE = 0.95e13;
 // MR: wrong: move_packet_across_shell_boundary() returns void
         move_packet_across_shell_boundary(rp, sm, DISTANCE);
@@ -253,42 +257,42 @@ test_move_packet_across_shell_boundary(){
 
 
 int64_t
-test_montecarlo_one_packet(){
+test_montecarlo_one_packet(void){
 	return montecarlo_one_packet(sm, rp, 1);
 }
 
 int64_t
-test_montecarlo_one_packet_loop(){
+test_montecarlo_one_packet_loop(void){
 	return montecarlo_one_packet_loop(sm, rp, 1);
 }
 
 bool
-test_macro_atom(){
+test_macro_atom(void){
 	macro_atom(rp, sm);
 	return true;
 }
 
 double
-test_calculate_chi_bf(){
+test_calculate_chi_bf(void){
 	calculate_chi_bf(rp, sm);
 	return rpacket_doppler_factor (rp, sm);
 }
 
 bool
-test_montecarlo_bound_free_scatter(){
+test_montecarlo_bound_free_scatter(void){
 	double DISTANCE = 1e13;
 	montecarlo_bound_free_scatter(rp, sm, DISTANCE);
 	return (rpacket_get_status(rp)!=0);
 }
 
 double
-test_bf_cross_section(){
+test_bf_cross_section(void){
 	double CONV_MU = 0.4;
 	return bf_cross_section(sm, 1, CONV_MU);
 }
 
 int64_t
-test_montecarlo_free_free_scatter(){
+test_montecarlo_free_free_scatter(void){
 	double DISTANCE = 1e13;
 	montecarlo_free_free_scatter(rp, sm, DISTANCE);
 	return rpacket_get_status(rp);

--- a/tardis/montecarlo/src/test_rpacket.c
+++ b/tardis/montecarlo/src/test_rpacket.c
@@ -29,169 +29,125 @@ bool test_rpacket_get_next_shell_id(int);
 bool test_rpacket_get_last_line(void);
 bool test_rpacket_get_close_line(void);
 bool test_rpacket_get_status(void);
+bool test_rpacket_get_id(void);
 
 bool
 test_rpacket_get_nu(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_nu(rp, value);
-	if( value != rpacket_get_nu(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_nu(&rp, value);
+        return value==rpacket_get_nu(&rp);
 }
 
 bool
 test_rpacket_get_mu(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_mu(rp, value);
-	if( value != rpacket_get_mu(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_mu(&rp, value);
+        return value==rpacket_get_mu(&rp);
 }
 
 bool
 test_rpacket_get_energy(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_energy(rp, value);
-	if( value != rpacket_get_energy(rp) ){
-		return false;
-	}
-	return true;	
+	rpacket_t rp;
+	rpacket_set_energy(&rp, value);
+        return value==rpacket_get_energy(&rp);
 }
 
 bool
 test_rpacket_get_r(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_r(rp, value);
-	if( value != rpacket_get_r(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_r(&rp, value);
+        return value==rpacket_get_r(&rp);
 }
 
 bool
 test_rpacket_get_tau_event(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_tau_event(rp, value);
-	if( value != rpacket_get_tau_event(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_tau_event(&rp, value);
+        return value==rpacket_get_tau_event(&rp); 
 }
 
 bool
 test_rpacket_get_nu_line(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_nu_line(rp, value);
-	if( value != rpacket_get_nu_line(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_nu_line(&rp, value);
+        return value==rpacket_get_nu_line(&rp); 
 }
 
 bool
 test_rpacket_get_current_shell_id(unsigned int value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_nu_line(rp, value);
-	if( value != rpacket_get_nu_line(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_current_shell_id(&rp, value);
+	return value==rpacket_get_current_shell_id(&rp);
 }
 
 bool
 test_rpacket_get_next_line_id(unsigned int value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_next_line_id(rp, value);
-	if( value != rpacket_get_next_line_id(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_next_line_id(&rp, value);
+	return value==rpacket_get_next_line_id(&rp);
 }
 
 bool
 test_rpacket_get_last_line(void){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_last_line(rp, true);
-	return rpacket_get_last_line(rp);	
+	rpacket_t rp;
+	rpacket_set_last_line(&rp, true);
+	return rpacket_get_last_line(&rp);	
 }
 
 bool
 test_rpacket_get_close_line(void){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_last_line(rp, true);
-	return rpacket_get_last_line(rp);
+	rpacket_t rp;
+	rpacket_set_last_line(&rp, true);
+	return rpacket_get_last_line(&rp);
 }
 
 bool
 test_rpacket_get_recently_crossed_boundary(int value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_recently_crossed_boundary(rp, value);
-	if( value != rpacket_get_recently_crossed_boundary(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_recently_crossed_boundary(&rp, value);
+	return value==rpacket_get_recently_crossed_boundary(&rp);
 }
 
 bool
 test_rpacket_get_virtual_packet_flag(int value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_virtual_packet_flag(rp, value);
-	if( value != rpacket_get_virtual_packet_flag(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_virtual_packet_flag(&rp, value);
+	return value==rpacket_get_virtual_packet_flag(&rp);
 }
 
 bool
 test_rpacket_get_virtual_packet(int value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_virtual_packet(rp, value);
-	if( value != rpacket_get_virtual_packet(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_virtual_packet(&rp, value);
+	return value==rpacket_get_virtual_packet(&rp);
 }
 
 bool
 test_rpacket_get_d_boundary(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_d_boundary(rp, value);
-	if( value != rpacket_get_d_boundary(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_d_boundary(&rp, value);
+	return value==rpacket_get_d_boundary(&rp);
 }
 
 bool
 test_rpacket_get_d_electron(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_d_electron(rp, value);
-	if( value != rpacket_get_d_electron(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_d_electron(&rp, value);
+	return value==rpacket_get_d_electron(&rp);
 }
 
 bool
 test_rpacket_get_d_line(double value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_d_line(rp, value);
-	if( value != rpacket_get_d_line(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_d_line(&rp, value);
+	return value==rpacket_get_d_line(&rp);
 }
 
 bool
 test_rpacket_get_next_shell_id(int value){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_next_shell_id(rp, value);
-	if( value != rpacket_get_next_shell_id(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_next_shell_id(&rp, value);
+	return value==rpacket_get_next_shell_id(&rp);
 }
 
 bool
@@ -200,25 +156,19 @@ test_rpacket_get_status(void){
 	rpacket_status_t emitted = TARDIS_PACKET_STATUS_EMITTED;
 	rpacket_status_t reabsorbed = TARDIS_PACKET_STATUS_REABSORBED;
 
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_status(rp, inProcess);
-	if( inProcess != rpacket_get_status(rp) ){
-		return false;
-	}
-	rpacket_set_status(rp, emitted);
-	if( emitted != rpacket_get_status(rp) ){
-		return false;
-	}
-	rpacket_set_status(rp, reabsorbed);
-	if( reabsorbed != rpacket_get_status(rp) ){
-		return false;
-	}
-	return true;
+	rpacket_t rp;
+	rpacket_set_status(&rp, inProcess);
+	bool res=  inProcess==rpacket_get_status(&rp);
+        rpacket_set_status(&rp, emitted);
+	res &= emitted==rpacket_get_status(&rp);
+	rpacket_set_status(&rp, reabsorbed);
+        res &= reabsorbed==rpacket_get_status(&rp);
+	return res;
 }
 
 bool
 test_rpacket_get_id(void){
-	rpacket_t * rp = (rpacket_t *) malloc(sizeof(rpacket_t));
-	rpacket_set_id(rp, 2);
-	return rpacket_get_id(rp) == 2;
+	rpacket_t rp;
+	rpacket_set_id(&rp, 2);
+	return rpacket_get_id(&rp) == 2;
 }

--- a/tardis/montecarlo/tests/test_cmontecarlo.py
+++ b/tardis/montecarlo/tests/test_cmontecarlo.py
@@ -72,6 +72,7 @@ def test_calculate_chi_bf():
 	assert_almost_equal(tests.test_calculate_chi_bf(),
 		chi_bf)
 
+@pytest.mark.xfail
 def test_montecarlo_bound_free_scatter():
 	assert tests.test_montecarlo_bound_free_scatter() == 1
 

--- a/tardis/montecarlo/tests/test_cmontecarlo.py
+++ b/tardis/montecarlo/tests/test_cmontecarlo.py
@@ -72,7 +72,6 @@ def test_calculate_chi_bf():
 	assert_almost_equal(tests.test_calculate_chi_bf(),
 		chi_bf)
 
-@pytest.mark.xfail
 def test_montecarlo_bound_free_scatter():
 	assert tests.test_montecarlo_bound_free_scatter() == 1
 


### PR DESCRIPTION
cmontecarlo.c and cmontecarlo.h:
- some functions rearranged to allow better inlining
- specify "const" in the interfaces where appropriate
- add FIXME comments in places where I suspect problems but can't fix them myself
- minor performance tweaks (replacing divisions by multiplications etc.)
- unify variable declaration/definition where possible

Tests:
- avoid memory leaks in test_rpacket.c
- fix initialisations in test_montecarlo.c
