### PR TITLE
Performance

### DIFF
--- a/scripts/tardis
+++ b/scripts/tardis
@@ -36,6 +36,8 @@ parser.add_argument('--profile', action='store_true', help=
 parser.add_argument('--profiler_log_file', default='profiler.log', help=
 'name of the profiler output file')
 
+parser.add_argument('--gdb', action='store_true', help='print pid and pause')
+
 args = parser.parse_args()
 
 packet_logging_fname = 'tardis_packets.log'
@@ -63,9 +65,11 @@ if args.packet_log_file:
 tardis_config = config_reader.Configuration.from_yaml(args.config_fname)
 radial1d_mdl = model.Radial1DModel(tardis_config)
 
+if args.gdb:
+    import os; print(os.getpid()); raw_input() # Workaround to attach gdb
 if args.profile:
     import cProfile
-    cProfile.runctx('simulation.run_radial1d(radial1d_mdl)', locals(),
+    cProfile.runctx('run_radial1d(radial1d_mdl)', locals(),
                     globals(), filename=args.profiler_log_file)
 else:
     run_radial1d(radial1d_mdl)

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -104,6 +104,11 @@ class MontecarloRunner(object):
         montecarlo.montecarlo_radial1d(
             model, self, virtual_packet_flag=no_of_virtual_packets,
             nthreads=nthreads)
+        # Workaround so that j_blue_estimator is in the right ordering
+        # They are written as an array of dimension (no_of_shells, no_of_lines)
+        # but python expects (no_of_lines, no_of_shells)
+        self.j_blue_estimator = self.j_blue_estimator.flatten().reshape(
+                self.j_blue_estimator.shape, order='F')
 
     def legacy_return(self):
         return (self.output_nu, self.output_energy,

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -147,17 +147,28 @@ cdef initialize_storage_model(model, runner, storage_model_t *storage):
     # Line lists
     storage.no_of_lines = model.atom_data.lines.nu.values.size
     storage.line_list_nu = <double*> PyArray_DATA(model.atom_data.lines.nu.values)
+    runner.line_lists_tau_sobolevs = (
+            model.plasma_array.tau_sobolevs.values.flatten(order='F')
+            )
     storage.line_lists_tau_sobolevs = <double*> PyArray_DATA(
-        model.plasma_array.tau_sobolevs.values)
-    storage.line_lists_j_blues = <double*> PyArray_DATA(runner.j_blue_estimator)
+            runner.line_lists_tau_sobolevs
+            )
+    storage.line_lists_j_blues = <double*> PyArray_DATA(
+            runner.j_blue_estimator)
 
     storage.line_interaction_id = runner.get_line_interaction_id(
         model.tardis_config.plasma.line_interaction_type)
 
     # macro atom & downbranch
     if storage.line_interaction_id >= 1:
+        runner.transition_probabilities = (
+                model.plasma_array.transition_probabilities.values.flatten(order='F')
+        )
         storage.transition_probabilities = <double*> PyArray_DATA(
-            model.plasma_array.transition_probabilities.values)
+                runner.transition_probabilities
+                )
+        storage.transition_probabilities_nd = (
+        model.plasma_array.transition_probabilities.values.shape[0])
         storage.line2macro_level_upper = <int_type_t*> PyArray_DATA(
             model.atom_data.lines_upper2macro_reference_idx)
         storage.macro_block_references = <int_type_t*> PyArray_DATA(

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -298,7 +298,7 @@ macro_atom (const rpacket_t * packet, const storage_model_t * storage, rk_state 
 {
   int emit = 0, i = 0, probability_idx = -1;
   int activate_level =
-    storage->line2macro_level_upper[rpacket_get_next_line_id (packet) - 1];
+    storage->line2macro_level_upper[rpacket_get_next_line_id (packet)];
   while (emit != -1)
     {
       double event_random = rk_double (mt_state);
@@ -607,7 +607,8 @@ void
 montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
                          double distance, rk_state *mt_state)
 {
-  int64_t line2d_idx = rpacket_get_next_line_id (packet)
+  int64_t next_line_id = rpacket_get_next_line_id (packet);
+  int64_t line2d_idx = next_line_id
     * storage->no_of_shells + rpacket_get_current_shell_id (packet);
   if (rpacket_get_virtual_packet (packet) == 0)
     {
@@ -617,9 +618,9 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
     storage->line_lists_tau_sobolevs[line2d_idx];
   double tau_continuum = rpacket_get_chi_continuum(packet) * distance;
   double tau_combined = tau_line + tau_continuum;
-  rpacket_set_next_line_id (packet, rpacket_get_next_line_id (packet) + 1);
+  //rpacket_set_next_line_id (packet, rpacket_get_next_line_id (packet) + 1);
 
-  if (rpacket_get_next_line_id (packet) == storage->no_of_lines)
+  if (next_line_id + 1 == storage->no_of_lines)
     {
       rpacket_set_last_line (packet, true);
     }
@@ -627,6 +628,7 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
     {
       rpacket_set_tau_event (packet,
                              rpacket_get_tau_event (packet) + tau_line);
+      rpacket_set_next_line_id (packet, next_line_id + 1);
     }
   else if (rpacket_get_tau_event (packet) < tau_combined)
     {
@@ -639,14 +641,14 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
       storage->last_interaction_in_nu[rpacket_get_id (packet)] =
         rpacket_get_nu (packet);
       storage->last_line_interaction_in_id[rpacket_get_id (packet)] =
-        rpacket_get_next_line_id (packet) - 1;
+        next_line_id;
       storage->last_line_interaction_shell_id[rpacket_get_id (packet)] =
         rpacket_get_current_shell_id (packet);
       storage->last_interaction_type[rpacket_get_id (packet)] = 2;
       int64_t emission_line_id = 0;
       if (storage->line_interaction_id == 0)
         {
-          emission_line_id = rpacket_get_next_line_id (packet) - 1;
+          emission_line_id = next_line_id;
         }
       else if (storage->line_interaction_id >= 1)
         {
@@ -683,6 +685,7 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
     {
       rpacket_set_tau_event (packet,
                              rpacket_get_tau_event (packet) - tau_line);
+      rpacket_set_next_line_id (packet, next_line_id + 1);
     }
   if (!rpacket_get_last_line (packet) &&
       fabs (storage->line_list_nu[rpacket_get_next_line_id (packet)] -

--- a/tardis/montecarlo/src/cmontecarlo.h
+++ b/tardis/montecarlo/src/cmontecarlo.h
@@ -33,7 +33,7 @@ double rpacket_doppler_factor(const rpacket_t *packet, const storage_model_t *st
  *
  * @return distance to shell boundary
  */
-double compute_distance2boundary (rpacket_t * packet,
+void compute_distance2boundary (rpacket_t * packet,
                                   const storage_model_t * storage);
 
 /** Calculate the distance the packet has to travel until it redshifts to the first spectral line.
@@ -43,9 +43,8 @@ double compute_distance2boundary (rpacket_t * packet,
  *
  * @return distance to the next spectral line
  */
-tardis_error_t compute_distance2line (const rpacket_t * packet,
-                                      const storage_model_t * storage,
-                                      double *result);
+tardis_error_t compute_distance2line (rpacket_t * packet,
+                                      const storage_model_t * storage);
 
 /** Calculate the distance to the next continuum event, which can be a Thomson scattering, bound-free absorption or
   free-free transition.

--- a/tardis/montecarlo/src/test_cmontecarlo.c
+++ b/tardis/montecarlo/src/test_cmontecarlo.c
@@ -220,10 +220,10 @@ test_compute_distance2boundary(void){
         storage_model_t sm;
         init_rpacket(&rp);
         init_storage_model(&sm);
-        double D_BOUNDARY = compute_distance2boundary(&rp, &sm);
-	rpacket_set_d_boundary(&rp, D_BOUNDARY);
+        compute_distance2boundary(&rp, &sm);
+        double D_BOUNDARY = rpacket_get_d_boundary(&rp);
         dealloc_storage_model(&sm);
-	return D_BOUNDARY;
+        return D_BOUNDARY;
 }
 double
 test_compute_distance2line(void){
@@ -231,12 +231,11 @@ test_compute_distance2line(void){
         storage_model_t sm;
         init_rpacket(&rp);
         init_storage_model(&sm);
-	double D_LINE;
         // FIXME MR: return status of compute_distance2line() is ignored
-	compute_distance2line(&rp, &sm, &D_LINE);
-	rpacket_set_d_line(&rp, D_LINE);
+        compute_distance2line(&rp, &sm);
+        double D_LINE = rpacket_get_d_line(&rp);
         dealloc_storage_model(&sm);
-	return D_LINE;
+        return D_LINE;
 }
 
 double
@@ -279,17 +278,12 @@ test_increment_j_blue_estimator(void){
         storage_model_t sm;
         init_rpacket(&rp);
         init_storage_model(&sm);
-	int64_t j_blue_idx = 0;
-        double D_BOUNDARY = compute_distance2boundary(&rp, &sm);
-        rpacket_set_d_boundary(&rp, D_BOUNDARY);
-        double D_LINE;
-        // FIXME MR: return status of compute_distance2line() is ignored
-        compute_distance2line(&rp, &sm, &D_LINE);
-        rpacket_set_d_line(&rp, D_LINE);
+        int64_t j_blue_idx = 0;
+        compute_distance2line(&rp, &sm);
         move_packet(&rp, &sm, 1e13);
-	double d_line = rpacket_get_d_line(&rp);
-	increment_j_blue_estimator(&rp, &sm, d_line, j_blue_idx);
-	double res = sm.line_lists_j_blues[j_blue_idx];
+        double d_line = rpacket_get_d_line(&rp);
+        increment_j_blue_estimator(&rp, &sm, d_line, j_blue_idx);
+        double res = sm.line_lists_j_blues[j_blue_idx];
         dealloc_storage_model(&sm);
         return res;
 }
@@ -379,12 +373,7 @@ test_calculate_chi_bf(void){
         rk_state mt_state;
         irandom(&mt_state);
         int64_t j_blue_idx = 0;
-        double D_BOUNDARY = compute_distance2boundary(&rp, &sm);
-        rpacket_set_d_boundary(&rp, D_BOUNDARY);
-        double D_LINE;
-        // FIXME MR: return status of compute_distance2line() is ignored
-        compute_distance2line(&rp, &sm, &D_LINE);
-        rpacket_set_d_line(&rp, D_LINE);
+        compute_distance2line(&rp, &sm);
         move_packet(&rp, &sm, 1e13);
         double d_line = rpacket_get_d_line(&rp);
         increment_j_blue_estimator(&rp, &sm, d_line, j_blue_idx);


### PR DESCRIPTION
This is a small collection of performance boosts and improvement of code readability.

Included changes:

- remove confusion from line_scatter by setting the next line only when it is known
- change memory layout of line_list_tau_sobolevs and transition_probabilities so the montecarlo routine can interprete it as no_of_shells x no_of_lines
- Fix for #497: distance2boundary is more structured now and has no overhead anymore

- [x] `tardis_example.yml`
- [x] `tardis_w7.yml` ~20-25%
- [x] `abn_tom_test.yml` ~31%