### PR TITLE
added two tests that replace test_atomic_reprepare()

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -145,9 +145,10 @@ def pytest_report_header(config):
 import os
 import tardis
 import yaml
-import h5py
 
 from tardis.io.config_reader import Configuration
+from tardis.atomic import AtomData
+
 
 @pytest.fixture(scope="session")
 def atomic_data_fname():
@@ -164,20 +165,6 @@ def atomic_data_fname():
         return atomic_data_fname
 
 
-@pytest.yield_fixture(scope="session")
-def lines_dataset(atomic_data_fname):
-    """ The fixture returns the dataset containing lines data from the provided dataset"""
-    with h5py.File(atomic_data_fname, 'r') as h5_file:
-        yield h5_file['lines_data']
-
-from tardis.atomic import AtomData
-
-@pytest.fixture
-def atom_data_from_dataset(atomic_data_fname):
-    """The fixture returns the AtomData instance that contains atomic data from the provided dataset"""
-    atom_data = AtomData.from_hdf5(atomic_data_fname)
-    return atom_data
-
 @pytest.fixture
 def kurucz_atomic_data(atomic_data_fname):
     atomic_data = AtomData.from_hdf5(atomic_data_fname)
@@ -188,15 +175,18 @@ def kurucz_atomic_data(atomic_data_fname):
     else:
         return atomic_data
 
+
 @pytest.fixture
 def test_data_path():
     return os.path.join(tardis.__path__[0], 'tests', 'data')
+
 
 @pytest.fixture
 def included_he_atomic_data(test_data_path):
     import os, tardis
     atomic_db_fname = os.path.join(test_data_path, 'chianti_he_db.h5')
     return AtomData.from_hdf5(atomic_db_fname)
+
 
 @pytest.fixture
 def tardis_config_verysimple():

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -164,14 +164,11 @@ def atomic_data_fname():
         return atomic_data_fname
 
 
-@pytest.fixture(scope="session")
-def lines_dataset(atomic_data_fname, request):
+@pytest.yield_fixture(scope="session")
+def lines_dataset(atomic_data_fname):
     """ The fixture returns the dataset containing lines data from the provided dataset"""
-    h5_file = h5py.File(atomic_data_fname, 'r')
-    def fin():
-        h5_file.close()
-    request.addfinalizer(fin)
-    return h5_file['lines_data']
+    with h5py.File(atomic_data_fname, 'r') as h5_file:
+        yield h5_file['lines_data']
 
 from tardis.atomic import AtomData
 

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -9,13 +9,6 @@ def lines_dataset(atomic_data_fname):
     with h5py.File(atomic_data_fname, 'r') as h5_file:
         yield h5_file['lines_data']
 
-@pytest.fixture
-def atom_data_f_dataset_not_prepared(atomic_data_fname):
-    """The fixture returns the AtomData instance that contains atomic data from the provided dataset.
-       Does NOT call AtomData.prepare_atom_data method on the instance."""
-    atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
-    return atom_data
-
 def test_atomic_h5_readin():
     data = atomic.read_basic_atom_data(atomic.default_atom_h5_path)
     assert data['atomic_number'][13] == 14
@@ -56,15 +49,16 @@ param_atom_num = [[14], [20], [14, 20]]
 
 @pytest.mark.parametrize("selected_atomic_numbers", param_atom_num,
                          ids = ["atom_num: {}".format(_) for _ in param_atom_num])
-def test_prepare_atom_data_set_lines(selected_atomic_numbers, atom_data_f_dataset_not_prepared, lines_dataset):
+def test_prepare_atom_data_set_lines(selected_atomic_numbers, atomic_data_fname, lines_dataset):
     """ Test that lines data is prepared in accordance with the selected atomic numbers
         Uses fixtures:
         --------
-        atom_data_from_dataset : '~tardis.atomic.AtomData' instance containing data from the provided atomic dataset
-        lines_dataset          :  HDF5 dataset "lines_data"
+        from tardis/conftest.py
+            atomic_data_fname :  the filename of the provided atomic dataset
 
+        lines_dataset     :  HDF5 dataset "lines_data"
     """
