### PR TITLE
Fixing plasma in 41d8fcd (not for merging)

### DIFF
--- a/tardis/plasma/properties/ion_population.py
+++ b/tardis/plasma/properties/ion_population.py
@@ -65,7 +65,7 @@ class PhiSahaNebular(ProcessingPlasmaProperty):
                              '- requested {2}'.format(
                 zeta_data.columns.values.min(), zeta_data.columns.values.max(),
                 t_rad))
-        phis = general_phi * delta * w * (zeta + w * (1 - zeta)) * \
+        phis = general_phi * w * (delta * zeta + w * (1 - zeta)) * \
                (t_electrons/t_rad) ** .5
         return phis
 

--- a/tardis/plasma/properties/partition_function.py
+++ b/tardis/plasma/properties/partition_function.py
@@ -82,10 +82,10 @@ class LevelBoltzmannFactorNLTE(ProcessingPlasmaProperty):
         self._update_inputs()
 
     def _main_nlte_calculation(self, nlte_species, atomic_data, nlte_data,
-        t_electrons, j_blues, beta_sobolevs, general_level_boltzmann_factor,
+        t_electrons, j_blues_array, beta_sobolevs, general_level_boltzmann_factor,
         previous_electron_densities):
         for species in nlte_species:
-            j_blues = j_blues.values
+            j_blues_array = j_blues_array.values
             logger.info('Calculating rates for species %s', species)
             number_of_levels = atomic_data.levels.energy.ix[species].count()
             lnl = nlte_data.lines_level_number_lower[species]
@@ -101,13 +101,13 @@ class LevelBoltzmannFactorNLTE(ProcessingPlasmaProperty):
             r_ul_matrix_reshaped = r_ul_matrix.reshape((number_of_levels**2,
                 len(t_electrons)))
             r_ul_matrix_reshaped[r_ul_index] = A_uls[np.newaxis].T + \
-                B_uls[np.newaxis].T * j_blues[lines_index]
+                B_uls[np.newaxis].T * j_blues_array[lines_index]
             r_ul_matrix_reshaped[r_ul_index] *= beta_sobolevs[lines_index]
             r_lu_matrix = np.zeros_like(r_ul_matrix)
             r_lu_matrix_reshaped = r_lu_matrix.reshape((number_of_levels**2,
                 len(t_electrons)))
             r_lu_matrix_reshaped[r_lu_index] = B_lus[np.newaxis].T * \
-                j_blues[lines_index] * beta_sobolevs[lines_index]
+                j_blues_array[lines_index] * beta_sobolevs[lines_index]
             if atomic_data.has_collision_data:
                 if previous_electron_densities is None:
                     collision_matrix = r_ul_matrix.copy()
@@ -132,16 +132,16 @@ class LevelBoltzmannFactorNLTE(ProcessingPlasmaProperty):
         return general_level_boltzmann_factor
 
     def _calculate_classical_nebular(self, t_electrons, lines, atomic_data,
-        nlte_data, general_level_boltzmann_factor, nlte_species, j_blues,
+        nlte_data, general_level_boltzmann_factor, nlte_species, j_blues_array,
         previous_beta_sobolevs, lte_j_blues, previous_electron_densities):
         beta_sobolevs = np.ones((len(lines), len(t_electrons)))
-        if len(j_blues)==0:
-            j_blues = lte_j_blues
+        if len(j_blues_array)==0:
+            j_blues_array = lte_j_blues
         else:
-            j_blues = pd.DataFrame(j_blues, index=lines.index, columns =
+            j_blues_array = pd.DataFrame(j_blues_array, index=lines.index, columns =
                 range(len(t_electrons)))
         general_level_boltzmann_factor = self._main_nlte_calculation(
-            nlte_species, atomic_data, nlte_data, t_electrons, j_blues,
+            nlte_species, atomic_data, nlte_data, t_electrons, j_blues_array,
             beta_sobolevs, general_level_boltzmann_factor,
             previous_electron_densities)
         return general_level_boltzmann_factor
@@ -150,27 +150,27 @@ class LevelBoltzmannFactorNLTE(ProcessingPlasmaProperty):
         nlte_data, general_level_boltzmann_factor, nlte_species,
         previous_electron_densities):
         beta_sobolevs = np.ones((len(lines), len(t_electrons)))
