### PR TITLE
Unit tests for untested methods of tardis/util.py

### DIFF
--- a/conda-requirements
+++ b/conda-requirements
@@ -1,10 +1,10 @@
-numpy==1.9
-scipy==0.16
-pandas==0.16
-pytables==3.2
+numpy==1.10.0
+scipy==0.17.0
+pandas==0.16.2
+pytables==3.2.2
 h5py==2.5
-matplotlib==1.4
-astropy==1.0.4
+matplotlib==1.4.3
+astropy==1.0.5
 PyYAML==3.11
 numexpr==2.4.4
 Cython==0.21

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -4,8 +4,8 @@ from astropy import units as u
 from io import StringIO
 
 from tardis.util import MalformedSpeciesError, MalformedElementSymbolError, MalformedQuantityError
-from tardis.util import (int_to_roman, calculate_luminosity,
-                         intensity_black_body, savitzky_golay,
+from tardis.util import (int_to_roman, roman_to_int, create_synpp_yaml,
+                         calculate_luminosity, intensity_black_body, savitzky_golay,
                          species_tuple_to_string, species_string_to_tuple, parse_quantity,
                          element_symbol2atomic_number, atomic_number2element_symbol,
                          reformat_element_symbol, quantity_linspace)
@@ -49,6 +49,25 @@ def test_int_to_roman(test_input, expected_result):
 
     with pytest.raises(ValueError):
         int_to_roman(4000)
+
+
+@pytest.mark.parametrize(['test_input', 'expected_result'], [
+    ('I', 1),
+    ('V', 5),
+    ('XIX', 19),
+    ('DLVI', 556),
+    ('MCD', 1400),
+    ('MCMXCIX', 1999),
+    ('MMM', 3000)
+])
+def test_roman_to_int(test_input, expected_result):
+    assert roman_to_int(test_input) == expected_result
+
+    with pytest.raises(TypeError):
+        roman_to_int(1)
+
+    with pytest.raises(ValueError):
+        roman_to_int('IIV')
 
 
 @pytest.mark.parametrize(['string_io', 'distance', 'result'], [

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -5,6 +5,26 @@ from astropy import units as u
 from tardis import atomic
 from tardis.util import species_string_to_tuple, species_tuple_to_string, parse_quantity, element_symbol2atomic_number, atomic_number2element_symbol, reformat_element_symbol, MalformedQuantityError
 
+from tardis.util import (MalformedSpeciesError, MalformedElementSymbolError)
+
+
+def test_malformed_species_error():
+    malformed_species_error = MalformedSpeciesError('He')
+    assert malformed_species_error.malformed_element_symbol == 'He'
+    assert str(malformed_species_error) == 'Expecting a species notation (e.g. "Si 2", "Si II", "Fe IV") - supplied He'
+
+
+def test_malformed_elements_symbol_error():
+    malformed_elements_symbol_error = MalformedElementSymbolError('Hx')
+    assert malformed_elements_symbol_error.malformed_element_symbol == 'Hx'
+    assert str(malformed_elements_symbol_error) == 'Expecting an atomic symbol (e.g. Fe) - supplied Hx'
+
+
+def test_malformed_quantity_error():
+    malformed_quantity_error = MalformedQuantityError('abcd')
+    assert malformed_quantity_error.malformed_quantity_string == 'abcd'
+
+
 def test_quantity_parser_normal():
     q1 = parse_quantity('5 km/s')
     assert q1.value == 5.

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -6,6 +6,7 @@ from tardis import atomic
 from tardis.util import species_string_to_tuple, species_tuple_to_string, parse_quantity, element_symbol2atomic_number, atomic_number2element_symbol, reformat_element_symbol, MalformedQuantityError
 
 from tardis.util import (MalformedSpeciesError, MalformedElementSymbolError)
+from tardis.util import int_to_roman
 
 
 def test_malformed_species_error():
@@ -23,6 +24,17 @@ def test_malformed_elements_symbol_error():
 def test_malformed_quantity_error():
     malformed_quantity_error = MalformedQuantityError('abcd')
     assert malformed_quantity_error.malformed_quantity_string == 'abcd'
+    assert str(malformed_quantity_error) == 'Expecting a quantity string(e.g. "5 km/s") for keyword - supplied abcd'
+
+
+@pytest.mark.parametrize(['test_input', 'expected_result'], [(1, 'I'), (5, 'V'), (19, 'XIX'), (556, 'DLVI'),
+                                                             (1400, 'MCD'), (1999, 'MCMXCIX'), (3000, 'MMM')])
+def test_int_to_roman(test_input, expected_result):
+    assert int_to_roman(test_input) == expected_result
+
+    with pytest.raises(TypeError ): int_to_roman(1.5)
+    with pytest.raises(ValueError): int_to_roman(0)
+    with pytest.raises(ValueError): int_to_roman(4000)
 
 
 def test_quantity_parser_normal():

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -4,10 +4,12 @@ import pytest
 from astropy import units as u
 import numpy as np
 from tardis import atomic
-from tardis.util import species_string_to_tuple, species_tuple_to_string, parse_quantity, element_symbol2atomic_number, atomic_number2element_symbol, reformat_element_symbol, MalformedQuantityError
+from tardis.util import species_string_to_tuple, species_tuple_to_string
 
-from tardis.util import (MalformedSpeciesError, MalformedElementSymbolError)
-from tardis.util import (int_to_roman, quantity_linspace)
+from tardis.util import MalformedSpeciesError, MalformedElementSymbolError, MalformedQuantityError
+from tardis.util import (int_to_roman, parse_quantity,
+                         element_symbol2atomic_number, atomic_number2element_symbol,
+                         reformat_element_symbol, quantity_linspace)
 
 
 def test_malformed_species_error():
@@ -88,17 +90,25 @@ def test_element_symbol_reformatter(unformatted_element_string, formatted_elemen
     ('si 2', (14, 1)),
     ('si ix', (14, 8)),
 ])
-def test_species_string_to_species_tuple(species_string, species_tuple):
+def test_species_string_to_tuple(species_string, species_tuple):
     assert species_string_to_tuple(species_string) == species_tuple
 
+    with pytest.raises(MalformedSpeciesError):
+        species_string_to_tuple('II')
 
-@pytest.mark.parametrize("species_string, species_tuple", [
-    ('Si II', (14, 1)),
-    ('Si IV', (14, 3)),
-    ('Si IX', (14, 8)),
+    with pytest.raises(MalformedSpeciesError):
+        species_string_to_tuple('He Si')
+
+    with pytest.raises(ValueError):
+        species_string_to_tuple('He IX')
+
+
+@pytest.mark.parametrize(['species_tuple', 'roman_numerals', 'species_string'], [
+    ((14, 1), True, 'Si II'), ((14, 3), True, 'Si IV'), ((14, 8), True, 'Si IX'),
+    ((14, 1), False, 'Si 1'), ((14, 3), False, 'Si 3'), ((14, 8), False, 'Si 8'),
 ])
-def test_species_tuple_to_species_string(species_string, species_tuple):
-    assert species_tuple_to_string(species_tuple) == species_string
+def test_species_tuple_to_string(species_tuple, roman_numerals, species_string):
+    assert species_tuple_to_string(species_tuple, roman_numerals=roman_numerals) == species_string
 
 
 @pytest.mark.parametrize(['start', 'stop', 'num', 'expected'], [

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -1,9 +1,10 @@
 import pytest
 import numpy as np
 from astropy import units as u
+from io import StringIO
 
 from tardis.util import MalformedSpeciesError, MalformedElementSymbolError, MalformedQuantityError
-from tardis.util import (int_to_roman,
+from tardis.util import (int_to_roman, calculate_luminosity, intensity_black_body,
                          species_tuple_to_string, species_string_to_tuple, parse_quantity,
                          element_symbol2atomic_number, atomic_number2element_symbol,
                          reformat_element_symbol, quantity_linspace)
@@ -47,6 +48,24 @@ def test_int_to_roman(test_input, expected_result):
 
     with pytest.raises(ValueError):
         int_to_roman(4000)
+
+
+@pytest.mark.parametrize(['string_io', 'distance', 'result'], [
+    (StringIO(u'4000 1e-21\n4500 3e-21\n5000 5e-21'), '100 km', (0.0037699111843077517, 4000.0, 5000.0)),
+    (StringIO(u'7600 2.4e-19\n7800 1.6e-19\n8100 9.1e-20'), '500 km', (2.439446695512474, 7600.0, 8100.0))
+])
+def test_calculate_luminosity(string_io, distance, result):
+    assert calculate_luminosity(string_io, distance) == result
+
+
+@pytest.mark.parametrize(['nu', 't', 'i'], [
+    (10**6, 1000, 3.072357852080765e-22),
+    (10**6, 300, 9.21707305730458e-23),
+    (10**8, 1000, 6.1562660718558254e-24),
+    (10**8, 300, 1.846869480674048e-24),
+])
+def test_intensity_black_body(nu, t, i):
+    assert float(intensity_black_body(nu, t)) == i
 
 
 @pytest.mark.parametrize(['species_tuple', 'roman_numerals', 'species_string'], [

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -1,13 +1,10 @@
-#tests for util module
-
 import pytest
-from astropy import units as u
 import numpy as np
-from tardis import atomic
-from tardis.util import species_string_to_tuple, species_tuple_to_string
+from astropy import units as u
 
 from tardis.util import MalformedSpeciesError, MalformedElementSymbolError, MalformedQuantityError
-from tardis.util import (int_to_roman, parse_quantity,
+from tardis.util import (int_to_roman,
+                         species_tuple_to_string, species_string_to_tuple, parse_quantity,
                          element_symbol2atomic_number, atomic_number2element_symbol,
                          reformat_element_symbol, quantity_linspace)
 
@@ -30,14 +27,56 @@ def test_malformed_quantity_error():
     assert str(malformed_quantity_error) == 'Expecting a quantity string(e.g. "5 km/s") for keyword - supplied abcd'
 
 
-@pytest.mark.parametrize(['test_input', 'expected_result'], [(1, 'I'), (5, 'V'), (19, 'XIX'), (556, 'DLVI'),
-                                                             (1400, 'MCD'), (1999, 'MCMXCIX'), (3000, 'MMM')])
+@pytest.mark.parametrize(['test_input', 'expected_result'], [
+    (1, 'I'),
+    (5, 'V'),
+    (19, 'XIX'),
+    (556, 'DLVI'),
+    (1400, 'MCD'),
+    (1999, 'MCMXCIX'),
+    (3000, 'MMM')
+])
 def test_int_to_roman(test_input, expected_result):
     assert int_to_roman(test_input) == expected_result
 
-    with pytest.raises(TypeError ): int_to_roman(1.5)
-    with pytest.raises(ValueError): int_to_roman(0)
-    with pytest.raises(ValueError): int_to_roman(4000)
+    with pytest.raises(TypeError):
+        int_to_roman(1.5)
+
+    with pytest.raises(ValueError):
+        int_to_roman(0)
+
+    with pytest.raises(ValueError):
+        int_to_roman(4000)
+
+
+@pytest.mark.parametrize(['species_tuple', 'roman_numerals', 'species_string'], [
+    ((14, 1), True, 'Si II'),
+    ((14, 1), False, 'Si 1'),
+    ((14, 3), True, 'Si IV'),
+    ((14, 3), False, 'Si 3'),
+    ((14, 8), True, 'Si IX'),
+    ((14, 8), False, 'Si 8'),
+])
+def test_species_tuple_to_string(species_tuple, roman_numerals, species_string):
+    assert species_tuple_to_string(species_tuple, roman_numerals=roman_numerals) == species_string
+
+
+@pytest.mark.parametrize(['species_string', 'species_tuple'], [
+    ('si ii', (14, 1)),
+    ('si 2', (14, 1)),
+    ('si ix', (14, 8)),
+])
+def test_species_string_to_tuple(species_string, species_tuple):
+    assert species_string_to_tuple(species_string) == species_tuple
+
+    with pytest.raises(MalformedSpeciesError):
+        species_string_to_tuple('II')
+
+    with pytest.raises(MalformedSpeciesError):
+        species_string_to_tuple('He Si')
+
+    with pytest.raises(ValueError):
+        species_string_to_tuple('He IX')
 
 
 def test_parse_quantity():
@@ -58,11 +97,7 @@ def test_parse_quantity():
         parse_quantity('5 abcd')
 
 
-def test_atomic_number2element_symbol():
-    assert atomic_number2element_symbol(14) == 'Si'
-
-
-@pytest.mark.parametrize("element_symbol, atomic_number", [
+@pytest.mark.parametrize(['element_symbol', 'atomic_number'], [
     ('sI', 14),
     ('ca', 20),
     ('Fe', 26)
@@ -74,41 +109,19 @@ def test_element_symbol2atomic_number(element_symbol, atomic_number):
         element_symbol2atomic_number('Hx')
 
 
-@pytest.mark.parametrize("unformatted_element_string, formatted_element_string", [
+def test_atomic_number2element_symbol():
+    assert atomic_number2element_symbol(14) == 'Si'
+
+
+@pytest.mark.parametrize(['unformatted_element_string', 'formatted_element_string'], [
     ('si', 'Si'),
     ('sI', 'Si'),
     ('Si', 'Si'),
     ('c', 'C'),
     ('C', 'C'),
 ])
-def test_element_symbol_reformatter(unformatted_element_string, formatted_element_string):
+def test_reformat_element_symbol(unformatted_element_string, formatted_element_string):
     assert reformat_element_symbol(unformatted_element_string) == formatted_element_string
-
-
-@pytest.mark.parametrize("species_string, species_tuple", [
-    ('si ii', (14, 1)),
-    ('si 2', (14, 1)),
-    ('si ix', (14, 8)),
-])
-def test_species_string_to_tuple(species_string, species_tuple):
-    assert species_string_to_tuple(species_string) == species_tuple
-
-    with pytest.raises(MalformedSpeciesError):
-        species_string_to_tuple('II')
-
-    with pytest.raises(MalformedSpeciesError):
-        species_string_to_tuple('He Si')
-
-    with pytest.raises(ValueError):
-        species_string_to_tuple('He IX')
-
-
-@pytest.mark.parametrize(['species_tuple', 'roman_numerals', 'species_string'], [
-    ((14, 1), True, 'Si II'), ((14, 3), True, 'Si IV'), ((14, 8), True, 'Si IX'),
-    ((14, 1), False, 'Si 1'), ((14, 3), False, 'Si 3'), ((14, 8), False, 'Si 8'),
-])
-def test_species_tuple_to_string(species_tuple, roman_numerals, species_string):
-    assert species_tuple_to_string(species_tuple, roman_numerals=roman_numerals) == species_string
 
 
 @pytest.mark.parametrize(['start', 'stop', 'num', 'expected'], [

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -99,62 +99,67 @@ def int_to_roman(int_input):
     return result
 
 
-def roman_to_int(input):
-   """
-   from http://code.activestate.com/recipes/81611-roman-numerals/
-   Convert a roman numeral to an integer.
+def roman_to_int(roman_input):
+    """
+    from http://code.activestate.com/recipes/81611-roman-numerals/
+    Convert a roman numeral to an integer.
 
-   >>> r = range(1, 4000)
-   >>> nums = [int_to_roman(i) for i in r]
-   >>> ints = [roman_to_int(n) for n in nums]
-   >>> print r == ints
-   1
+    :param roman_input: a valid roman numeral string
+    :returns sum: equivalent integer of passed :param{roman_input}
 
-   >>> roman_to_int('VVVIV')
-   Traceback (most recent call last):
-    ...
-   ValueError: input is not a valid roman numeral: VVVIV
-   >>> roman_to_int(1)
-   Traceback (most recent call last):
-    ...
-   TypeError: expected string, got <type 'int'>
-   >>> roman_to_int('a')
-   Traceback (most recent call last):
-    ...
-   ValueError: input is not a valid roman numeral: A
-   >>> roman_to_int('IL')
-   Traceback (most recent call last):
-    ...
-   ValueError: input is not a valid roman numeral: IL
-   """
-   if type(input) != type(""):
-      raise TypeError, "expected string, got %s" % type(input)
-   input = input.upper()
-   nums = ['M', 'D', 'C', 'L', 'X', 'V', 'I']
-   ints = [1000, 500, 100, 50,  10,  5,   1]
-   places = []
-   for c in input:
-      if not c in nums:
-         raise ValueError, "input is not a valid roman numeral: %s" % input
-   for i in range(len(input)):
-      c = input[i]
-      value = ints[nums.index(c)]
-      # If the next place holds a larger number, this value is negative.
-      try:
-         nextvalue = ints[nums.index(input[i +1])]
-         if nextvalue > value:
-            value *= -1
-      except IndexError:
-         # there is no next place.
-         pass
-      places.append(value)
-   sum = 0
-   for n in places: sum += n
-   # Easiest test for validity...
-   if int_to_roman(sum) == input:
-      return sum
-   else:
-      raise ValueError, 'input is not a valid roman numeral: %s' % input
+    >>> r = range(1, 4000)
+    >>> nums = [int_to_roman(i) for i in r]
+    >>> ints = [roman_to_int(n) for n in nums]
+    >>> print r == ints
+    1
+
+    >>> roman_to_int('VVVIV')
+    Traceback (most recent call last):
+     ...
+    ValueError: input is not a valid roman numeral: VVVIV
+    >>> roman_to_int(1)
+    Traceback (most recent call last):
+     ...
+    TypeError: expected string, got <type 'int'>
+    >>> roman_to_int('a')
+    Traceback (most recent call last):
+     ...
+    ValueError: input is not a valid roman numeral: A
+    >>> roman_to_int('IL')
+    Traceback (most recent call last):
+     ...
+    ValueError: input is not a valid roman numeral: IL
+    """
+    if not isinstance(roman_input, str):
+        raise TypeError("expected string, got %s" % type(roman_input))
+
+    roman_input = roman_input.upper()
+    nums = ['M', 'D', 'C', 'L', 'X', 'V', 'I']
+    ints = [1000, 500, 100, 50,  10,  5,   1]
+    places = []
+    for c in roman_input:
+        if not c in nums:
+            raise ValueError("input is not a valid roman numeral: %s" % roman_input)
+    for i in range(len(roman_input)):
+        c = roman_input[i]
+        value = ints[nums.index(c)]
+        # If the next place holds a larger number, this value is negative.
+        try:
+            nextvalue = ints[nums.index(roman_input[i +1])]
+            if nextvalue > value:
+                value *= -1
+        except IndexError:
+            # there is no next place.
+            pass
+        places.append(value)
+    result = 0
+    for n in places:
+        result += n
+    # Easiest test for validity...
+    if int_to_roman(result) == roman_input:
+        return result
+    else:
+        raise ValueError('input is not a valid roman numeral: %s' % roman_input)
 
 
 def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_unit=u.angstrom, flux_column=1,

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -92,10 +92,10 @@ def int_to_roman(int_input):
                         (10  , 'X'), (9  , 'IX'), (5  , 'V'), (4  , 'IV'), (1, 'I')]
 
     result = ''
-    for iterable, int_roman_tuple in enumerate(int_roman_tuples):
-        count = int(int_input / int_roman_tuple[0])
-        result += int_roman_tuple[1] * count
-        int_input -= int_roman_tuple[0] * count
+    for (integer, roman) in int_roman_tuples:
+        count = int(int_input / integer)
+        result += roman * count
+        int_input -= integer * count
     return result
 
 

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -52,64 +52,52 @@ logger = logging.getLogger(__name__)
 
 synpp_default_yaml_fname = os.path.join(os.path.dirname(__file__), 'data', 'synpp_default.yaml')
 
-def int_to_roman(input):
-   """
-   from http://code.activestate.com/recipes/81611-roman-numerals/
-   Convert an integer to Roman numerals.
 
-   Examples:
-   >>> int_to_roman(0)
-   Traceback (most recent call last):
-   ValueError: Argument must be between 1 and 3999
+def int_to_roman(int_input):
+    """
+    from http://code.activestate.com/recipes/81611-roman-numerals/
+    Convert an integer to Roman numerals.
 
-   >>> int_to_roman(-1)
-   Traceback (most recent call last):
-   ValueError: Argument must be between 1 and 3999
+    :param int_input: an integer between 1 and 3999
+    :returns result: roman equivalent string of passed :param{int_input}
 
-   >>> int_to_roman(1.5)
-   Traceback (most recent call last):
-   TypeError: expected integer, got <type 'float'>
+    Examples:
+    >>> int_to_roman(0)
+    Traceback (most recent call last):
+    ValueError: Argument must be between 1 and 3999
 
-   >>> for i in range(1, 21): print int_to_roman(i)
-   ...
-   I
-   II
-   III
-   IV
-   V
-   VI
-   VII
-   VIII
-   IX
-   X
-   XI
-   XII
-   XIII
-   XIV
-   XV
-   XVI
-   XVII
-   XVIII
-   XIX
-   XX
-   >>> print int_to_roman(2000)
-   MM
-   >>> print int_to_roman(1999)
-   MCMXCIX
-   """
-   input = int(input)
-   if type(input) != type(1):
-      raise TypeError, "expected integer, got %s" % type(input)
-   if not 0 < input < 4000:
-      raise ValueError, "Argument must be between 1 and 3999"
-   ints = (1000, 900,  500, 400, 100,  90, 50,  40, 10,  9,   5,  4,   1)
-   nums = ('M',  'CM', 'D', 'CD','C', 'XC','L','XL','X','IX','V','IV','I')
-   result = ""
-   for i in range(len(ints)):
-      count = int(input / ints[i])
-      result += nums[i] * count
-      input -= ints[i] * count
-   return result
+    >>> int_to_roman(-1)
+    Traceback (most recent call last):
+    ValueError: Argument must be between 1 and 3999
+
+    >>> int_to_roman(1.5)
+    Traceback (most recent call last):
+    TypeError: expected integer, got <type 'float'>
+
+    >>> for i in range(1, 21): print int_to_roman(i),
+    ...
+    I II III IV V VI VII VIII IX X XI XII XIII XIV XV XVI XVII XVIII XIX XX
+    >>> print int_to_roman(2000)
+    MM
+    >>> print int_to_roman(1999)
+    MCMXCIX
+    """
+    if not isinstance(int_input, int):
+        raise TypeError("Expected integer, got %s" % type(int_input))
+    if not 0 < int_input < 4000:
+        raise ValueError("Argument must be between 1 and 3999")
+
+    int_roman_tuples = [(1000, 'M'), (900, 'CM'), (500, 'D'), (400, 'CD'),
+                        (100 , 'C'), (90 , 'XC'), (50 , 'L'), (40 , 'XL'),
+                        (10  , 'X'), (9  , 'IX'), (5  , 'V'), (4  , 'IV'), (1, 'I')]
+
+    result = ''
+    for iterable, int_roman_tuple in enumerate(int_roman_tuples):
+        count = int(int_input / int_roman_tuple[0])
+        result += int_roman_tuple[1] * count
+        int_input -= int_roman_tuple[0] * count
+    return result
+
 
 def roman_to_int(input):
    """


### PR DESCRIPTION
This PR will be consisting a series of commits targetting to improve code coverage of **tardis/utils.py**.

This checklist maintains the methods/ classes present in **tardis/utils.py** on 05 March 2016, the day when #506 was created. The commits enclosed in brackets show where these tests were modified/ added.
- **Classes**:
- [X] MalformedError (71bc70d)
- [X] MalformedSpeciesError (71bc70d)
- [X] MalformedElementSymbolError (71bc70d)
- [x] MalformedQuantityError (71bc70d) <br><br>
- **Methods**:
- [X] int_to_roman (fe58570)
- [X] roman_to_int (03c3f95)
- [X] calculate_luminosity (dc4abe6)
- [ ] create_synpp_yaml (excluded in this PR)
- [X] intensity_black_body (dc4abe6)
- [X] savitzky_golay (9fe1a16)
- [X] species_tuple_to_string (6bed2b4)
- [X] species_string_to_tuple (6bed2b4)
- [X] parse_quantity (9231364)
- [X] element_symbol2atomic_number (9231364)
- [X] quantity_linspace (9231364)
