### PR TITLE
Pandas macroatom issue fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
         - COMPILER=gcc
         - CYTHON_VERSION=0.21
         - NUMPY_VERSION=1.8
-        - PANDAS_VERSION=0.12
+        - PANDAS_VERSION=0.16
         - ASTROPY_VERSION=0.4.4
         - ASTROPY_USE_SYSTEM_PYTEST=1
         - SETUP_CMD='test'
@@ -26,7 +26,7 @@ env:
 matrix:
     include:
         - python: "2.7"
-          env: PANDAS_VERSION=0.12
+          env: PANDAS_VERSION=0.16
 
         - python: "2.7"
           env: PANDAS_VERSION=latest

--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -463,7 +463,6 @@ class AtomData(object):
             maximum ion number to be included in the calculation
 
         """
-
         self.selected_atomic_numbers = selected_atomic_numbers
 
         self.nlte_species = nlte_species
@@ -529,16 +528,22 @@ class AtomData(object):
             elif line_interaction_type == 'macroatom':
                 block_references = np.hstack((0, np.cumsum(
                     self.macro_atom_references['count_total'].values[:-1])))
-
-                self.macro_atom_references.loc[:, 'block_references'] = (
-                    block_references)
+                self.macro_atom_references.insert(len(
+                    self.macro_atom_references.columns), 'block_references',
+                    pd.Series(block_references,
+                    index=self.macro_atom_references.index))
 
             self.macro_atom_references.set_index(['atomic_number', 'ion_number', 'source_level_number'], inplace=True)
-            self.macro_atom_references.loc[:, 'references_idx'] = np.arange(
-                len(self.macro_atom_references))
+            self.macro_atom_references.insert(len(
+                    self.macro_atom_references.columns), 'references_idx',
+                    pd.Series(np.arange(len(self.macro_atom_references)),
+                    index=self.macro_atom_references.index))
 
-            self.macro_atom_data.loc[:, 'lines_idx'] = self.lines_index.ix[
-                self.macro_atom_data['transition_line_id']].values
+            self.macro_atom_data.insert(len(
+                self.macro_atom_data.columns), 'lines_idx',
+                pd.Series(self.lines_index.ix[self.macro_atom_data[
+                'transition_line_id']].values,
+                index=self.macro_atom_data.index))
 
             tmp_lines_upper2level_idx = pd.MultiIndex.from_arrays(
                 [self.lines['atomic_number'], self.lines['ion_number'],
@@ -553,12 +558,13 @@ class AtomData(object):
                                                                              'destination_level_number']])
 
             if line_interaction_type == 'macroatom':
-                #Sets all 
-                self.macro_atom_data.loc[:, 'destination_level_idx'] = (
-                    self.macro_atom_references['references_idx'].ix[
-                        tmp_macro_destination_level_idx].values.astype(
-                        np.int64))
+                #Sets all
 
+                self.macro_atom_data.insert(len(
+                    self.macro_atom_data.columns), 'destination_level_idx',
+                    pd.Series(self.macro_atom_references['references_idx'].ix[
+                    tmp_macro_destination_level_idx].values.astype(
+                        np.int64), index=self.macro_atom_data.index))
 
             elif line_interaction_type == 'downbranch':
                 # Sets all the destination levels to -1 to indicate that they

--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -16,6 +16,9 @@ from pandas import DataFrame
 
 import pandas as pd
 
+import warnings
+warnings.filterwarnings('error')
+
 
 
 logger = logging.getLogger(__name__)
@@ -527,14 +530,18 @@ class AtomData(object):
                                                                             np.cumsum(self.macro_atom_references[
                                                                                           'count_down'].values[:-1])))
             elif line_interaction_type == 'macroatom':
-                self.macro_atom_references['block_references'] = np.hstack((0,
-                                                                            np.cumsum(self.macro_atom_references[
-                                                                                          'count_total'].values[:-1])))
+                block_references = np.hstack((0, np.cumsum(
+                    self.macro_atom_references['count_total'].values[:-1])))
+
+                self.macro_atom_references.loc[:, 'block_references'] = (
+                    block_references)
 
             self.macro_atom_references.set_index(['atomic_number', 'ion_number', 'source_level_number'], inplace=True)
-            self.macro_atom_references['references_idx'] = np.arange(len(self.macro_atom_references))
+            self.macro_atom_references.loc[:, 'references_idx'] = np.arange(
+                len(self.macro_atom_references))
 
-            self.macro_atom_data['lines_idx'] = self.lines_index.ix[self.macro_atom_data['transition_line_id']].values
+            self.macro_atom_data.loc[:, 'lines_idx'] = self.lines_index.ix[
+                self.macro_atom_data['transition_line_id']].values
 
             tmp_lines_upper2level_idx = pd.MultiIndex.from_arrays(
                 [self.lines['atomic_number'], self.lines['ion_number'],
@@ -549,11 +556,14 @@ class AtomData(object):
                                                                              'destination_level_number']])
 
             if line_interaction_type == 'macroatom':
-                self.macro_atom_data['destination_level_idx'] = self.macro_atom_references['references_idx'].ix[
-                    tmp_macro_destination_level_idx].values.astype(np.int64)
+                self.macro_atom_data.loc[:, 'destination_level_idx'] = (
+                    self.macro_atom_references['references_idx'].ix[
+                        tmp_macro_destination_level_idx].values.astype(
+                        np.int64))
+
             elif line_interaction_type == 'downbranch':
-                self.macro_atom_data['destination_level_idx'] = (np.ones(len(self.macro_atom_data)) * -1).astype(
-                    np.int64)
+                self.macro_atom_data.loc[:, 'destination_level_idx'] = (
+                    np.ones(len(self.macro_atom_data)) * -1).astype(np.int64)
 
         self.nlte_data = NLTEData(self, nlte_species)
 

--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -16,9 +16,6 @@ from pandas import DataFrame
 
 import pandas as pd
 
-import warnings
-warnings.filterwarnings('error')
-
 
 
 logger = logging.getLogger(__name__)

--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -553,12 +553,16 @@ class AtomData(object):
                                                                              'destination_level_number']])
 
             if line_interaction_type == 'macroatom':
+                #Sets all 
                 self.macro_atom_data.loc[:, 'destination_level_idx'] = (
                     self.macro_atom_references['references_idx'].ix[
                         tmp_macro_destination_level_idx].values.astype(
                         np.int64))
 
+
             elif line_interaction_type == 'downbranch':
+                # Sets all the destination levels to -1 to indicate that they
+                # are not used in downbranch calculations
                 self.macro_atom_data.loc[:, 'destination_level_idx'] = (
                     np.ones(len(self.macro_atom_data)) * -1).astype(np.int64)
 


### PR DESCRIPTION
Alternative fix to issue #402 that seems to remove all of the errors.

@ssim This removes all of the errors for me with pandas 0.16.2 (using the config. file you provided). Could you checkout this PR and check it works for you too?

The problem seems to arise when a column is added to a dataframe with an unsorted index. I think the warning is intended to highlight that the index is unsorted and therefore that the data being added may not match up with the index correctly. But the use of .insert() with the data in Pandas series form seems to work, probably because the index of the new data is then specified. That's my understanding of it anyway.