### PR TITLE
Updates requirements to solve libgfortran error. Fixes #509

### DIFF
--- a/conda-requirements
+++ b/conda-requirements
@@ -1,10 +1,10 @@
-numpy==1.9
-scipy==0.16
-pandas==0.16
-pytables==3.2
+numpy==1.10.0
+scipy==0.17.0
+pandas==0.16.2
+pytables==3.2.2
 h5py==2.5
-matplotlib==1.4
-astropy==1.0.4
+matplotlib==1.4.3
+astropy==1.0.5
 PyYAML==3.11
 numexpr==2.4.4
 Cython==0.21


### PR DESCRIPTION
Minimum required versions of certain libraries were increased in file **conda-requirements**, as stated in comment of #509.

This modification should eliminate the `libgfortran` issue and continue smooth builds in Travis CI.