### PR TITLE
Montecarlo progress

### DIFF
--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -858,7 +858,10 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
               finished_packets * omp_get_num_threads(),
               storage->no_of_packets);
 #else
-        fprintf(stderr, STATUS_FORMAT, finished_packets*100/storage->no_of_packets, finished_packets, storage->no_of_packets);
+        fprintf(stderr, STATUS_FORMAT,
+                finished_packets * 100 / storage->no_of_packets,
+                finished_packets,
+                storage->no_of_packets);
 #endif
       }
       int reabsorbed = 0;


### PR DESCRIPTION
This is a quick implementation that prints and updates a status line
containing the how many packets are already finished, how many total
packets are there and the percentage of finished packets.

The format of the statusline can be changed by the gobal macro
STATUS_FORMAT.

The implmentation is exact when running without OMP and an approximation
when activating OMP. This is not garanteed to work bugfree in case the
sheduler for the for-loop changes.
The alternative would be to have a shared variable but that could lead
to a minor performance reduction.