### PR TITLE
Consistency between old virtual packet arrays and new ones introduced in PR 384

### DIFF
--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -78,9 +78,9 @@ cdef extern from "src/cmontecarlo.h":
         double *virt_packet_nus
         double *virt_packet_energies
         double *virt_last_interaction_in_nu
-        int_type_t *virt_last_interaction_type
-        int_type_t *virt_last_line_interaction_in_id
-        int_type_t *virt_last_line_interaction_out_id
+        int_type_t *virt_packet_last_interaction_type
+        int_type_t *virt_packet_last_line_interaction_in_id
+        int_type_t *virt_packet_last_line_interaction_out_id
         int_type_t virt_packet_count
         int_type_t virt_array_size
 
@@ -238,24 +238,24 @@ def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
 
     cdef np.ndarray[double, ndim=1] virt_packet_nus = np.zeros(storage.virt_packet_count, dtype=np.float64)
     cdef np.ndarray[double, ndim=1] virt_packet_energies = np.zeros(storage.virt_packet_count, dtype=np.float64)
-    cdef np.ndarray[double, ndim=1] virt_last_interaction_in_nu = np.zeros(storage.virt_packet_count, dtype=np.float64)
-    cdef np.ndarray[int_type_t, ndim=1] virt_last_interaction_type = np.zeros(storage.virt_packet_count, dtype=np.int64)
-    cdef np.ndarray[int_type_t, ndim=1] virt_last_line_interaction_in_id = np.zeros(storage.virt_packet_count, dtype=np.int64)
-    cdef np.ndarray[int_type_t, ndim=1] virt_last_line_interaction_out_id = np.zeros(storage.virt_packet_count, dtype=np.int64)
+    cdef np.ndarray[double, ndim=1] virt_packet_last_interaction_in_nu = np.zeros(storage.virt_packet_count, dtype=np.float64)
+    cdef np.ndarray[int_type_t, ndim=1] virt_packet_last_interaction_type = np.zeros(storage.virt_packet_count, dtype=np.int64)
+    cdef np.ndarray[int_type_t, ndim=1] virt_packet_last_line_interaction_in_id = np.zeros(storage.virt_packet_count, dtype=np.int64)
+    cdef np.ndarray[int_type_t, ndim=1] virt_packet_last_line_interaction_out_id = np.zeros(storage.virt_packet_count, dtype=np.int64)
 
     for i in range(storage.virt_packet_count):
         virt_packet_nus[i] = storage.virt_packet_nus[i]
         virt_packet_energies[i] = storage.virt_packet_energies[i]
-        virt_last_interaction_in_nu[i] = storage.virt_last_interaction_in_nu[i]
-        virt_last_interaction_type[i] = storage.virt_last_interaction_type[i]
-        virt_last_line_interaction_in_id[i] = storage.virt_last_line_interaction_in_id[i]
-        virt_last_line_interaction_out_id[i] = storage.virt_last_line_interaction_out_id[i]
+        virt_packet_last_interaction_in_nu[i] = storage.virt_packet_last_interaction_in_nu[i]
+        virt_packet_last_interaction_type[i] = storage.virt_packet_last_interaction_type[i]
+        virt_packet_last_line_interaction_in_id[i] = storage.virt_packet_last_line_interaction_in_id[i]
+        virt_packet_last_line_interaction_out_id[i] = storage.virt_packet_last_line_interaction_out_id[i]
     free(<void *>storage.virt_packet_nus)
     free(<void *>storage.virt_packet_energies)
-    free(<void *>storage.virt_last_interaction_in_nu)
-    free(<void *>storage.virt_last_interaction_type)
-    free(<void *>storage.virt_last_line_interaction_in_id)
-    free(<void *>storage.virt_last_line_interaction_out_id)
+    free(<void *>storage.virt_packet_last_interaction_in_nu)
+    free(<void *>storage.virt_packet_last_interaction_type)
+    free(<void *>storage.virt_packet_last_line_interaction_in_id)
+    free(<void *>storage.virt_packet_last_line_interaction_out_id)
     runner._packet_nu = output_nus
     runner._packet_energy = output_energies
     runner.j_estimator = js
@@ -267,10 +267,10 @@ def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
     runner.last_interaction_in_nu = last_interaction_in_nu
     runner.virt_packet_nus = virt_packet_nus
     runner.virt_packet_energies = virt_packet_energies
-    runner.virt_last_interaction_in_nu = virt_last_interaction_in_nu
-    runner.virt_last_interaction_type = virt_last_interaction_type
-    runner.virt_last_line_interaction_in_id = virt_last_line_interaction_in_id
-    runner.virt_last_line_interaction_out_id = virt_last_line_interaction_out_id
+    runner.virt_packet_last_interaction_in_nu = virt_packet_last_interaction_in_nu
+    runner.virt_packet_last_interaction_type = virt_packet_last_interaction_type
+    runner.virt_packet_last_line_interaction_in_id = virt_packet_last_line_interaction_in_id
+    runner.virt_packet_last_line_interaction_out_id = virt_packet_last_line_interaction_out_id
     
     #return output_nus, output_energies, js, nubars, last_line_interaction_in_id, last_line_interaction_out_id, last_interaction_type, last_line_interaction_shell_id, virt_packet_nus, virt_packet_energies
 

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -77,7 +77,7 @@ cdef extern from "src/cmontecarlo.h":
         ContinuumProcessesStatus cont_status
         double *virt_packet_nus
         double *virt_packet_energies
