### PR TITLE
A new structure to also take care of isotopes

### DIFF
--- a/tardis/io/decay.py
+++ b/tardis/io/decay.py
@@ -1,0 +1,87 @@
+import pandas as pd
+from pyne import nucname, material
+from astropy import units as u
+
+class IsotopeAbundances(pd.DataFrame):
+
+    @property
+    def _constructor(self):
+        return IsotopeAbundances
+
+    def _update_material(self):
+        self.comp_dicts = [{}] * len(self.columns)
+        for (atomic_number, mass_number), abundances in self.iterrows():
+            nuclear_symbol = '%s%d'.format(nucname.name(atomic_number),
+                                           mass_number)
+            for i in xrange(len(self.columns)):
+                self.comp_dicts[i][nuclear_symbol] = abundances[i]
+
+    @classmethod
+    def from_materials(cls, materials):
+        multi_index_tuples = set([])
+        for material in materials:
+            multi_index_tuples.update([cls.id_to_tuple(key)
+                                       for key in material.keys()])
+
+        index = pd.MultiIndex.from_tuples(
+            multi_index_tuples, names=['atomic_number', 'mass_number'])
+
+
+        abundances = pd.DataFrame(index=index, columns=xrange(len(materials)))
+
+        for i, material in enumerate(materials):
+            for key, value in material.items():
+                abundances.loc[cls.id_to_tuple(key), i] = value
+
+        return abundances
+
+
+
+
+    @staticmethod
+    def id_to_tuple(atomic_id):
+        return nucname.znum(atomic_id), nucname.anum(atomic_id)
+
+
+    def to_materials(self):
+        """
+        Convert DataFrame to a list of materials interpreting the MultiIndex as
+        atomic_number and mass_number
+
+        Returns
+        -------
+            : ~list
+            list of pyne Materialss
+        :return:
+        """
+
+        comp_dicts = [{}] * len(self.columns)
+        for (atomic_number, mass_number), abundances in self.iterrows():
+            nuclear_symbol = '{0:s}{1:d}'.format(nucname.name(atomic_number),
+                                           mass_number)
+            for i in xrange(len(self.columns)):
+                comp_dicts[i][nuclear_symbol] = abundances[i]
+        return [material.Material(comp_dict) for comp_dict in comp_dicts]
+
+
+
+    def decay(self, t):
+        """
+        Decay the Model
+
+        Parameters
+        ----------
+
+        t: ~float or ~astropy.units.Quantity
+            if float it will be understood as days
+
+        Returns:
+            : decayed abundances
+        """
+
+        materials = self.to_materials()
+        t_second = u.Quantity(t, u.day).to(u.s).value
+
+        decayed_materials = [item.decay(t_second) for item in materials]
+
+        return IsotopeAbundances.from_materials(decayed_materials)

--- a/tardis/io/tests/test_decay.py
+++ b/tardis/io/tests/test_decay.py
@@ -1,0 +1,14 @@
+import pytest
+import pandas as pd
+
+from tardis.io.decay import IsotopeAbundances
+
+@pytest.fixture
+def simple_abundance_model():
+    index = pd.MultiIndex.from_tuples([(28, 56)],
+                                      names=['atomic_number', 'mass_number'])
+    return IsotopeAbundances([[1.0, 1.0]], index=index)
+
+
+def test_simple_decay(simple_abundance_model):
+    1/0


### PR DESCRIPTION
This is the beginning of a new structure that can hold isotope abundances and then decay them using nuclear networks. The structure inherits from a `DataFrame` and has a multi-index with `atomic_number` and `mass_number`. The columns are shells like in all our other TARDIS frames. 

Here is an example. This is the input 
```python
>>> simple_abundance_model
atomic_number mass_number
28            56           1  1
```
and after being decayed:
```python
simple_abundance_model.decay(100)
atomic_number mass_number
27            56             0.442379    0.442379
26            56              0.55752     0.55752
28            56           1.1086e-05  1.1086e-05
```

This is mostly to read Stephan Blondin's files but I'm sure can be used for other things. Currently, don't have the time to finish it.

 - [ ] finish tests
 - [ ] make it possible to write out elemental abundances
 - [ ] allow for elemental abundances with unknown isotope distribution
 - [ ] replace the current ARTIS file decay mechanism
 - [ ] read CMFgen files

