### PR TITLE
Fix comparison in AtomData.from_hdf5() of atomic.py

### DIFF
--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -332,7 +332,7 @@ class AtomData(object):
         else:
             synpp_refs = None
 
-        if 'ion_cx_data' in h5_datasets and 'ion_cx_data' in h5_datasets:
+        if 'ionization_cx_threshold' in h5_datasets and 'ionization_cx_support' in h5_datasets:
             ion_cx_data = read_ion_cx_data(fname)
         else:
             ion_cx_data = None


### PR DESCRIPTION
In **tardis/atomic.py**:

In `AtomData.from_hdf5` method, there's this block:
```python
if 'ion_cx_data' in h5_datasets and 'ion_cx_data' in h5_datasets:
    ion_cx_data = read_ion_cx_data(fname)
else:
    ion_cx_data = None
```

Whereas in `read_ion_cx_data` method, there's something else:
```python
ion_cx_th_data = h5_file['ionization_cx_threshold']
ion_cx_sp_data = h5_file['ionization_cx_support']
```

It should be:
```python
if 'ionization_cx_threshold' in h5_datasets and 'ionization_cx_support' in h5_datasets:
    ion_cx_data = read_ion_cx_data(fname)
else:
    ion_cx_data = None
```
Then it would denote that call the method **only if both columns exist** in dataset.

I discovered that this part of code was contributed last by @mklauser . Please review it and confirm whether I have fixed it correctly.