### PR TITLE
[config-system] Add a custom YAML Loader to parse astropy quantities

### DIFF
--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -1,5 +1,5 @@
 # tests for the config reader module
-from tardis.io import config_reader
+from tardis.io import config_reader, util
 from astropy import units as u
 import os
 import pytest
@@ -366,6 +366,16 @@ def test_absolute_relative_config_paths(monkeypatch, cwd):
                                                        test_parser=True)
     config_abs = config_reader.Configuration.from_yaml(os.path.abspath(data_path(filename)),
                                                        test_parser=True)
+
+def test_custom_yaml_loader():
+    filename = 'tardis_configv1_density_exponential_test.yml'
+    default_conf = config_reader.Configuration.from_yaml(data_path(filename), test_parser=True,
+                                                         loader=yaml.Loader)
+    custom_conf = config_reader.Configuration.from_yaml(data_path(filename), test_parser=True,
+                                                        loader=config_reader.YAMLLoader)
+    assert len(default_conf) == len(custom_conf)
+    assert set(default_conf.keys()) == set(custom_conf.keys())
+    assert util.check_equality(default_conf, custom_conf)
 
 
 #write tests for inner and outer boundary indices

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -1,6 +1,8 @@
 #Utility functions for the IO part of TARDIS
 
 import pandas as pd
+import numpy as np
+import collections
 from tardis.util import element_symbol2atomic_number
 
 import logging
@@ -20,3 +22,50 @@ def parse_abundance_dict_to_dataframe(abundance_dict):
         abundances /= abundance_norm
 
     return abundances
+
+
+def traverse_configs(base, other, func, *args):
+    """
+    Recursively traverse a base dict or list along with another one
+    calling `func` for leafs of both objects.
+
+    Parameters
+    ----------
+    base:
+        The object on which the traversing is done
+    other:
+        The object which is traversed along with `base`
+    func:
+        A function called for each leaf of `base` and the correspnding leaf of `other`
+        Signature: `func(item1, item2, *args)`
+    args:
+        Arguments passed into `func`
+
+    """
+    if isinstance(base, collections.Mapping):
+        for k in base:
+            traverse_configs(base[k], other[k], func, *args)
+    elif isinstance(base, collections.Iterable) and not isinstance(base, basestring) and not hasattr(base, 'shape'):
+        for val1, val2 in zip(base, other):
+            traverse_configs(val1, val2, func, *args)
+    else:
+        func(base, other, *args)
+
+
+def assert_equality(item1, item2):
+    assert type(item1) is type(item2)
+    try:
+        if hasattr(item1, 'unit'):
+            assert item1.unit == item2.unit
+        assert np.allclose(item1, item2, atol=0.0)
+    except (ValueError, TypeError):
+        assert item1 == item2
+
+
+def check_equality(item1, item2):
+    try:
+        traverse_configs(item1, item2, assert_equality)
+    except AssertionError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
The `yaml.Loader` class supports adding constructors and implicit resolvers to parse a YAML scalar as a Python object.

In this PR the following changes are introduced:

- Subclass the default `yaml.Loader`, add a constructor and an implicit resolver for `quantity` properties to the subclass and allow the user to choose which loader they will use when parsing the YAML configuration.
- Monkeypatch pyyaml's [bug #57](https://bitbucket.org/xi/pyyaml/issues/57/add_implicit_resolver-on-a-subclass-may) which affected this implementation.
- Change the `tardis.io.config_validator` to accept already constructed `astropy.units.Quantity` objects as valid quantity properties.
- Write a `pytest` test which checks if `yaml.Loader` and the new `config_reader.YAMLLoader` both produce the same `Configuration` object for a given input.