### PR TITLE
added new version requirements for pandas and astropy

### DIFF
--- a/conda-requirements
+++ b/conda-requirements
@@ -1,10 +1,10 @@
 numpy>=1.4.0
 scipy>=0.10
-pandas>=0.12
+pandas>=0.16
 pytables
 h5py>=2.0
 matplotlib>=1.1
-astropy>=0.4
+astropy>=1.0
 PyYAML>=3.0
 numexpr>=2.0.0
 Cython>=0.21

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,11 +21,11 @@ TARDIS has the following requirements:
 
 - `Scipy <http://www.scipy.org/>`_ 0.10 or later
 
-- `Astropy <http://www.astropy.org/>`_ 0.4 or later
+- `Astropy <http://www.astropy.org/>`_ 1.0 or later
 
 - `h5py <http://www.h5py.org/>`_ 2.0.0 or later
 
-- `pandas <http://pandas.pydata.org/>`_ 0.12.0 or later
+- `pandas <http://pandas.pydata.org/>`_ 0.16.1 or later
 
 - `pyyaml <http://pyyaml.org/>`_ 3.0 or later
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ LONG_DESCRIPTION = "" #package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.0.1'
+VERSION = '1.5dev'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ LONG_DESCRIPTION = "" #package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.5dev'
+VERSION = '1.5.dev'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
This should fix #415 
@unoebauer I think this should clarify what version one needs. 