-        double *virt_last_interaction_in_nu
+        double *virt_packet_last_interaction_in_nu
         int_type_t *virt_packet_last_interaction_type
         int_type_t *virt_packet_last_line_interaction_in_id
         int_type_t *virt_packet_last_line_interaction_out_id

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -487,17 +487,17 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 			storage->virt_array_size *= 2;
 			storage->virt_packet_nus = realloc(storage->virt_packet_nus, sizeof(double) * storage->virt_array_size);
 			storage->virt_packet_energies = realloc(storage->virt_packet_energies, sizeof(double) * storage->virt_array_size);
-			storage->virt_last_interaction_in_nu = realloc(storage->virt_last_interaction_in_nu, sizeof(double) * storage->virt_array_size);
-      storage->virt_last_interaction_type = realloc(storage->virt_last_interaction_type, sizeof(int64_t) * storage->virt_array_size);
-      storage->virt_last_line_interaction_in_id = realloc(storage->virt_last_line_interaction_in_id, sizeof(int64_t) * storage->virt_array_size);
-      storage->virt_last_line_interaction_out_id = realloc(storage->virt_last_line_interaction_out_id, sizeof(int64_t) * storage->virt_array_size);
+			storage->virt_packet_last_interaction_in_nu = realloc(storage->virt_packet_last_interaction_in_nu, sizeof(double) * storage->virt_array_size);
+      storage->virt_packet_last_interaction_type = realloc(storage->virt_packet_last_interaction_type, sizeof(int64_t) * storage->virt_array_size);
+      storage->virt_packet_last_line_interaction_in_id = realloc(storage->virt_packet_last_line_interaction_in_id, sizeof(int64_t) * storage->virt_array_size);
+      storage->virt_packet_last_line_interaction_out_id = realloc(storage->virt_packet_last_line_interaction_out_id, sizeof(int64_t) * storage->virt_array_size);
 		      }
 		    storage->virt_packet_nus[storage->virt_packet_count] = rpacket_get_nu(&virt_packet);
 		    storage->virt_packet_energies[storage->virt_packet_count] = rpacket_get_energy(&virt_packet) * weight;
-        storage->virt_last_interaction_in_nu[storage->virt_packet_count] = storage->last_interaction_in_nu[rpacket_get_id (packet)];
-        storage->virt_last_interaction_type[storage->virt_packet_count] = storage->last_interaction_type[rpacket_get_id (packet)];
-        storage->virt_last_line_interaction_in_id[storage->virt_packet_count] = storage->last_line_interaction_in_id[rpacket_get_id (packet)];
-        storage->virt_last_line_interaction_out_id[storage->virt_packet_count] = storage->last_line_interaction_out_id[rpacket_get_id (packet)];
+        storage->virt_packet_last_interaction_in_nu[storage->virt_packet_count] = storage->last_interaction_in_nu[rpacket_get_id (packet)];
+        storage->virt_packet_last_interaction_type[storage->virt_packet_count] = storage->last_interaction_type[rpacket_get_id (packet)];
+        storage->virt_packet_last_line_interaction_in_id[storage->virt_packet_count] = storage->last_line_interaction_in_id[rpacket_get_id (packet)];
+        storage->virt_packet_last_line_interaction_out_id[storage->virt_packet_count] = storage->last_line_interaction_out_id[rpacket_get_id (packet)];
 		    storage->virt_packet_count += 1;
 		    virt_id_nu =
 		      floor ((rpacket_get_nu(&virt_packet) -
@@ -876,10 +876,10 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
   int64_t packet_index;
   storage->virt_packet_nus = (double *)malloc(sizeof(double) * storage->no_of_packets);
   storage->virt_packet_energies = (double *)malloc(sizeof(double) * storage->no_of_packets);
-  storage->virt_last_interaction_in_nu = (double *)malloc(sizeof(double) * storage->no_of_packets);
-  storage->virt_last_interaction_type = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
-  storage->virt_last_line_interaction_in_id = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
-  storage->virt_last_line_interaction_out_id = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
+  storage->virt_packet_last_interaction_in_nu = (double *)malloc(sizeof(double) * storage->no_of_packets);
+  storage->virt_packet_last_interaction_type = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
+  storage->virt_packet_last_line_interaction_in_id = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
+  storage->virt_packet_last_line_interaction_out_id = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
   storage->virt_packet_count = 0;
   storage->virt_array_size = storage->no_of_packets;
 #ifdef WITHOPENMP

--- a/tardis/montecarlo/src/storage.h
+++ b/tardis/montecarlo/src/storage.h
@@ -65,10 +65,10 @@ typedef struct StorageModel
   ContinuumProcessesStatus cont_status;
   double *virt_packet_nus;
   double *virt_packet_energies;
-  double *virt_last_interaction_in_nu;
-  int64_t *virt_last_interaction_type;
-  int64_t *virt_last_line_interaction_in_id;
-  int64_t *virt_last_line_interaction_out_id;
+  double *virt_packet_last_interaction_in_nu;
+  int64_t *virt_packet_last_interaction_type;
+  int64_t *virt_packet_last_line_interaction_in_id;
+  int64_t *virt_packet_last_line_interaction_out_id;
   int64_t virt_packet_count;
   int64_t virt_array_size;
 } storage_model_t;


### PR DESCRIPTION
All arrays holding properties of virtual packets now begin with
```
virt_packet_
````