### PR TITLE
Ignore invalid OpenMP nthreads values

### DIFF
--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -833,7 +833,10 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
 #endif // WITH_VPACKET_LOGGING
 #ifdef WITHOPENMP
   omp_set_dynamic(0);
-  omp_set_num_threads(nthreads);
+  if (nthreads > 0)
+    {
+      omp_set_num_threads(nthreads);
+    }
 
 #pragma omp parallel firstprivate(finished_packets)
     {


### PR DESCRIPTION
If nthreads is not a positive integer omp_set_num_threads won't be
called. The result is that the default number of threads, or if set
OMP_NUM_THREADS is used.
This enables setting nthreads=0 for example to control the number of
threads through the environment (useful for use on clusters).