### PR TITLE
Introcuding safe_malloc and safe_realloc macros: fixes #480

### DIFF
--- a/tardis/montecarlo/src/abbrev.h
+++ b/tardis/montecarlo/src/abbrev.h
@@ -3,14 +3,12 @@
 
 #include <stdlib.h>
 
-#define FAIL() abort()
-
 /**
  * @brief safe malloc; checks for NULL and aborts if encountered
  */
 static inline void* safe_malloc(size_t size) {
   void *mem = malloc(size);
-  if (mem == NULL && size != 0) FAIL();
+  if (mem == NULL && size != 0) abort();
   return mem;
 }
 
@@ -19,7 +17,7 @@ static inline void* safe_malloc(size_t size) {
  */
 static inline void* safe_realloc(void *ptr, size_t size) {
   void *mem = realloc(ptr, size);
-  if (mem == NULL && size != 0) FAIL();
+  if (mem == NULL && size != 0) abort();
   return mem;
 }
 

--- a/tardis/montecarlo/src/abbrev.h
+++ b/tardis/montecarlo/src/abbrev.h
@@ -3,14 +3,18 @@
 
 #define FAIL() abort()
 
-/* safe malloc */
-
+/**
+ * @brief safe malloc; checks for NULL and aborts if encountered
+ */
 static inline void* safe_malloc(size_t size) {
   void *mem = malloc(size);
   if (mem == NULL && size != 0) FAIL();
   return mem;
 }
 
+/**
+ * @brief safe realloc; checks for NULL and aborts if encountered
+ */
 static inline void* safe_realloc(void *ptr, size_t size) {
   void *mem = realloc(ptr, size);
   if (mem == NULL && size != 0) FAIL();

--- a/tardis/montecarlo/src/abbrev.h
+++ b/tardis/montecarlo/src/abbrev.h
@@ -1,0 +1,20 @@
+#ifndef ABBREV_H
+#define ABBREV_H
+
+#define FAIL() abort()
+
+/* safe malloc */
+
+static inline void* safe_malloc(size_t size) {
+  void *mem = malloc(size);
+  if (mem == NULL && size != 0) FAIL();
+  return mem;
+}
+
+static inline void* safe_realloc(void *ptr, size_t size) {
+  void *mem = realloc(ptr, size);
+  if (mem == NULL && size != 0) FAIL();
+  return mem;
+}
+
+#endif /* ABBREV_H */

--- a/tardis/montecarlo/src/abbrev.h
+++ b/tardis/montecarlo/src/abbrev.h
@@ -1,6 +1,8 @@
 #ifndef ABBREV_H
 #define ABBREV_H
 
+#include <stdlib.h>
+
 #define FAIL() abort()
 
 /**

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -2,6 +2,7 @@
 #ifdef WITHOPENMP
 #include <omp.h>
 #endif
+#include "abbrev.h"
 #include "cmontecarlo.h"
 
 /** Look for a place to insert a value in an inversely sorted float array.
@@ -431,12 +432,12 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
 		    if (storage->virt_packet_count >= storage->virt_array_size)
 		      {
 			storage->virt_array_size *= 2;
-			storage->virt_packet_nus = realloc(storage->virt_packet_nus, sizeof(double) * storage->virt_array_size);
-			storage->virt_packet_energies = realloc(storage->virt_packet_energies, sizeof(double) * storage->virt_array_size);
-			storage->virt_packet_last_interaction_in_nu = realloc(storage->virt_packet_last_interaction_in_nu, sizeof(double) * storage->virt_array_size);
-      storage->virt_packet_last_interaction_type = realloc(storage->virt_packet_last_interaction_type, sizeof(int64_t) * storage->virt_array_size);
-      storage->virt_packet_last_line_interaction_in_id = realloc(storage->virt_packet_last_line_interaction_in_id, sizeof(int64_t) * storage->virt_array_size);
-      storage->virt_packet_last_line_interaction_out_id = realloc(storage->virt_packet_last_line_interaction_out_id, sizeof(int64_t) * storage->virt_array_size);
+			storage->virt_packet_nus = safe_realloc(storage->virt_packet_nus, sizeof(double) * storage->virt_array_size);
+			storage->virt_packet_energies = safe_realloc(storage->virt_packet_energies, sizeof(double) * storage->virt_array_size);
+			storage->virt_packet_last_interaction_in_nu = safe_realloc(storage->virt_packet_last_interaction_in_nu, sizeof(double) * storage->virt_array_size);
+      storage->virt_packet_last_interaction_type = safe_realloc(storage->virt_packet_last_interaction_type, sizeof(int64_t) * storage->virt_array_size);
+      storage->virt_packet_last_line_interaction_in_id = safe_realloc(storage->virt_packet_last_line_interaction_in_id, sizeof(int64_t) * storage->virt_array_size);
+      storage->virt_packet_last_line_interaction_out_id = safe_realloc(storage->virt_packet_last_line_interaction_out_id, sizeof(int64_t) * storage->virt_array_size);
 		      }
 		    storage->virt_packet_nus[storage->virt_packet_count] = rpacket_get_nu(&virt_packet);
 		    storage->virt_packet_energies[storage->virt_packet_count] = rpacket_get_energy(&virt_packet) * weight;
@@ -817,12 +818,12 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
 {
   storage->virt_packet_count = 0;
 #ifdef WITH_VPACKET_LOGGING
-  storage->virt_packet_nus = (double *)malloc(sizeof(double) * storage->no_of_packets);
-  storage->virt_packet_energies = (double *)malloc(sizeof(double) * storage->no_of_packets);
-  storage->virt_packet_last_interaction_in_nu = (double *)malloc(sizeof(double) * storage->no_of_packets);
-  storage->virt_packet_last_interaction_type = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
-  storage->virt_packet_last_line_interaction_in_id = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
-  storage->virt_packet_last_line_interaction_out_id = (int64_t *)malloc(sizeof(int64_t) * storage->no_of_packets);
+  storage->virt_packet_nus = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
+  storage->virt_packet_energies = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
+  storage->virt_packet_last_interaction_in_nu = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
+  storage->virt_packet_last_interaction_type = (int64_t *)safe_malloc(sizeof(int64_t) * storage->no_of_packets);
+  storage->virt_packet_last_line_interaction_in_id = (int64_t *)safe_malloc(sizeof(int64_t) * storage->no_of_packets);
+  storage->virt_packet_last_line_interaction_out_id = (int64_t *)safe_malloc(sizeof(int64_t) * storage->no_of_packets);
   storage->virt_array_size = storage->no_of_packets;
 #endif // WITH_VPACKET_LOGGING
 #ifdef WITHOPENMP


### PR DESCRIPTION
Simple safe_malloc and safe_realloc macros are introduced. These check for returned NULL pointers in the allocation process and stop the calculation in these cases.

- [x] introduce safe_malloc and safe_realloc macros
- [x] replace memory operations with safe counterparts
- [x] test it:
   - [x] tardis_example
   - [x] tardis_example with OMP
   - [x] tardis_example with v-logging
   - [x] tardis_example with OMP and v-logging