-        j_blues = np.zeros((len(lines), len(t_electrons)))
+        j_blues_array = np.zeros((len(lines), len(t_electrons)))
         general_level_boltzmann_factor = self._main_nlte_calculation(
-            nlte_species, atomic_data, nlte_data, t_electrons, j_blues,
+            nlte_species, atomic_data, nlte_data, t_electrons, j_blues_array,
             beta_sobolevs, general_level_boltzmann_factor,
             previous_electron_densities)
         return general_level_boltzmann_factor
 
     def _calculate_general(self, t_electrons, lines, atomic_data, nlte_data,
-        general_level_boltzmann_factor, nlte_species, j_blues,
+        general_level_boltzmann_factor, nlte_species, j_blues_array,
         previous_beta_sobolevs, lte_j_blues, previous_electron_densities):
         if previous_beta_sobolevs is None:
             beta_sobolevs = np.ones((len(lines), len(t_electrons)))
         else:
             beta_sobolevs = previous_beta_sobolevs
-        if len(j_blues)==0:
-            j_blues = lte_j_blues
+        if len(j_blues_array)==0:
+            j_blues_array = lte_j_blues
         else:
-            j_blues = pd.DataFrame(j_blues, index=lines.index, columns =
+            j_blues_array = pd.DataFrame(j_blues_array, index=lines.index, columns =
                 range(len(t_electrons)))
         general_level_boltzmann_factor = self._main_nlte_calculation(
-            nlte_species, atomic_data, nlte_data, t_electrons, j_blues,
+            nlte_species, atomic_data, nlte_data, t_electrons, j_blues_array,
             beta_sobolevs, general_level_boltzmann_factor,
             previous_electron_densities)
         return general_level_boltzmann_factor

--- a/tardis/plasma/properties/plasma_input.py
+++ b/tardis/plasma/properties/plasma_input.py
@@ -3,7 +3,7 @@ import pandas as pd
 from tardis.plasma.properties.base import BasePlasmaProperty
 
 __all__ = ['TRadiative', 'DilutionFactor', 'AtomicData', 'Abundance', 'Density',
-           'TimeExplosion', 'JBlues', 'LinkTRadTElectron', 'NLTESpecies',
+           'TimeExplosion', 'JBluesArray', 'LinkTRadTElectron', 'NLTESpecies',
            'RadiationFieldCorrectionInput']
 
 class Input(BasePlasmaProperty):
@@ -71,13 +71,13 @@ class TimeExplosion(DynamicInput):
     outputs = ('time_explosion',)
     latex_name = ('t_{\\textrm{exp}}',)
 
-class JBlues(DataFrameInput):
+class JBluesArray(DataFrameInput):
     """
     Outputs:
     j_blues : Pandas DataFrame
         Mean intensity in the blue wing of each line.
     """
-    outputs = ('j_blues',)
+    outputs = ('j_blues_array',)
     latex_name = ('J_{lu}^{b}',)
 
 class LinkTRadTElectron(StaticInput):

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -3,27 +3,27 @@ from tardis.plasma.properties import (BetaRadiation, LevelBoltzmannFactorLTE,
     LevelNumberDensity, PhiSahaLTE, GElectron,
     IonizationData, NumberDensity, IonNumberDensity, LinesLowerLevelIndex,
     LinesUpperLevelIndex, TauSobolev, TRadiative, AtomicData, Abundance,
-    Density, TimeExplosion, BetaSobolev, JBlues,
+    Density, TimeExplosion, BetaSobolev, JBluesArray,
     TransitionProbabilities, StimulatedEmissionFactor, SelectedAtoms,
     PhiGeneral, PhiSahaNebular, LevelBoltzmannFactorDiluteLTE, DilutionFactor,
     ZetaData, ElectronTemperature, LinkTRadTElectron, BetaElectron,
     RadiationFieldCorrection, RadiationFieldCorrectionInput,
     LevelBoltzmannFactorNoNLTE, LevelBoltzmannFactorNLTE, NLTEData,
     NLTESpecies, PreviousBetaSobolevs, LTEJBlues,
-    PreviousElectronDensities)
+    PreviousElectronDensities, JBlues)
 
 class PlasmaPropertyCollection(list):
     pass
 
 basic_inputs = PlasmaPropertyCollection([TRadiative, Abundance, Density,
-    TimeExplosion, AtomicData, JBlues, DilutionFactor, LinkTRadTElectron,
+    TimeExplosion, AtomicData, JBluesArray, DilutionFactor, LinkTRadTElectron,
     RadiationFieldCorrectionInput, NLTESpecies, PreviousBetaSobolevs,
     PreviousElectronDensities])
 basic_properties = PlasmaPropertyCollection([BetaRadiation,
     Levels, Lines, AtomicMass, PartitionFunction,
     GElectron, IonizationData, NumberDensity, LinesLowerLevelIndex,
     LinesUpperLevelIndex, TauSobolev, LevelNumberDensity, IonNumberDensity,
-    StimulatedEmissionFactor, SelectedAtoms, PhiGeneral, ElectronTemperature])
+    StimulatedEmissionFactor, SelectedAtoms, PhiGeneral, ElectronTemperature, JBlues])
 lte_ionization_properties = PlasmaPropertyCollection([PhiSahaLTE])
 lte_excitation_properties = PlasmaPropertyCollection([LevelBoltzmannFactorLTE])
 macro_atom_properties = PlasmaPropertyCollection([BetaSobolev,

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -158,7 +158,11 @@ class JBlues(ProcessingPlasmaProperty):
     
     @staticmethod
     def calculate(lines, j_blues_array, beta_rad):
-        return pd.DataFrame(j_blues_array, index=lines.index)
+        if len(j_blues_array)==0:
+            j_blues = pd.DataFrame()
+        else:
+            j_blues = pd.DataFrame(j_blues_array, index=lines.index)
+        return j_blues
 
 class LTEJBlues(ProcessingPlasmaProperty):
     outputs = ('lte_j_blues',)

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -49,7 +49,7 @@ class LegacyPlasmaArray(BasePlasma):
         initialize_nlte=False):
         if nlte_config.species:
             self.store_previous_properties()
-        self.update(t_rad=t_rad, w=ws, j_blues=j_blues)
+        self.update(t_rad=t_rad, w=ws, j_blues_array=j_blues)
 
     def __init__(self, number_densities, atomic_data, time_explosion,
         t_rad=None, delta_treatment=None, nlte_config=None,
@@ -99,7 +99,7 @@ class LegacyPlasmaArray(BasePlasma):
         super(LegacyPlasmaArray, self).__init__(plasma_properties=plasma_modules,
             t_rad=t_rad, abundance=abundance, density=density,
             atomic_data=atomic_data, time_explosion=time_explosion,
-            j_blues=None, w=w, link_t_rad_t_electron=link_t_rad_t_electron,
+            j_blues_array=None, w=w, link_t_rad_t_electron=link_t_rad_t_electron,
             delta_input=delta_treatment, nlte_species=nlte_config.species,
             previous_electron_densities=initial_electron_densities,
             previous_beta_sobolevs=initial_beta_sobolevs)


### PR DESCRIPTION
Issue #455: 41d8fcd is the commit at which the plasma_restructure branch was originally merged with the Tardis master branch. Here I have fixed a couple of things to ensure the plasma results are consistent with those of 45eca24 (last working example). All of the plasma quantities (taus, transition_probabilities, etc.) now agree between this version and 45eca24. But the nubar_estimators are still wrong. I think this may be a view/copy issue. Someone who knows more about the C/Python interface needs to look at these parameters to see which are being transferred wrong.