-    atom_data = atom_data_f_dataset_not_prepared
+    atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
     atom_data.prepare_atom_data(selected_atomic_numbers)
     num_of_lines = 0
     # Go through the dataset and count the number of lines that should be selected
@@ -79,9 +73,9 @@ param_atom_num_max_ion_num = [([14], 1), ([14, 20], 3)]
 @pytest.mark.parametrize("selected_atomic_numbers, max_ion_number", param_atom_num_max_ion_num,
                          ids = ["atom_num: {}, max_ion_num: {}".format(*_) for _ in param_atom_num_max_ion_num])
 def test_prepare_atom_data_set_lines_w_max_ion_number(selected_atomic_numbers, max_ion_number,
-                                                      atom_data_f_dataset_not_prepared, lines_dataset):
+                                                      atomic_data_fname, lines_dataset):
     """ Test that lines data is prepared in accordance with the selected atomic numbers and the maximum ion number."""
-    atom_data = atom_data_f_dataset_not_prepared
+    atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
     atom_data.prepare_atom_data(selected_atomic_numbers, max_ion_number=max_ion_number)
     num_of_lines = 0
     for atom_num, ion_num in lines_dataset['atomic_number', 'ion_number']:

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -1,7 +1,20 @@
 from tardis import atomic
 from numpy import testing
 import pytest
-import os
+import h5py
+
+@pytest.yield_fixture(scope="module")
+def lines_dataset(atomic_data_fname):
+    """ The fixture returns the dataset containing lines data from the provided dataset"""
+    with h5py.File(atomic_data_fname, 'r') as h5_file:
+        yield h5_file['lines_data']
+
+@pytest.fixture
+def atom_data_f_dataset_not_prepared(atomic_data_fname):
+    """The fixture returns the AtomData instance that contains atomic data from the provided dataset.
+       Does NOT call AtomData.prepare_atom_data method on the instance."""
+    atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
+    return atom_data
 
 def test_atomic_h5_readin():
     data = atomic.read_basic_atom_data(atomic.default_atom_h5_path)
@@ -43,7 +56,7 @@ param_atom_num = [[14], [20], [14, 20]]
 
 @pytest.mark.parametrize("selected_atomic_numbers", param_atom_num,
                          ids = ["atom_num: {}".format(_) for _ in param_atom_num])
-def test_prepare_atom_data_set_lines(selected_atomic_numbers, atom_data_from_dataset, lines_dataset):
+def test_prepare_atom_data_set_lines(selected_atomic_numbers, atom_data_f_dataset_not_prepared, lines_dataset):
     """ Test that lines data is prepared in accordance with the selected atomic numbers
         Uses fixtures:
         --------
@@ -51,27 +64,29 @@ def test_prepare_atom_data_set_lines(selected_atomic_numbers, atom_data_from_dat
         lines_dataset          :  HDF5 dataset "lines_data"
 
     """
-    atom_data_from_dataset.prepare_atom_data(selected_atomic_numbers)
+    atom_data = atom_data_f_dataset_not_prepared
+    atom_data.prepare_atom_data(selected_atomic_numbers)
     num_of_lines = 0
     # Go through the dataset and count the number of lines that should be selected
     for atom_num in lines_dataset['atomic_number']:
         if atom_num in selected_atomic_numbers:
             num_of_lines += 1
 
-    assert len(atom_data_from_dataset.lines) == num_of_lines
+    assert len(atom_data.lines) == num_of_lines
 
 param_atom_num_max_ion_num = [([14], 1), ([14, 20], 3)]
 
 @pytest.mark.parametrize("selected_atomic_numbers, max_ion_number", param_atom_num_max_ion_num,
                          ids = ["atom_num: {}, max_ion_num: {}".format(*_) for _ in param_atom_num_max_ion_num])
