### PR TITLE
Bugfix radiative rates type detailed

### DIFF
--- a/tardis/model.py
+++ b/tardis/model.py
@@ -207,7 +207,7 @@ class Radial1DModel(object):
             logger.info('Calculating J_blues for radiate_rates_type=detailed')
 
             self.j_blues = pd.DataFrame(
-                self.j_blue_estimators.transpose() *
+                self.j_blue_estimators *
                 self.j_blues_norm_factor.value,
                 index=self.atom_data.lines.index,
                 columns=np.arange(len(self.t_rads)))

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -216,7 +216,7 @@ class Radial1DModel(object):
                 zero_j_blues = self.j_blues[i] == 0.0
                 self.j_blues[i][zero_j_blues] = (
                     w_epsilon * intensity_black_body(
-                        self.atom_data.lines.nu.values[zero_j_blues],
+                        self.atom_data.lines.nu[zero_j_blues].values,
                         self.t_rads.value[i]))
 
         else:

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -208,9 +208,9 @@ class Radial1DModel(object):
 
             self.j_blues = pd.DataFrame(
                 self.j_blue_estimators *
-                self.j_blues_norm_factor.value,
-                index=self.atom_data.lines.index,
-                columns=np.arange(len(self.t_rads)))
+                    self.j_blues_norm_factor.value,
+                    index=self.atom_data.lines.index,
+                    columns=np.arange(len(self.t_rads)))
 
             for i in xrange(self.tardis_config.structure.no_of_shells):
                 zero_j_blues = self.j_blues[i] == 0.0

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -245,6 +245,7 @@ class Simulation(object):
             model.t_rads = next_t_rad
             model.ws = next_w
             model.t_inner = next_t_inner
+            model.j_blue_estimators = self.runner.j_blue_estimator
 
             model.calculate_j_blues(init_detailed_j_blues=False)
             model.update_plasmas(initialize_nlte=False)

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -5,7 +5,8 @@ import pytest
 from tardis.io import config_reader
 from tardis.model import Radial1DModel
 from tardis.simulation import Simulation
-
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 @pytest.fixture
 def tardis_config(kurucz_atomic_data, tardis_config_verysimple):
@@ -46,17 +47,17 @@ def test_plasma_estimates(simulation_one_loop, simulation_compare_data):
                         simulation_compare_data['test1/j_estimators'],
                         atol=0.0)
 
-    npt.assert_allclose(
-            t_rad, simulation_compare_data['test1/t_rad'], atol=0.0)
+    assert_quantity_allclose(
+            t_rad, simulation_compare_data['test1/t_rad'] * u.Unit('K'), atol=0.0 * u.Unit('K'))
     npt.assert_allclose(w, simulation_compare_data['test1/w'], atol=0.0)
 
 
 def test_packet_output(simulation_one_loop, simulation_compare_data):
-    npt.assert_allclose(
+    assert_quantity_allclose(
             simulation_one_loop.runner.output_nu,
-            simulation_compare_data['test1/output_nu'],
-            atol=0.0)
+            simulation_compare_data['test1/output_nu'] * u.Unit('Hz'),
+            atol=0.0 * u.Unit('Hz'))
 
-    npt.assert_allclose(simulation_one_loop.runner.output_energy,
-                        simulation_compare_data['test1/output_energy'],
-                        atol=0.0)
+    assert_quantity_allclose(simulation_one_loop.runner.output_energy,
+                        simulation_compare_data['test1/output_energy'] * u.Unit('erg'),
+                        atol=0.0 * u.Unit('erg'))

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -44,6 +44,13 @@ class TestSimpleRun():
 
         self.simulation.legacy_run_simulation(self.model)
 
+    def test_j_blue_estimators(self):
+        j_blue_estimator = np.load(
+            data_path('simple_test_j_blue_estimator.npy'))
+
+        np.testing.assert_allclose(self.model.runner.j_blue_estimator,
+                                   j_blue_estimator)
+
     def test_spectrum(self):
         luminosity_density = np.load(
             data_path('simple_test_luminosity_density_lambda.npy'))


### PR DESCRIPTION
In the current version of TARDIS the detailed mode for the estimation of radiative rates does not work (see #487). This PR fixes the problem.