### PR TITLE
Renamed virtual_packet_flag to virtual_packet_count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ distribute-*.tar.gz
 # Other
 .*.swp
 *~
+.ycm_extra_conf.py
 
 # Mac OSX
 .DS_Store

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -102,7 +102,7 @@ class MontecarloRunner(object):
                                  no_of_packets)
 
         montecarlo.montecarlo_radial1d(
-            model, self, virtual_packet_flag=no_of_virtual_packets,
+            model, self, virtual_packet_count=no_of_virtual_packets,
             nthreads=nthreads)
 
     def legacy_return(self):

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -87,7 +87,7 @@ cdef extern from "src/cmontecarlo.h":
         int_type_t virt_packet_count
         int_type_t virt_array_size
 
-    void montecarlo_main_loop(storage_model_t * storage, int_type_t virtual_packet_flag, int nthreads, unsigned long seed)
+    void montecarlo_main_loop(storage_model_t * storage, int_type_t virtual_packet_count, int nthreads, unsigned long seed)
 
 
 
@@ -206,7 +206,7 @@ cdef initialize_storage_model(model, runner, storage_model_t *storage):
     cdef np.ndarray[double, ndim=1] t_electrons = model.plasma_array.t_electrons
     storage.t_electrons = <double*> t_electrons.data
 
