### PR TITLE
Unit tests for untested methods of tardis/atomic.py

### DIFF
--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -19,15 +19,13 @@ class AtomDataNotPreparedError(Exception):
 
 logger = logging.getLogger(__name__)
 
-default_atom_h5_path = os.path.join(os.path.dirname(__file__), 'data', 'atom_data.h5')
 
 def data_path(fname):
-    data_dir = os.path.join(os.path.dirname(__file__), 'data')
-    return os.path.join(data_dir, fname)
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', fname)
 
-atomic_symbols_data = np.recfromtxt(data_path('atomic_symbols.dat'),
-                                    names=['atomic_number', 'symbol'])
 
+default_atom_h5_path = data_path('atom_data.h5')
+atomic_symbols_data = np.recfromtxt(data_path('atomic_symbols.dat'), names=['atomic_number', 'symbol'])
 symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'], atomic_symbols_data['atomic_number']))
 atomic_number2symbol = OrderedDict(atomic_symbols_data)
 

--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -21,12 +21,16 @@ logger = logging.getLogger(__name__)
 
 
 def data_path(fname):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data', fname)
+    return os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 'data', fname)
 
 
 default_atom_h5_path = data_path('atom_data.h5')
-atomic_symbols_data = np.recfromtxt(data_path('atomic_symbols.dat'), names=['atomic_number', 'symbol'])
-symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'], atomic_symbols_data['atomic_number']))
+atomic_symbols_data = np.recfromtxt(data_path('atomic_symbols.dat'),
+                                    names=['atomic_number', 'symbol'])
+
+symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'],
+                                       atomic_symbols_data['atomic_number']))
 atomic_number2symbol = OrderedDict(atomic_symbols_data)
 
 

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -72,6 +72,27 @@ def test_read_zeta_data():
         atomic.read_zeta_data(atomic.default_atom_h5_path)
 
 
+def test_read_collision_data():
+    data = atomic.read_collision_data(chianti_he_db_h5_path)
+    assert data[0]['atomic_number'][0] == 2
+    assert data[0]['ion_number'][0] == 0
+    assert data[0]['level_number_upper'][0] == 18
+    assert data[0]['level_number_lower'][0] == 2
+    assert data[0]['g_ratio'][0] == 1.0
+    testing.assert_almost_equal(data[0]['delta_e'][0], 35484.251143, decimal=4)
+    assert data[1][0] == 2000.0
+    assert data[1][1] == 4000.0
+
+    with pytest.raises(ValueError):
+        atomic.read_zeta_data(None)
+
+    with pytest.raises(IOError):
+        atomic.read_zeta_data('fakepath')
+
+    with pytest.raises(ValueError):
+        atomic.read_zeta_data(atomic.default_atom_h5_path)
+
+
 def test_atom_levels():
     atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
     with pytest.raises(Exception):

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -4,6 +4,10 @@ from numpy import testing
 from tardis import atomic
 
 
+chianti_he_db_h5_path = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), 'data', 'chianti_he_db.h5')
+
+
 def test_data_path():
     data_path = atomic.data_path('test')
     assert data_path.split('/')[-3:] == ['tardis', 'data', 'test']
@@ -36,13 +40,36 @@ def test_read_levels_data():
 def test_read_lines_data():
     data = atomic.read_lines_data(atomic.default_atom_h5_path)
     assert data['line_id'][0] == 8
-    assert data['atomic_numer'][0] == 14
+    assert data['atomic_number'][0] == 14
     assert data['ion_number'][0] == 5
     testing.assert_almost_equal(data['wavelength'][0], 66.772, decimal=4)
     testing.assert_almost_equal(data['f_ul'][0], 0.02703, decimal=4)
     testing.assert_almost_equal(data['f_lu'][0], 0.04054, decimal=4)
-    assert data['level_number_lower'] == 0.0
-    assert data['level_number_upper'] == 36.0
+    assert data['level_number_lower'][0] == 0.0
+    assert data['level_number_upper'][0] == 36.0
+
+
+def test_read_synpp_refs():
+    data = atomic.read_synpp_refs(chianti_he_db_h5_path)
+    assert data['atomic_number'][0] == 1
+    assert data['ion_number'][0] == 0
+    testing.assert_almost_equal(data['wavelength'][0], 6562.7973633, decimal=4)
+    assert data['line_id'][0] == 564995
+
+
+def test_read_zeta_data():
+    data = atomic.read_zeta_data(chianti_he_db_h5_path)
+    testing.assert_almost_equal(data[2000][1][1], 0.339, decimal=4)
+    testing.assert_almost_equal(data[2000][1][2], 0.000, decimal=4)
+
+    with pytest.raises(ValueError):
+        atomic.read_zeta_data(None)
+
+    with pytest.raises(IOError):
+        atomic.read_zeta_data('fakepath')
+
+    with pytest.raises(ValueError):
+        atomic.read_zeta_data(atomic.default_atom_h5_path)
 
 
 def test_atom_levels():

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -93,6 +93,30 @@ def test_read_collision_data():
         atomic.read_zeta_data(atomic.default_atom_h5_path)
 
 
