### PR TITLE
Fix Issue #454

### DIFF
--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -828,11 +828,12 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
 #ifdef WITHOPENMP
   omp_set_dynamic(0);
   omp_set_num_threads(nthreads);
-  fprintf(stderr, "Running with OpenMP - %d threads\n", omp_get_num_threads());
 #pragma omp parallel
   {
     rk_state mt_state;
     rk_seed (seed + omp_get_thread_num(), &mt_state);
+#pragma omp master
+    fprintf(stderr, "Running with OpenMP - %d threads\n", omp_get_num_threads());
 
 #pragma omp for
 #else


### PR DESCRIPTION
A small fix for issue #454 
omp_get_num_threads() returns number of threads in the current team.
Outside a parallel region this is always 1.

See:
https://gcc.gnu.org/onlinedocs/libgomp/omp_005fget_005fnum_005fthreads.html