### PR TITLE
fix for #455 (transition probabilities, tau_sobolevs)

### DIFF
--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -65,28 +65,15 @@ class Levels(BaseAtomicDataProperty):
         return (levels.index, levels['energy'], levels['metastable'],
             levels['g'])
 
-class Lines(BaseAtomicDataProperty):
+class Lines(ProcessingPlasmaProperty):
     """
     Outputs:
     lines : Pandas DataFrame
         Lines data needed for particular simulation
     """
     outputs = ('lines', 'nu', 'f_lu', 'wavelength_cm')
-
-    def _filter_atomic_property(self, lines, selected_atoms):
-        return lines[lines.atomic_number.isin(selected_atoms)]
-
-    def _set_index(self, lines):
-# Filtering process re-arranges the index. This re-orders it.
-# It seems to be important that the lines stay indexed in the correct order
-# so that the tau_sobolevs values are in the right order for the montecarlo
-# code, or it returns the wrong answer.
-        try:
-            reindexed = lines.reindex(lines.index)
-        except:
-            reindexed = lines.reindex(lines.index)
-        lines = reindexed.dropna(subset=['atomic_number'])
-        return lines, lines['nu'], lines['f_lu'], lines['wavelength_cm']
+    def calculate(self, atomic_data):
+            return atomic_data.lines, atomic_data.lines.nu, atomic_data.lines.f_lu, atomic_data.lines.wavelength_cm
 
 class LinesLowerLevelIndex(ProcessingPlasmaProperty):
     """


### PR DESCRIPTION
With this fix the transition_probabilities, tau_sobololevs and electron densities have no significant error compared to 45eca24 (rel. error <1e-12)

However this doesn't solve the issue with the nu_bar_estimators. For that one need to look at f7ca576 which i identified in another git bisect as the root for the new discrepancy in nu_bar_estimators.