### PR TITLE
Remove rpacket.recently_crossed_boundary flag

### DIFF
--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -145,12 +145,7 @@ compute_distance2boundary (rpacket_t * packet, const storage_model_t * storage)
   double r_outer = storage->r_outer[rpacket_get_current_shell_id (packet)];
   double r_inner = storage->r_inner[rpacket_get_current_shell_id (packet)];
   double check, distance;
-  if (rpacket_get_recently_crossed_boundary (packet) == 1)
-    {
-      rpacket_set_next_shell_id (packet, 1);
-      distance = sqrt (r_outer * r_outer + ((mu * mu - 1.0) * r * r)) - (r * mu);
-    }
-  else if (mu > 0.0)
+  if (mu > 0.0)
     { // direction outward
       rpacket_set_next_shell_id (packet, 1);
       distance = sqrt (r_outer * r_outer + ((mu * mu - 1.0) * r * r)) - (r * mu);
@@ -502,9 +497,6 @@ move_packet_across_shell_boundary (rpacket_t * packet,
       rpacket_set_current_shell_id (packet,
                                     rpacket_get_current_shell_id (packet) +
                                     rpacket_get_next_shell_id (packet));
-      rpacket_set_recently_crossed_boundary (packet,
-                                             rpacket_get_next_shell_id
-                                             (packet));
     }
   else if (rpacket_get_next_shell_id (packet) == 1)
     {
@@ -524,7 +516,6 @@ move_packet_across_shell_boundary (rpacket_t * packet,
       double inverse_doppler_factor = 1.0 / rpacket_doppler_factor (packet, storage);
       rpacket_set_nu (packet, comov_nu * inverse_doppler_factor);
       rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
-      rpacket_set_recently_crossed_boundary (packet, 1);
       if (rpacket_get_virtual_packet_flag (packet) > 0)
         {
           montecarlo_one_packet (storage, packet, -2, mt_state);
@@ -545,7 +536,6 @@ montecarlo_thomson_scatter (rpacket_t * packet, storage_model_t * storage,
   rpacket_set_nu (packet, comov_nu * inverse_doppler_factor);
   rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
   rpacket_reset_tau_event (packet, mt_state);
-  rpacket_set_recently_crossed_boundary (packet, 0);
   storage->last_interaction_type[rpacket_get_id (packet)] = 1;
   if (rpacket_get_virtual_packet_flag (packet) > 0)
     {
@@ -660,7 +650,6 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
       rpacket_set_nu_line (packet, storage->line_list_nu[emission_line_id]);
       rpacket_set_next_line_id (packet, emission_line_id + 1);
       rpacket_reset_tau_event (packet, mt_state);
-      rpacket_set_recently_crossed_boundary (packet, 0);
       if (rpacket_get_virtual_packet_flag (packet) > 0)
         {
           bool virtual_close_line = false;

--- a/tardis/montecarlo/src/rpacket.c
+++ b/tardis/montecarlo/src/rpacket.c
@@ -37,7 +37,6 @@ rpacket_init (rpacket_t * packet, storage_model_t * storage, int packet_index,
   rpacket_set_next_line_id (packet, current_line_id);
   rpacket_set_last_line (packet, last_line);
   rpacket_set_close_line (packet, false);
-  rpacket_set_recently_crossed_boundary (packet, true);
   rpacket_set_virtual_packet_flag (packet, virtual_packet_flag);
   return ret_val;
 }

--- a/tardis/montecarlo/src/rpacket.h
+++ b/tardis/montecarlo/src/rpacket.h
@@ -43,12 +43,6 @@ typedef struct RPacket
    */
   int64_t close_line;
   /**
-   * @brief The packet has recently crossed the boundary and is now sitting on the boundary.
-   * To avoid numerical errors, make sure that d_inner is not calculated. The value is -1
-   * if the packed moved inwards, 1 if the packet moved outwards and 0 otherwise.
-   */
-  int64_t recently_crossed_boundary;
-  /**
    * @brief packet is a virtual packet and will ignore any d_line or d_electron checks.
    * It now whenever a d_line is calculated only adds the tau_line to an
    * internal float.
@@ -169,17 +163,6 @@ static inline bool rpacket_get_close_line (const rpacket_t * packet)
 static inline void rpacket_set_close_line (rpacket_t * packet, bool close_line)
 {
   packet->close_line = close_line;
-}
-
-static inline int rpacket_get_recently_crossed_boundary (const rpacket_t * packet)
-{
-  return packet->recently_crossed_boundary;
-}
-
-static inline void rpacket_set_recently_crossed_boundary (rpacket_t * packet,
-                                                          int recently_crossed_boundary)
-{
-  packet->recently_crossed_boundary = recently_crossed_boundary;
 }
 
 static inline int rpacket_get_virtual_packet_flag (const rpacket_t * packet)

--- a/tardis/montecarlo/src/test_cmontecarlo.c
+++ b/tardis/montecarlo/src/test_cmontecarlo.c
@@ -50,8 +50,6 @@ static void init_rpacket(rpacket_t *rp){
 	rpacket_set_nu(rp, NU);
 	rpacket_set_r(rp, R);
 	rpacket_set_last_line(rp, false);
-	rpacket_set_recently_crossed_boundary(rp, 1);
-
 	rpacket_set_close_line(rp, false);
 	rpacket_set_nu_line(rp, NU_LINE);
 

--- a/tardis/montecarlo/src/test_rpacket.c
+++ b/tardis/montecarlo/src/test_rpacket.c
@@ -21,7 +21,6 @@ bool test_rpacket_get_d_line(double);
 bool test_rpacket_get_current_shell_id(unsigned int);
 bool test_rpacket_get_next_line_id(unsigned int);
 
-bool test_rpacket_get_recently_crossed_boundary(int);
 bool test_rpacket_get_virtual_packet_flag(int);
 bool test_rpacket_get_virtual_packet(int);
 bool test_rpacket_get_next_shell_id(int);
@@ -99,13 +98,6 @@ test_rpacket_get_close_line(void){
 	rpacket_t rp;
 	rpacket_set_last_line(&rp, true);
 	return rpacket_get_last_line(&rp);
-}
-
-bool
-test_rpacket_get_recently_crossed_boundary(int value){
-	rpacket_t rp;
-	rpacket_set_recently_crossed_boundary(&rp, value);
-	return value==rpacket_get_recently_crossed_boundary(&rp);
 }
 
 bool

--- a/tardis/montecarlo/tests/test_rpacket.py
+++ b/tardis/montecarlo/tests/test_rpacket.py
@@ -97,10 +97,6 @@ def test_rpacket_get_next_line_id(unsigned_int_value):
 
 # Testing functions with Integer valued parameters
 
-def test_rpacket_get_recently_crossed_boundary(int_value):
-    assert tests.test_rpacket_get_recently_crossed_boundary(int_value)
-
-
 def test_rpacket_get_virtual_packet_flag(int_value):
     assert tests.test_rpacket_get_virtual_packet_flag(int_value)
 
@@ -117,8 +113,10 @@ def test_rpacket_get_next_shell_id(int_value):
 def test_rpacket_get_last_line():
     assert tests.test_rpacket_get_last_line()
 
+
 def test_rpacket_get_close_line():
     assert tests.test_rpacket_get_close_line()
+
 
 def test_rpacket_get_status():
     assert tests.test_rpacket_get_status()


### PR DESCRIPTION
Using the new distance2boundary calculation, we don't need recently_crossed_boundary flag, so it is
removed from all occurences.
This flag covered only outward propagating packets which have mu>0
anyway and result in the same calculation. This commit removes that
overhead and improves readability of the code.

This is in line with the discussion in Issue #517 .
If we are not 100% sure that there is no negative side effect, I'd suggest waiting for the improved C tests. Adding simple counters showed that `recently_crossed_boundary == 1` implies `mu > 0` for all testes setups (w7, abn_tom, example).