-def test_prepare_atom_data_set_lines_w_max_ion_number(selected_atomic_numbers,
-                                                      max_ion_number, atom_data_from_dataset, lines_dataset):
+def test_prepare_atom_data_set_lines_w_max_ion_number(selected_atomic_numbers, max_ion_number,
+                                                      atom_data_f_dataset_not_prepared, lines_dataset):
     """ Test that lines data is prepared in accordance with the selected atomic numbers and the maximum ion number."""
-    atom_data_from_dataset.prepare_atom_data(selected_atomic_numbers, max_ion_number=max_ion_number)
+    atom_data = atom_data_f_dataset_not_prepared
+    atom_data.prepare_atom_data(selected_atomic_numbers, max_ion_number=max_ion_number)
     num_of_lines = 0
     for atom_num, ion_num in lines_dataset['atomic_number', 'ion_number']:
         if atom_num in selected_atomic_numbers and ion_num <= max_ion_number:
             num_of_lines += 1
 
-    assert len(atom_data_from_dataset.lines) == num_of_lines
+    assert len(atom_data.lines) == num_of_lines
 

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -39,7 +39,10 @@ def test_atomic_symbol_reverse():
     assert atomic.symbol2atomic_number['Si'] == 14
 
 
-@pytest.mark.parametrize("selected_atomic_numbers", [[14], [20], [14, 20]], ids=str)
+param_atom_num = [[14], [20], [14, 20]]
+
+@pytest.mark.parametrize("selected_atomic_numbers", param_atom_num,
+                         ids = ["atom_num: {}".format(_) for _ in param_atom_num])
 def test_prepare_atom_data_set_lines(selected_atomic_numbers, atom_data_from_dataset, lines_dataset):
     """ Test that lines data is prepared in accordance with the selected atomic numbers
         Uses fixtures:
@@ -57,10 +60,10 @@ def test_prepare_atom_data_set_lines(selected_atomic_numbers, atom_data_from_dat
 
     assert len(atom_data_from_dataset.lines) == num_of_lines
 
+param_atom_num_max_ion_num = [([14], 1), ([14, 20], 3)]
 
-@pytest.mark.parametrize("selected_atomic_numbers, max_ion_number", [
-                        ([14], 1),
-                        ([14, 20], 3),], ids=str)
+@pytest.mark.parametrize("selected_atomic_numbers, max_ion_number", param_atom_num_max_ion_num,
+                         ids = ["atom_num: {}, max_ion_num: {}".format(*_) for _ in param_atom_num_max_ion_num])
 def test_prepare_atom_data_set_lines_w_max_ion_number(selected_atomic_numbers,
                                                       max_ion_number, atom_data_from_dataset, lines_dataset):
     """ Test that lines data is prepared in accordance with the selected atomic numbers and the maximum ion number."""


### PR DESCRIPTION
@yeganer @unoebauer @wkerzendorf 
Hi, this is my first pull request! I've implemented the idea from #473 . 
- Firstly, I removed the  `pytest.mark.skipif` marker and moved all the verification to the `atomic_data_fname` fixture in the tardis/conftest.py. This way we don't have to check it in each test that requests an atomic database. I also included two other fixtures: `lines_dataset` that returns  lines data from hdf5 file and `atom_data_from_dataset` that requests the `atomic_data_fname` fixture and returns an AtomData object.
- Then I replaced `test_atomic_reprepare` with two tests: `test_prepare_atom_data_set_lines` and `test_prepare_atom_data_set_lines_w_max_ion_number`. I decided to go with to tests because I didn't want to overload them with logic - they are unit tests after all. So the second one does basically the same thing as the first but also checks max_ion_number. As suggested in #473 the number of lines is calculated from the provided atomic data file and then compared with the value from `prepare_atom_data` method. 

Look forward to a review