+def test_read_macro_atom_data():
+    data = atomic.read_macro_atom_data(chianti_he_db_h5_path)
+    assert data[0]['atomic_number'][0] == 2
+    assert data[0]['ion_number'][0] == 0
+    assert data[0]['source_level_number'][0] == 0.0
+    assert data[0]['destination_level_number'][0] == 48.0
+    assert data[0]['transition_type'][0] == 1
+    assert data[0]['transition_probability'][0] == 0.0
+    assert data[0]['transition_line_id'][0] == 564957
+
+    assert data[1]['count_down'][0] == 0
+    assert data[1]['count_up'][0] == 7
+    assert data[1]['count_total'][0] == 7
+
+    with pytest.raises(ValueError):
+        atomic.read_macro_atom_data(None)
+
+    with pytest.raises(IOError):
+        atomic.read_macro_atom_data('fakepath')
+
+    with pytest.raises(ValueError):
+        atomic.read_macro_atom_data(atomic.default_atom_h5_path)
+
+
 def test_atom_levels():
     atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
     with pytest.raises(Exception):

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -9,28 +9,40 @@ def test_data_path():
     assert data_path.split('/')[-3:] == ['tardis', 'data', 'test']
 
 
-def test_atomic_h5_readin():
+def test_read_basic_atom_data():
     data = atomic.read_basic_atom_data(atomic.default_atom_h5_path)
     assert data['atomic_number'][13] == 14
     assert data['symbol'][13] == "Si"
-    si_mass = data['mass'][13]
-    testing.assert_almost_equal(si_mass, 28.085, decimal=4)
-    pass
+    testing.assert_almost_equal(data['mass'][13], 28.085, decimal=4)
 
-def test_ionization_h5_readin():
+
+def test_read_ionization_data():
     data = atomic.read_ionization_data(atomic.default_atom_h5_path)
-    hi_ionization = data['ionization_energy'][0]
-    testing.assert_almost_equal(hi_ionization, 13.59844, decimal=4)
+    assert data['atomic_number'][0] == 1
+    assert data['ion_number'][0] == 1
+    testing.assert_almost_equal(data['ionization_energy'][0], 13.59844, decimal=4)
 
-def test_levels_h5_readin():
+
+def test_read_levels_data():
     data = atomic.read_levels_data(atomic.default_atom_h5_path)
     assert data['atomic_number'][4] == 14
     assert data['ion_number'][4] == 0
     assert data['level_number'][4] == 4
-    si_energy = data['energy'][4]
-    testing.assert_almost_equal(si_energy, 1.90865, decimal=4)
+    testing.assert_almost_equal(data['energy'][4], 1.90865, decimal=4)
     assert data['g'][4] == 1
     assert data['metastable'][4] == False
+
+
+def test_read_lines_data():
+    data = atomic.read_lines_data(atomic.default_atom_h5_path)
+    assert data['line_id'][0] == 8
+    assert data['atomic_numer'][0] == 14
+    assert data['ion_number'][0] == 5
+    testing.assert_almost_equal(data['wavelength'][0], 66.772, decimal=4)
+    testing.assert_almost_equal(data['f_ul'][0], 0.02703, decimal=4)
+    testing.assert_almost_equal(data['f_lu'][0], 0.04054, decimal=4)
+    assert data['level_number_lower'] == 0.0
+    assert data['level_number_upper'] == 36.0
 
 
 def test_atom_levels():

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -1,7 +1,13 @@
-from tardis import atomic
-from numpy import testing
-import pytest
 import os
+import pytest
+from numpy import testing
+from tardis import atomic
+
+
+def test_data_path():
+    data_path = atomic.data_path('test')
+    assert data_path.split('/')[-3:] == ['tardis', 'data', 'test']
+
 
 def test_atomic_h5_readin():
     data = atomic.read_basic_atom_data(atomic.default_atom_h5_path)

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -4,8 +4,15 @@ from numpy import testing
 from tardis import atomic
 
 
-chianti_he_db_h5_path = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), 'data', 'chianti_he_db.h5')
+@pytest.fixture(scope="module")
+def default_atom_h5_path():
+    return atomic.default_atom_h5_path
+
+
+@pytest.fixture(scope="module")
+def chianti_he_db_h5_path():
+    return os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 'data', 'chianti_he_db.h5')
 
 
 def test_data_path():
@@ -13,22 +20,22 @@ def test_data_path():
     assert data_path.split('/')[-3:] == ['tardis', 'data', 'test']
 
 
