### PR TITLE
fix for initializing a linspace with quantities

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -10,12 +10,12 @@ import pandas as pd
 import yaml
 
 import tardis
-from tardis.io.model_reader import read_density_file, \
-    calculate_density_after_time, read_abundances_file
+from tardis.io.model_reader import (
+    read_density_file, calculate_density_after_time, read_abundances_file)
 from tardis.io.config_validator import ConfigurationValidator
 from tardis import atomic
-from tardis.util import species_string_to_tuple, parse_quantity, \
-    element_symbol2atomic_number
+from tardis.util import (species_string_to_tuple, parse_quantity,
+                         element_symbol2atomic_number, quantity_linspace)
 
 import copy
 
@@ -42,43 +42,6 @@ inv_mn52_efolding_time = 1 / (0.0211395 * u.day)
 
 class ConfigurationError(ValueError):
     pass
-
-
-def parse_quantity_linspace(quantity_linspace_dictionary, add_one=True):
-    """
-    parse a dictionary of the following kind
-    {'start': 5000 km/s,
-     'stop': 10000 km/s,
-     'num': 1000}
-
-    Parameters
-    ----------
-
-    quantity_linspace_dictionary: ~dict
-
-    add_one: boolean, default: True
-
-    Returns
-    -------
-
-    ~np.array
-
-    """
-
-    start = parse_quantity(quantity_linspace_dictionary['start'])
-    stop = parse_quantity(quantity_linspace_dictionary['stop'])
-
-    try:
-        stop = stop.to(start.unit)
-    except u.UnitsError:
-        raise ConfigurationError('"start" and "stop" keyword must be compatible quantities')
-
-    num = quantity_linspace_dictionary['num']
-    if add_one:
-        num += 1
-
-    return np.linspace(start.value, stop.value, num=num) * start.unit
-
 
 def parse_spectral_bin(spectral_bin_boundary_1, spectral_bin_boundary_2):
     spectral_bin_boundary_1 = parse_quantity(spectral_bin_boundary_1).to('Angstrom', u.spectral())
@@ -282,7 +245,8 @@ def parse_model_file_section(model_setup_file_dict, time_explosion):
         if split_shells > 1:
             logger.info('Increasing the number of shells by a factor of %s' % split_shells)
             no_of_shells = len(v_inner)
-            velocities = np.linspace(v_inner[0], v_outer[-1], no_of_shells * split_shells + 1)
+            velocities = quantity_linspace(
+                v_inner[0], v_outer[-1], no_of_shells * split_shells + 1)
             v_inner = velocities[:-1]
             v_outer = velocities[1:]
             old_mean_densities = mean_densities
@@ -533,7 +497,7 @@ def parse_spectrum_list2dict(spectrum_list):
     spectrum_config_dict['end'] = spectrum_list[1]
     spectrum_config_dict['bins'] = spectrum_list[2]
 
