### PR TITLE
Include IDE specific auto-generated files in .gitignore. Fixes #490

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ htmlcov
 
 ### PyDev IDE - Eclipse
 .metadata
-bin/
 tmp/
 *.tmp
 *.bak

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,22 @@ __pycache__
 htmlcov
 .coverage
 
+# IDE Specific files
+### Pycharm IDE - Jetbrains
+.idea/*
+
+### PyDev IDE - Eclipse
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+local.properties
+.settings/
+.loadpath
+*.project
+*.pydevproject
+
 # Sphinx
 _build
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,16 +5,19 @@
 *.so
 __pycache__
 
+
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.
 *.c
 !tardis/montecarlo/src/*.c
+
 
 # Other generated files
 */version.py
 */cython_version.py
 htmlcov
 .coverage
+
 
 # IDE Specific files
 ### Pycharm IDE - Jetbrains
@@ -31,8 +34,13 @@ local.properties
 *.project
 *.pydevproject
 
+### YouCompleteMe - VIM plugin
+.ycm_extra_conf.py
+
+
 # Sphinx
 _build
+
 
 # Packages/installer info
 *.egg
@@ -52,6 +60,7 @@ distribute-*.tar.gz
 # Other
 .*.swp
 *~
+
 
 # Mac OSX
 .DS_Store


### PR DESCRIPTION
As described in #490, the necessary files and directories for the following two IDEs have been included in .gitignore :
- **Pycharm IDE** - Jetbrains.
  - `.idea/` directory in top level project directory.
- **PyDev IDE** - Eclipse.
  - mainly `*.project` and `*.pydevproject` files, along with some other common eclipse generated files.
