### PR TITLE
Change to NLTE properties

### DIFF
--- a/tardis/plasma/base.py
+++ b/tardis/plasma/base.py
@@ -108,7 +108,12 @@ class BasePlasma(object):
         self.outputs_dict = {}
         for plasma_property in plasma_properties:
 
-            if hasattr(plasma_property, 'set_value'):
+            if hasattr(plasma_property, 'set_initial_value'):
+                #duck-typing for PreviousIterationProperty
+                current_property_object = plasma_property()
+                current_property_object.set_initial_value(kwargs)
+
+            elif hasattr(plasma_property, 'set_value'):
                 #duck-typing for PlasmaInputProperty
                 #that means if it is an input property from model
                 if not set(kwargs.keys()).issuperset(plasma_property.outputs):

--- a/tardis/plasma/properties/general.py
+++ b/tardis/plasma/properties/general.py
@@ -48,7 +48,8 @@ class NumberDensity(ProcessingPlasmaProperty):
     outputs = ('number_density',)
     latex_name = ('N_{i}',)
 
-    def calculate(self, atomic_mass, abundance, density):
+    @staticmethod
+    def calculate(atomic_mass, abundance, density):
         number_densities = (abundance * density)
         return number_densities.div(atomic_mass.ix[abundance.index], axis=0)
 

--- a/tardis/plasma/properties/nlte.py
+++ b/tardis/plasma/properties/nlte.py
@@ -5,11 +5,16 @@ from scipy import interpolate
 from tardis.plasma.properties.base import (BasePlasmaProperty,
                                            ProcessingPlasmaProperty)
 from tardis.plasma.properties import PhiSahaNebular, PhiSahaLTE
+from tardis.plasma.properties import NumberDensity
 
 __all__ = ['PreviousElectronDensities', 'PreviousBetaSobolevs',
            'HeliumNLTE']
 
 class PreviousIterationProperty(BasePlasmaProperty):
+
+    def _set_initial_value(self, value):
+        self.set_value(value)
+
     def _set_output_value(self, output, value):
         setattr(self, output, value)
 
@@ -20,8 +25,21 @@ class PreviousIterationProperty(BasePlasmaProperty):
 class PreviousElectronDensities(PreviousIterationProperty):
     outputs = ('previous_electron_densities',)
 
+    def set_initial_value(self, kwargs):
+        initial_value = np.ones(len(kwargs['abundance'].columns))*1000000.0
+        self._set_initial_value(initial_value)
+
 class PreviousBetaSobolevs(PreviousIterationProperty):
     outputs = ('previous_beta_sobolevs',)
+
+    def set_initial_value(self, kwargs):
+        try:
+            lines = len(kwargs['atomic_data'].lines)
+        except:
+            lines = len(kwargs['atomic_data']._lines)
+        initial_value = np.ones((lines,
+            len(kwargs['abundance'].columns)))
+        self._set_initial_value(initial_value)
 
 class HeliumNLTE(ProcessingPlasmaProperty):
     outputs = ('helium_population',)

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -1,16 +1,4 @@
-from tardis.plasma.properties import (BetaRadiation, LevelBoltzmannFactorLTE,
-    Levels, Lines, AtomicMass, PartitionFunction,
-    LevelNumberDensity, PhiSahaLTE, GElectron,
-    IonizationData, NumberDensity, IonNumberDensity, LinesLowerLevelIndex,
-    LinesUpperLevelIndex, TauSobolev, TRadiative, AtomicData, Abundance,
-    Density, TimeExplosion, BetaSobolev, JBlues,
-    TransitionProbabilities, StimulatedEmissionFactor, SelectedAtoms,
-    PhiSahaNebular, LevelBoltzmannFactorDiluteLTE, DilutionFactor,
-    ZetaData, ElectronTemperature, LinkTRadTElectron, BetaElectron,
-    RadiationFieldCorrection, RadiationFieldCorrectionInput,
-    LevelBoltzmannFactorNoNLTE, LevelBoltzmannFactorNLTE, NLTEData,
-    NLTESpecies, PreviousBetaSobolevs, LTEJBlues,
-    PreviousElectronDensities, Chi0, HeliumNLTE)
+from tardis.plasma.properties import *
 
 class PlasmaPropertyCollection(list):
     pass

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -24,8 +24,7 @@ class LTEPlasma(BasePlasma):
             t_rad=t_rad, abundance=abundance, atomic_data=atomic_data,
             density=density, time_explosion=time_explosion, j_blues=j_blues,
 	        w=None, link_t_rad_t_electron=link_t_rad_t_electron,
-            delta_input=delta_treatment, nlte_species=None,
-            previous_beta_sobolevs=None, previous_electron_densities=None)
+            delta_input=delta_treatment, nlte_species=None)
 
 class LegacyPlasmaArray(BasePlasma):
 
@@ -112,6 +111,4 @@ class LegacyPlasmaArray(BasePlasma):
             t_rad=t_rad, abundance=abundance, density=density,
             atomic_data=atomic_data, time_explosion=time_explosion,
             j_blues=None, w=w, link_t_rad_t_electron=link_t_rad_t_electron,
-            delta_input=delta_treatment, nlte_species=nlte_species,
-            previous_electron_densities=initial_electron_densities,
-            previous_beta_sobolevs=initial_beta_sobolevs)
+            delta_input=delta_treatment, nlte_species=nlte_species)


### PR DESCRIPTION
The NLTE excitation (and now ionisation) modules use a class of properties called `PreviousIterationProperty`, which store values (`electron_densities` and `beta_sobolevs`) from previous iterations of the plasma so they can be used in the NLTE calculations to prevent property loops. I have just changed how these properties are initialised in the plasma. It reduces the number of arguments required to initialise the plasma and means that these properties do not have to be included in the plasma calculations if they are not used. 