### PR TITLE
added control skipping of tests with command line option

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -152,9 +152,6 @@ import yaml
 from tardis.atomic import AtomData
 from tardis.io.config_reader import Configuration
 
-def slow():
-    return pytest.mark.skipif(not pytest.config.getoption("--runslow"),
-            reason="need --runslow option to run")
 
 @pytest.fixture
 def atomic_data_fname():

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -32,6 +32,10 @@ def pytest_addoption(parser):
     parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
                      help="filename for atomic dataset")
 
+    parser.addoption("--runslow", action="store_true",
+                     help="run slow tests")
+
+
 def pytest_report_header(config):
 
     stdoutencoding = getattr(sys.stdout, 'encoding') or 'ascii'
@@ -145,8 +149,12 @@ def pytest_report_header(config):
 import os
 import tardis
 import yaml
-
+from tardis.atomic import AtomData
 from tardis.io.config_reader import Configuration
+
+def slow():
+    return pytest.mark.skipif(not pytest.config.getoption("--runslow"),
+            reason="need --runslow option to run")
 
 @pytest.fixture
 def atomic_data_fname():
@@ -155,8 +163,6 @@ def atomic_data_fname():
         pytest.skip('--atomic_database was not specified')
     else:
         return os.path.expandvars(os.path.expanduser(atomic_data_fname))
-
-from tardis.atomic import AtomData
 
 @pytest.fixture
 def kurucz_atomic_data(atomic_data_fname):

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -14,10 +14,16 @@ from tardis.montecarlo.base import MontecarloRunner
 from tardis.plasma.standard_plasmas import LegacyPlasmaArray
 
 
+slow = pytest.mark.skipif(
+    not pytest.config.getoption("--runslow"),
+    reason="need --runslow option to run"
+)
+
 
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'tests', 'data', fname)
 
+@slow
 @pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
                     reason='--atomic_database was not specified')
 class TestSimpleRun():


### PR DESCRIPTION
@wkerzendorf 
I've read this year description of the testing project and made this PR for the first [objective.](http://opensupernova.org/gsoc2016/doku.php?id=ideas_page#testing) 
There is an example of how to skip tests with command line option in the [py.test documentaion](http://pytest.org/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option).
In this PR I just followed the example since it is surely the right way to implement this. The execution of slow tests can be enabled with `--runslow` command line option.
I also considered creating a custom marker, like `pytest.mark.slow`, but it will require implementing two more pytest hooks in `conftest.py` (at least the way I see it). This only makes sense to me if there will be a lot of slow test