### PR TITLE
Fix Issue 534

### DIFF
--- a/tardis/model.py
+++ b/tardis/model.py
@@ -372,7 +372,7 @@ class TARDISSpectrum(object):
 
     @property
     def frequency(self):
-        return self._frequency[:-1]
+        return (self._frequency[1:] + self._frequency[:-1]) / 2
 
 
     @property


### PR DESCRIPTION
This is a quickfix approximating each bin bin the bin_center instead of
one bin edge.

The tests comparing the spectrum are currently failing. I'm thinking about doing a proper fix later.

This would include logic to use the packet_nu and packet_energy if available to create `luminosity_density_lambda` and, if that's not available, transfrom `luminosity_density_nu` into `luminosity_density_lambda`.