-def test_read_basic_atom_data():
-    data = atomic.read_basic_atom_data(atomic.default_atom_h5_path)
+def test_read_basic_atom_data(default_atom_h5_path):
+    data = atomic.read_basic_atom_data(default_atom_h5_path)
     assert data['atomic_number'][13] == 14
     assert data['symbol'][13] == "Si"
     testing.assert_almost_equal(data['mass'][13], 28.085, decimal=4)
 
 
-def test_read_ionization_data():
-    data = atomic.read_ionization_data(atomic.default_atom_h5_path)
+def test_read_ionization_data(default_atom_h5_path):
+    data = atomic.read_ionization_data(default_atom_h5_path)
     assert data['atomic_number'][0] == 1
     assert data['ion_number'][0] == 1
     testing.assert_almost_equal(data['ionization_energy'][0], 13.59844, decimal=4)
 
 
-def test_read_levels_data():
-    data = atomic.read_levels_data(atomic.default_atom_h5_path)
+def test_read_levels_data(default_atom_h5_path):
+    data = atomic.read_levels_data(default_atom_h5_path)
     assert data['atomic_number'][4] == 14
     assert data['ion_number'][4] == 0
     assert data['level_number'][4] == 4
@@ -37,8 +44,8 @@ def test_read_levels_data():
     assert data['metastable'][4] == False
 
 
-def test_read_lines_data():
-    data = atomic.read_lines_data(atomic.default_atom_h5_path)
+def test_read_lines_data(default_atom_h5_path):
+    data = atomic.read_lines_data(default_atom_h5_path)
     assert data['line_id'][0] == 8
     assert data['atomic_number'][0] == 14
     assert data['ion_number'][0] == 5
@@ -49,7 +56,7 @@ def test_read_lines_data():
     assert data['level_number_upper'][0] == 36.0
 
 
-def test_read_synpp_refs():
+def test_read_synpp_refs(chianti_he_db_h5_path):
     data = atomic.read_synpp_refs(chianti_he_db_h5_path)
     assert data['atomic_number'][0] == 1
     assert data['ion_number'][0] == 0
@@ -57,7 +64,7 @@ def test_read_synpp_refs():
     assert data['line_id'][0] == 564995
 
 
-def test_read_zeta_data():
+def test_read_zeta_data(default_atom_h5_path, chianti_he_db_h5_path):
     data = atomic.read_zeta_data(chianti_he_db_h5_path)
     testing.assert_almost_equal(data[2000][1][1], 0.339, decimal=4)
     testing.assert_almost_equal(data[2000][1][2], 0.000, decimal=4)
@@ -69,10 +76,10 @@ def test_read_zeta_data():
         atomic.read_zeta_data('fakepath')
 
     with pytest.raises(ValueError):
-        atomic.read_zeta_data(atomic.default_atom_h5_path)
+        atomic.read_zeta_data(default_atom_h5_path)
 
 
-def test_read_collision_data():
+def test_read_collision_data(default_atom_h5_path, chianti_he_db_h5_path):
     data = atomic.read_collision_data(chianti_he_db_h5_path)
     assert data[0]['atomic_number'][0] == 2
     assert data[0]['ion_number'][0] == 0
@@ -90,10 +97,10 @@ def test_read_collision_data():
         atomic.read_zeta_data('fakepath')
 
     with pytest.raises(ValueError):
-        atomic.read_zeta_data(atomic.default_atom_h5_path)
+        atomic.read_zeta_data(default_atom_h5_path)
 
 
-def test_read_macro_atom_data():
+def test_read_macro_atom_data(default_atom_h5_path, chianti_he_db_h5_path):
     data = atomic.read_macro_atom_data(chianti_he_db_h5_path)
     assert data[0]['atomic_number'][0] == 2
     assert data[0]['ion_number'][0] == 0
@@ -114,7 +121,7 @@ def test_read_macro_atom_data():
         atomic.read_macro_atom_data('fakepath')
 
     with pytest.raises(ValueError):
-        atomic.read_macro_atom_data(atomic.default_atom_h5_path)
+        atomic.read_macro_atom_data(default_atom_h5_path)
 
 
 def test_atom_levels():


### PR DESCRIPTION
This PR will be consisting a series of commits targetting to improve code coverage of [**tardis/atomic.py**](https://github.com/tardis-sn/tardis/blob/master/tardis/atomic.py).

This checklist maintains the methods imporved in **tardis/atomic.py**. The commits enclosed in brackets show where these tests were modified/ added.

**Methods:**
- [x] data_path (0645546)
- [x] read_basic_atom_data (6da1b9d)
- [x] read_ionization_data (6da1b9d)
- [x] read_levels_data (6da1b9d)
- [x] read_synpp_refs (24c3796)
- [x] read_lines_data (6da1b9d)
- [x] read_zeta_data (24c3796)
- [x] read_collision_data (fa7d778)
- [ ] read_ion_cx_data
- [x] read_macro_atom_data (013a625)