### PR TITLE
Minor improvement of vpacket logging scheme

### DIFF
--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -269,13 +269,11 @@ def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
         runner.virt_packet_last_interaction_type = virt_packet_last_interaction_type
         runner.virt_packet_last_line_interaction_in_id = virt_packet_last_line_interaction_in_id
         runner.virt_packet_last_line_interaction_out_id = virt_packet_last_line_interaction_out_id
-    else:
-        runner.virt_packet_nus = None
-        runner.virt_packet_energies = None
-        runner.virt_packet_last_interaction_in_nu = None
-        runner.virt_packet_last_interaction_type = None
-        runner.virt_packet_last_line_interaction_in_id = None
-        runner.virt_packet_last_line_interaction_out_id = None
     #return output_nus, output_energies, js, nubars, last_line_interaction_in_id, last_line_interaction_out_id, last_interaction_type, last_line_interaction_shell_id, virt_packet_nus, virt_packet_energies
-
-
+    else:
+        runner.virt_packet_nus = np.zeros(0)
+        runner.virt_packet_energies = np.zeros(0)
+        runner.virt_packet_last_interaction_in_nu = np.zeros(0)
+        runner.virt_packet_last_interaction_type = np.zeros(0)
+        runner.virt_packet_last_line_interaction_in_id = np.zeros(0)
+        runner.virt_packet_last_line_interaction_out_id = np.zeros(0)

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -78,10 +78,7 @@ class TestSimpleRun():
 
         """
 
-        if self.model.runner.virt_logging > 0:
-            virt_type = np.ndarray
-        else:
-            virt_type = type(None)
+        virt_type = np.ndarray
 
 
         props_required_by_modeltohdf5 = dict([


### PR DESCRIPTION
This PR implements minor changes into the vpacket logging scheme. Currently, the virtual_packet property arrays are set to None if the vpacket logging is inactive. This has caused some confusion in DALEK (multiplication of None with units, etc.). To this end, this behaviour is changed by this PR. Now the virtual packet property arrays are not None but empty numpy arrays in case the vpacket logging is off

- [x] change type of vpacket_properties from None to np.zeros(0)
- [x] update tests
- [x] check with tardis example