-def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
+def montecarlo_radial1d(model, runner, int_type_t virtual_packet_count=0,
                         int nthreads=4):
     """
     Parameters
@@ -240,7 +240,7 @@ def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
 
     initialize_storage_model(model, runner, &storage)
 
-    montecarlo_main_loop(&storage, virtual_packet_flag, nthreads,
+    montecarlo_main_loop(&storage, virtual_packet_count, nthreads,
                          model.tardis_config.montecarlo.seed)
     cdef np.ndarray[double, ndim=1] virt_packet_nus = np.zeros(storage.virt_packet_count, dtype=np.float64)
     cdef np.ndarray[double, ndim=1] virt_packet_energies = np.zeros(storage.virt_packet_count, dtype=np.float64)

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -377,7 +377,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
     {
       if ((rpacket_get_nu (packet) > storage->spectrum_virt_start_nu) && (rpacket_get_nu(packet) < storage->spectrum_virt_end_nu))
 	{
-	  for (int64_t i = 0; i < rpacket_get_virtual_packet_flag (packet); i++)
+	  for (int64_t i = 0; i < rpacket_get_virtual_packet_count (packet); i++)
 	    {
               double weight;
               rpacket_t virt_packet = *packet;
@@ -393,22 +393,22 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 		{
 		  mu_min = 0.0;
 		}
-	      double mu_bin = (1.0 - mu_min) / rpacket_get_virtual_packet_flag (packet);
+	      double mu_bin = (1.0 - mu_min) / rpacket_get_virtual_packet_count (packet);
 	      rpacket_set_mu(&virt_packet,mu_min + (i + rk_double (mt_state)) * mu_bin);
 	      switch (virtual_mode)
 		{
 		case -2:
-		  weight = 1.0 / rpacket_get_virtual_packet_flag (packet);
+		  weight = 1.0 / rpacket_get_virtual_packet_count (packet);
 		  break;
 		case -1:
 		  weight =
 		    2.0 * rpacket_get_mu(&virt_packet) /
-		    rpacket_get_virtual_packet_flag (packet);
+		    rpacket_get_virtual_packet_count (packet);
 		  break;
 		case 1:
 		  weight =
 		    (1.0 -
-		     mu_min) / 2.0 / rpacket_get_virtual_packet_flag (packet);
+		     mu_min) / 2.0 / rpacket_get_virtual_packet_count (packet);
 		  break;
 		default:
 		  fprintf (stderr, "Something has gone horribly wrong!\n");
@@ -523,7 +523,7 @@ move_packet_across_shell_boundary (rpacket_t * packet,
       rpacket_set_nu (packet, comov_nu * inverse_doppler_factor);
       rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
       rpacket_set_recently_crossed_boundary (packet, 1);
-      if (rpacket_get_virtual_packet_flag (packet) > 0)
+      if (rpacket_get_virtual_packet_count (packet) > 0)
 	{
 	  montecarlo_one_packet (storage, packet, -2, mt_state);
 	}
@@ -544,7 +544,7 @@ montecarlo_thomson_scatter (rpacket_t * packet, storage_model_t * storage,
   rpacket_reset_tau_event (packet, mt_state);
   rpacket_set_recently_crossed_boundary (packet, 0);
   storage->last_interaction_type[rpacket_get_id (packet)] = 1;
-  if (rpacket_get_virtual_packet_flag (packet) > 0)
+  if (rpacket_get_virtual_packet_count (packet) > 0)
     {
       montecarlo_one_packet (storage, packet, 1, mt_state);
     }
@@ -655,7 +655,7 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
       rpacket_set_next_line_id (packet, emission_line_id + 1);
       rpacket_reset_tau_event (packet, mt_state);
       rpacket_set_recently_crossed_boundary (packet, 0);
-      if (rpacket_get_virtual_packet_flag (packet) > 0)
+      if (rpacket_get_virtual_packet_count (packet) > 0)
 	{
 	  bool virtual_close_line = false;
 	  if (!rpacket_get_last_line (packet) &&
@@ -813,7 +813,7 @@ montecarlo_one_packet_loop (storage_model_t * storage, rpacket_t * packet,
 }
 
 void
-montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int nthreads, unsigned long seed)
+montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_count, int nthreads, unsigned long seed)
 {
   storage->virt_packet_count = 0;
 #ifdef WITH_VPACKET_LOGGING
@@ -845,8 +845,8 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
       int reabsorbed = 0;
       rpacket_t packet;
       rpacket_set_id(&packet, packet_index);
-      rpacket_init(&packet, storage, packet_index, virtual_packet_flag);
-      if (virtual_packet_flag > 0)
+      rpacket_init(&packet, storage, packet_index, virtual_packet_count);
+      if (virtual_packet_count > 0)
 	{
 	  reabsorbed = montecarlo_one_packet(storage, &packet, -1, &mt_state);
 	}

--- a/tardis/montecarlo/src/cmontecarlo.h
+++ b/tardis/montecarlo/src/cmontecarlo.h
@@ -74,7 +74,7 @@ int64_t montecarlo_one_packet_loop (storage_model_t * storage,
 				    int64_t virtual_packet, rk_state *mt_state);
 
 void montecarlo_main_loop(storage_model_t * storage,
-			  int64_t virtual_packet_flag,
+			  int64_t virtual_packet_count,
 			  int nthreads,
 			  unsigned long seed);
 

--- a/tardis/montecarlo/src/rpacket.c
+++ b/tardis/montecarlo/src/rpacket.c
@@ -3,7 +3,7 @@
 
 tardis_error_t
 rpacket_init (rpacket_t * packet, storage_model_t * storage, int packet_index,
-	      int virtual_packet_flag)
+	      int virtual_packet_count)
 {
   int64_t current_line_id;
   tardis_error_t ret_val = TARDIS_ERROR_OK;
@@ -38,6 +38,6 @@ rpacket_init (rpacket_t * packet, storage_model_t * storage, int packet_index,
   rpacket_set_last_line (packet, last_line);
   rpacket_set_close_line (packet, false);
   rpacket_set_recently_crossed_boundary (packet, true);
-  rpacket_set_virtual_packet_flag (packet, virtual_packet_flag);
+  rpacket_set_virtual_packet_count (packet, virtual_packet_count);
   return ret_val;
 }

--- a/tardis/montecarlo/src/rpacket.h
+++ b/tardis/montecarlo/src/rpacket.h
@@ -54,7 +54,7 @@ typedef struct RPacket
    * internal float.
    */
   int64_t current_continuum_id; /* Packet can interact with bf-continua with an index equal or bigger than this */
-  int64_t virtual_packet_flag;
+  int64_t virtual_packet_count;
   int64_t virtual_packet;
   double d_line; /**< Distance to electron event. */
   double d_electron; /**< Distance to line event. */
@@ -182,15 +182,15 @@ static inline void rpacket_set_recently_crossed_boundary (rpacket_t * packet,
   packet->recently_crossed_boundary = recently_crossed_boundary;
 }
 
-static inline int rpacket_get_virtual_packet_flag (const rpacket_t * packet)
+static inline int rpacket_get_virtual_packet_count (const rpacket_t * packet)
 {
-  return packet->virtual_packet_flag;
+  return packet->virtual_packet_count;
 }
 
-static inline void rpacket_set_virtual_packet_flag (rpacket_t * packet,
-               int virtual_packet_flag)
+static inline void rpacket_set_virtual_packet_count (rpacket_t * packet,
+               int virtual_packet_count)
 {
-  packet->virtual_packet_flag = virtual_packet_flag;
+  packet->virtual_packet_count = virtual_packet_count;
 }
 
 static inline int rpacket_get_virtual_packet (const rpacket_t * packet)
@@ -270,7 +270,7 @@ static inline void rpacket_reset_tau_event (rpacket_t * packet, rk_state *mt_sta
 }
 
 tardis_error_t rpacket_init (rpacket_t * packet, storage_model_t * storage,
-           int packet_index, int virtual_packet_flag);
+           int packet_index, int virtual_packet_count);
 
 /* New getter and setter methods for continuum implementation */
 

--- a/tardis/montecarlo/src/test_cmontecarlo.c
+++ b/tardis/montecarlo/src/test_cmontecarlo.c
@@ -60,7 +60,7 @@ static void init_rpacket(rpacket_t *rp){
 	rpacket_set_tau_event(rp, TAU_EVENT);
 	rpacket_set_virtual_packet(rp, 0);
 	rpacket_set_energy(rp, ENERGY);
-	rpacket_set_virtual_packet_flag(rp, true);
+	rpacket_set_virtual_packet_count(rp, true);
 	rpacket_set_status(rp, TARDIS_PACKET_STATUS_IN_PROCESS);
 	rpacket_set_id(rp, 0);
 

--- a/tardis/montecarlo/src/test_rpacket.c
+++ b/tardis/montecarlo/src/test_rpacket.c
@@ -22,7 +22,7 @@ bool test_rpacket_get_current_shell_id(unsigned int);
 bool test_rpacket_get_next_line_id(unsigned int);
 
 bool test_rpacket_get_recently_crossed_boundary(int);
-bool test_rpacket_get_virtual_packet_flag(int);
+bool test_rpacket_get_virtual_packet_count(int);
 bool test_rpacket_get_virtual_packet(int);
 bool test_rpacket_get_next_shell_id(int);
 
@@ -109,10 +109,10 @@ test_rpacket_get_recently_crossed_boundary(int value){
 }
 
 bool
-test_rpacket_get_virtual_packet_flag(int value){
+test_rpacket_get_virtual_packet_count(int value){
 	rpacket_t rp;
-	rpacket_set_virtual_packet_flag(&rp, value);
-	return value==rpacket_get_virtual_packet_flag(&rp);
+	rpacket_set_virtual_packet_count(&rp, value);
+	return value==rpacket_get_virtual_packet_count(&rp);
 }
 
 bool

--- a/tardis/montecarlo/tests/test_rpacket.py
+++ b/tardis/montecarlo/tests/test_rpacket.py
@@ -101,8 +101,8 @@ def test_rpacket_get_recently_crossed_boundary(int_value):
     assert tests.test_rpacket_get_recently_crossed_boundary(int_value)
 
 
-def test_rpacket_get_virtual_packet_flag(int_value):
-    assert tests.test_rpacket_get_virtual_packet_flag(int_value)
+def test_rpacket_get_virtual_packet_count(int_value):
+    assert tests.test_rpacket_get_virtual_packet_count(int_value)
 
 
 def test_rpacket_get_virtual_packet(int_value):


### PR DESCRIPTION
Renamed virtual_packet_flag to virtual_packet_count in the C backend to better reflect it's meaning.

I would suggest to also rename rpacket_get_virtual_packet to something like rpacket_get_type and introduce an enumerate to reflect the different types of packets ( REAL, different virtual ones).

If that's a good idea, i'll create another pull request.