### PR TITLE
Changed the Link for AstroPy's dev workflow

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ available here :ref:`installation`.
 A file containing an example configuration file and an atomic database can be found in the section :ref:`running`
 
 If you're interested in contributing to the code, either contact us or you can contribute directly via github.
-We are using Astropy's excellent workflow - more details can be found at `<http://astropy.readthedocs.org/en/latest/development/workflow/index.html>`_.
+We are using Astropy's excellent workflow - more details can be found at `<http://astropy.readthedocs.org/en/latest/development/workflow/maintainer_workflow.html>`_.
 
 
 


### PR DESCRIPTION
Made Changes to the Link for the AstroPy's Development workflow,which previously led to Error Page.