### PR TITLE
Add check for dangerously misplaced packets (Debugging PR not for merging)

### DIFF
--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -147,6 +147,10 @@ compute_distance2boundary (rpacket_t * packet, const storage_model_t * storage)
   double d_outer =
     sqrt (r_outer * r_outer + ((mu * mu - 1.0) * r * r)) - (r * mu);
   double d_inner;
+  double discriminant = r_outer * r_outer + ((mu * mu - 1.0) * r * r);
+  if (discriminant <= 0){
+    fprintf(stderr, "Potentially dangerous packet misplacement detected\n");
+  }
   if (rpacket_get_recently_crossed_boundary (packet) == 1)
     {
       rpacket_set_next_shell_id (packet, 1);


### PR DESCRIPTION
@yeganer, @wkerzendorf, @ssim: Following our discussion, I've added a check for what I think are the potentially dangerous packets. For these, the r_outer calculation should produce a NAN (due to negative values in the sqrt). 

I've tested it with tardis_example and did not find a single packet falling into this.