-    spectrum_frequency = np.linspace(
+    spectrum_frequency = quantity_linspace(
         spectrum_config_dict['end'].to('Hz', u.spectral()),
         spectrum_config_dict['start'].to('Hz', u.spectral()),
         num=spectrum_config_dict['bins'] + 1)
@@ -879,7 +843,7 @@ class Configuration(ConfigurationNameSpace):
         if structure_section['type'] == 'specific':
             start, stop, num = model_section['structure']['velocity']
             num += 1
-            velocities = np.linspace(start, stop, num)
+            velocities = quantity_linspace(start, stop, num)
 
             v_inner, v_outer = velocities[:-1], velocities[1:]
             mean_densities = parse_density_section(
@@ -898,7 +862,6 @@ class Configuration(ConfigurationNameSpace):
         r_outer = validated_config_dict['supernova']['time_explosion'] * v_outer
         r_middle = 0.5 * (r_inner + r_outer)
 
-        structure_validated_config_dict = {}
         structure_section['v_inner'] = v_inner.cgs
         structure_section['v_outer'] = v_outer.cgs
         structure_section['mean_densities'] = mean_densities.cgs

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -15,7 +15,8 @@ class ConfigurationError(Exception):
     pass
 
 
-def read_density_file(density_filename, density_filetype, time_explosion, v_inner_boundary=0.0, v_outer_boundary=np.inf):
+def read_density_file(density_filename, density_filetype, time_explosion,
+                      v_inner_boundary=0.0, v_outer_boundary=np.inf):
     """
     read different density file formats
 
@@ -75,9 +76,11 @@ def read_density_file(density_filename, density_filetype, time_explosion, v_inne
     mean_densities = mean_densities[inner_boundary_index:outer_boundary_index]
 
 
-    return v_inner, v_outer, mean_densities, inner_boundary_index, outer_boundary_index
+    return (v_inner, v_outer, mean_densities,
+            inner_boundary_index, outer_boundary_index)
 
-def read_abundances_file(abundance_filename, abundance_filetype, inner_boundary_index=None, outer_boundary_index=None):
+def read_abundances_file(abundance_filename, abundance_filetype,
+                         inner_boundary_index=None, outer_boundary_index=None):
     """
     read different density file formats
 

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -23,7 +23,7 @@ def test_config_namespace_attribute_test():
         assert namespace.param2 == 1
 
 def test_quantity_linspace():
-    quantity_linspace_dict = dict(start='1.1e4 km/s', stop='2e4 cm/h', num=1000)
+    quantity_linspace_dict = dict(start=1.1e4 * u.Unit('km/s'), stop=2e4 * u.Unit('cm/h'), num=1000)
     quantity_linspace = config_reader.quantity_linspace(**quantity_linspace_dict)
     assert_almost_equal(quantity_linspace[0].value, 1.1e4)
     assert_almost_equal(quantity_linspace[-1].to('cm/h').value, 2e4)

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -27,7 +27,7 @@ def test_quantity_linspace():
     quantity_linspace = config_reader.quantity_linspace(**quantity_linspace_dict)
     assert_almost_equal(quantity_linspace[0].value, 1.1e4)
     assert_almost_equal(quantity_linspace[-1].to('cm/h').value, 2e4)
-    assert len(quantity_linspace) == 1001
+    assert len(quantity_linspace) == 1000
 
 
 def test_spectrum_list2_dict():

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -24,7 +24,7 @@ def test_config_namespace_attribute_test():
 
 def test_quantity_linspace():
     quantity_linspace_dict = dict(start='1.1e4 km/s', stop='2e4 cm/h', num=1000)
-    quantity_linspace = config_reader.parse_quantity_linspace(quantity_linspace_dict)
+    quantity_linspace = config_reader.quantity_linspace(**quantity_linspace_dict)
     assert_almost_equal(quantity_linspace[0].value, 1.1e4)
     assert_almost_equal(quantity_linspace[-1].to('cm/h').value, 2e4)
     assert len(quantity_linspace) == 1001

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -434,4 +434,4 @@ def quantity_linspace(start, stop, num, **kwargs):
         raise ValueError('Both start and stop need to be quantities with a '
                          'unit attribute')
 
-    return np.linspace(start.value, stop.value, num, **kwargs) * start.unit
+    return np.linspace(start.value, stop.to(start.unit).value, num, **kwargs) * start.unit

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -413,3 +413,25 @@ def reformat_element_symbol(element_string):
     return element_string[0].upper() + element_string[1:].lower()
 
 
+def quantity_linspace(start, stop, num, **kwargs):
+    """
+    Calculate the linspace for a quantity start and stop.
+    Other than that essentially the same input parameters as linspace
+
+    Parameters
+    ----------
+    start: ~astropy.Quantity
+    stop: ~astropy.Quantity
+    num: ~int
+
+    Returns
+    -------
+        : ~astropy.Quantity
+
+
+    """
+    if not (hasattr(start, 'unit') and hasattr(stop, 'unit')):
+        raise ValueError('Both start and stop need to be quantities with a '
+                         'unit attribute')
+
+    return np.linspace(start.value, stop.value, num, **kwargs) * start.unit


### PR DESCRIPTION
Small but important fix to ensure that TARDIS will work with newer versions of astropy/numpy as well as older ones. 