### PR TITLE
started addressing issue #436

### DIFF
--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -248,6 +248,7 @@ def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
     cdef np.ndarray[int_type_t, ndim=1] virt_packet_last_interaction_type = np.zeros(storage.virt_packet_count, dtype=np.int64)
     cdef np.ndarray[int_type_t, ndim=1] virt_packet_last_line_interaction_in_id = np.zeros(storage.virt_packet_count, dtype=np.int64)
     cdef np.ndarray[int_type_t, ndim=1] virt_packet_last_line_interaction_out_id = np.zeros(storage.virt_packet_count, dtype=np.int64)
+    runner.virt_logging = LOG_VPACKETS
     if LOG_VPACKETS != 0:
         for i in range(storage.virt_packet_count):
             virt_packet_nus[i] = storage.virt_packet_nus[i]

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -329,7 +329,21 @@ class Simulation(object):
         #pass the runner to the model
         model.runner = self.runner
         #TODO: pass packet diagnostic arrays
+        (montecarlo_nu, montecarlo_energies, model.j_estimators,
+                model.nubar_estimators, last_line_interaction_in_id,
+                last_line_interaction_out_id, model.last_interaction_type,
+                model.last_line_interaction_shell_id) = model.runner.legacy_return()
 
+        model.montecarlo_nu = self.runner.output_nu
+        model.montecarlo_luminosity = self.runner.packet_luminosity
+
+
+        model.last_line_interaction_in_id = model.atom_data.lines_index.index.values[last_line_interaction_in_id]
+        model.last_line_interaction_in_id = model.last_line_interaction_in_id[last_line_interaction_in_id != -1]
+        model.last_line_interaction_out_id = model.atom_data.lines_index.index.values[last_line_interaction_out_id]
+        model.last_line_interaction_out_id = model.last_line_interaction_out_id[last_line_interaction_out_id != -1]
+        model.last_line_interaction_angstrom = model.montecarlo_nu[last_line_interaction_in_id != -1].to('angstrom',
+                                                                                                       u.spectral())
 
 def run_radial1d(radial1d_model, history_fname=None):
     if history_fname is not None:

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -213,6 +213,7 @@ class Simulation(object):
         start_time = time.time()
 
         iterations_remaining = self.tardis_config.montecarlo.iterations
+        iterations_max_requested = self.tardis_config.montecarlo.iterations
         iterations_executed = 0
 
         while iterations_remaining > 1:
@@ -256,6 +257,7 @@ class Simulation(object):
                     convergence_section.global_convergence_parameters.
                         hold_iterations_wrong)
             elif not converged and self.converged:
+                # UMN Warning: the following two iterations attributes of the Simulation object don't exist
                 self.iterations_remaining = self.iterations_max_requested - self.iterations_executed
                 self.converged = False
             else:
@@ -285,6 +287,14 @@ class Simulation(object):
 
         self.legacy_update_spectrum(model, no_of_virtual_packets)
         self.legacy_set_final_model_properties(model)
+
+        #the following instructions, passing down information to the model are
+        #required for the gui
+        model.no_of_packets = no_of_packets
+        model.no_of_virtual_packets = no_of_virtual_packets
+        model.converged = converged
+        model.iterations_executed = iterations_executed
+        model.iterations_max_requested = iterations_max_requested
 
         logger.info("Finished in {0:d} iterations and took {1:.2f} s".format(
             iterations_executed, time.time()-start_time))
@@ -344,6 +354,8 @@ class Simulation(object):
         model.last_line_interaction_out_id = model.last_line_interaction_out_id[last_line_interaction_out_id != -1]
         model.last_line_interaction_angstrom = model.montecarlo_nu[last_line_interaction_in_id != -1].to('angstrom',
                                                                                                        u.spectral())
+        # required for gui
+        model.current_no_of_packets = model.tardis_config.montecarlo.no_of_packets
 
 def run_radial1d(radial1d_model, history_fname=None):
     if history_fname is not None:

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -284,6 +284,7 @@ class Simulation(object):
         self.run_single_montecarlo(model, no_of_packets, no_of_virtual_packets)
 
         self.legacy_update_spectrum(model, no_of_virtual_packets)
+        self.legacy_set_final_model_properties(model)
 
         logger.info("Finished in {0:d} iterations and took {1:.2f} s".format(
             iterations_executed, time.time()-start_time))
@@ -310,6 +311,24 @@ class Simulation(object):
             model.spectrum_virtual.update_luminosity(
                 model.montecarlo_virtual_luminosity)
 
