### PR TITLE
Docs: Include conda-requirements in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,19 +15,8 @@ Requirements
 
 TARDIS has the following requirements:
 
-- `Python <http://www.python.org/>`_ 2.7
-
-- `Numpy <http://www.numpy.org/>`_ 1.9 or later
-
-- `Scipy <http://www.scipy.org/>`_ 0.16 or later
-
-- `Astropy <http://www.astropy.org/>`_ 1.0 or later
-
-- `h5py <http://www.h5py.org/>`_ 2.0.0 or later
-
-- `pandas <http://pandas.pydata.org/>`_ 0.16.1 or later
-
-- `pyyaml <http://pyyaml.org/>`_ 3.0 or later
+.. include:: ../conda-requirements
+    :literal:
 
 Most of these requirements are easy to install using package managers like
 OS X's macports or linux package managers or using the Anaconda python


### PR DESCRIPTION
**docs/installation.rst** had the requirements listed within. On readthedocs.org, they looked like this:
![image](https://cloud.githubusercontent.com/assets/10494087/13925816/cbc4ee40-efaf-11e5-8b59-5543377cb361.png)

Upon modification in **conda-requirements**, there had to be manual changes here. This is now avoided by literal inclusion of contents from requirements file here... Now, the page as viewed on readthedocs.org looks like this:
![image](https://cloud.githubusercontent.com/assets/10494087/13925897/2837be46-efb0-11e5-9e47-9dc2465d2b03.png)
Modification in **conda-requirements** will be reflected here automatically.