### PR TITLE
Check and zero Be abundances - circumvents #438

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -628,7 +628,7 @@ class ConfigurationNameSpace(dict):
 
         return cls(ConfigurationValidator(config_definition,
                                        config_dict).get_config())
-    
+
     marker = object()
     def __init__(self, value=None):
         if value is None:
@@ -773,7 +773,7 @@ class Configuration(ConfigurationNameSpace):
             in the `data` directory that ships with TARDIS
 
         validate: ~bool
-            Turn validation on or off. 
+            Turn validation on or off.
 
 
         Returns
@@ -901,6 +901,15 @@ class Configuration(ConfigurationNameSpace):
 
         abundances = abundances.replace(np.nan, 0.0)
 
+        # Beryllium quickfix - see Issue #438
+        try:
+            is_be = abundances.ix[4] > 0.
+            if is_be.any():
+                logger.warning("Be present in model - setting to 0; see Issue #438")
+                abundances.ix[4] = np.zeros(len(abundances.ix[4]))
+        except KeyError:
+            pass
+
         abundances = abundances[abundances.sum(axis=1) > 0]
 
         norm_factor = abundances.sum(axis=0)
@@ -908,6 +917,7 @@ class Configuration(ConfigurationNameSpace):
         if np.any(np.abs(norm_factor - 1) > 1e-12):
             logger.warning("Abundances have not been normalized to 1. - normalizing")
             abundances /= norm_factor
+
 
         validated_config_dict['abundances'] = abundances
 

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -905,8 +905,8 @@ class Configuration(ConfigurationNameSpace):
         try:
             is_be = abundances.ix[4] > 0.
             if is_be.any():
-                logger.warning("Be present in model - setting to 0; see Issue #438")
-                abundances.ix[4] = np.zeros(len(abundances.ix[4]))
+                raise ConfigurationError("Beryllium (Be) is present in model. This is currently not "
+                                         "supported (see Issue #438) - aborting")
         except KeyError:
             pass
 


### PR DESCRIPTION
This PR provides a quickfix for #438. It does not solve the underlying problem but ensures that the Tardis calculation proceeds even if Be is present in the model.

If it is, its abundance is set to zero everywhere. This is done before the normalization step. The rationale behind this is that in any reasonable model, Be should only of minor importance. This quickfix should be adopted and kept until all the necessary atomic data has been added to the standard atomic data set (or if the capability is implemented in Tardis to not require always all ionisation stages of a given element).

- [x] add checker for Be abundance
- [x] set Be abundance to zero and log warning
- [ ] log warning if specified Be abundance was significant
- [x] test with tardis_example
- [ ] test with uniform and stratified models containing Be