+    def legacy_set_final_model_properties(self, model):
+        """Sets additional model properties to be compatible with old model design
+
+        The runner object is given to the model and other packet diagnostics are set.
+
+        Parameters
+        ----------
+        model: ~tardis.model.Radial1DModel
+
+        Returns
+        -------
+            : None
+
+        """
+
+        #pass the runner to the model
+        model.runner = self.runner
+        #TODO: pass packet diagnostic arrays
 
 
 def run_radial1d(radial1d_model, history_fname=None):

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -215,6 +215,7 @@ class Simulation(object):
         iterations_remaining = self.tardis_config.montecarlo.iterations
         iterations_max_requested = self.tardis_config.montecarlo.iterations
         iterations_executed = 0
+        converged = False
 
         while iterations_remaining > 1:
             logger.info('Remaining run %d', iterations_remaining)

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -10,6 +10,8 @@ from tardis.simulation.base import Simulation
 from tardis.model import Radial1DModel
 
 from tardis.io.config_reader import Configuration
+from tardis.montecarlo.base import MontecarloRunner
+from tardis.plasma.standard_plasmas import LegacyPlasmaArray
 
 
 
@@ -51,3 +53,76 @@ class TestSimpleRun():
 
         np.testing.assert_allclose(
             self.model.spectrum.luminosity_density_lambda,luminosity_density)
+
+    def test_plasma_properties(self):
+
+        pass
+
+    def test_runner_properties(self):
+        """Tests whether a number of runner attributes exist and also verifies
+        their types
+
+        Currently, runner attributes needed to call the model routine to_hdf5
+        are checked.
+
+        """
+
+        if self.model.runner.virt_logging > 0:
+            virt_type = np.ndarray
+        else:
+            virt_type = None
+
+
+        props_required_by_modeltohdf5 = dict([
+                ("virt_packet_last_interaction_type", virt_type),
+                ("virt_packet_last_line_interaction_in_id", virt_type),
+                ("virt_packet_last_line_interaction_out_id", virt_type),
+                ("virt_packet_last_interaction_in_nu", virt_type),
+                ("virt_packet_nus", virt_type),
+                ("virt_packet_energies", virt_type),
+                ])
+
+        required_props = props_required_by_modeltohdf5.copy()
+
+        for prop, prop_type in required_props.items():
+
+            assert type(getattr(self.model.runner, prop)) == prop_type, ("wrong type of attribute '{}': expected {}, found {}".format(prop, prop_type, type(getattr(self.model.runner, prop))))
+
+
+    def test_legacy_model_properties(self):
+        """Tests whether a number of model attributes exist and also verifies
+        their types
+
+        Currently, model attributes needed to run the gui and to call the model
+        routine to_hdf5 are checked.
+
+        Notes
+        -----
+        The list of properties may be incomplete
+
+        """
+
+        props_required_by_gui = dict([
+                ("converged", bool),
+                ("iterations_executed", int),
+                ("iterations_max_requested", int),
+                ("current_no_of_packets", int),
+                ("no_of_packets", int),
+                ("no_of_virtual_packets", int),
+                ])
+        props_required_by_tohdf5 = dict([
+                ("runner", MontecarloRunner),
+                ("plasma_array", LegacyPlasmaArray),
+                ("last_line_interaction_in_id", np.ndarray),
+                ("last_line_interaction_out_id", np.ndarray),
+                ("last_line_interaction_shell_id", np.ndarray),
+                ("last_line_interaction_in_id", np.ndarray),
+                ("last_line_interaction_angstrom", u.quantity.Quantity),
+                ])
+
+        required_props = props_required_by_gui.copy()
+        required_props.update(props_required_by_tohdf5)
+
+        for prop, prop_type in required_props.items():
+
+            assert type(getattr(self.model, prop)) == prop_type, ("wrong type of attribute '{}': expected {}, found {}".format(prop, prop_type, type(getattr(self.model, prop))))

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -70,7 +70,7 @@ class TestSimpleRun():
         if self.model.runner.virt_logging > 0:
             virt_type = np.ndarray
         else:
-            virt_type = None
+            virt_type = type(None)
 
 
         props_required_by_modeltohdf5 = dict([


### PR DESCRIPTION
- Currently, only the runner is passed back to the model in the legacy mode
- Todo: set remaining packet diagnostic arrays

 - [x] the runner has be accessible from inside the model
 - [x] set remaining packet diagnostic arrays
 - [x] model.to_hdf5 has to work
 - [x] the tardis gui has to work
 - [x] add tests