### PR TITLE
Upgrading to the new Readthedocs infrastructure

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ TARDIS
 .. image:: https://zenodo.org/badge/5756/tardis-sn/tardis.svg   
   :target: http://dx.doi.org/10.5281/zenodo.17630
 
+.. image:: https://readthedocs.org/projects/tardis/badge/?version=latest
+  :target: http://tardis.readthedocs.org/en/latest/?badge=latest
+  :alt: Documentation Status
 
 TARDIS is a tool that creates synthetic observations (spectra) for exploding stars (supernovae).
 

--- a/conda-requirements
+++ b/conda-requirements
@@ -8,6 +8,5 @@ astropy==1.0.5
 PyYAML==3.11
 numexpr==2.4.4
 Cython==0.21
-jinja2
 networkx==1.10
 pytest==2.6.3

--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,4 +1,5 @@
 ### TARDIS requirements ###
+python==2
 numpy==1.9
 astropy>=1.0.4
 cython>=0.23

--- a/docs/rtd_conda_env.yml
+++ b/docs/rtd_conda_env.yml
@@ -1,0 +1,29 @@
+name: tardis-rtd
+dependencies:
+- python=2.7
+- numpy=1.10.0
+- scipy=0.17.0
+- pandas=0.16.2
+- pytables=3.2.2
+- h5py=2.5
+- matplotlib=1.4.3
+- astropy=1.0.5
+- PyYAML=3.11
+- numexpr=2.4.4
+- Cython=0.21
+- networkx=1.10
+- pytest=2.6.3
+# RTD requirements
+- sphinx=1.4.1
+- nbconvert=4.2.0
+- numpydoc=0.5
+- docutils
+
+- pip:
+  - nbsphinx==0.2.6
+  - sphinx_bootstrap_theme
+  - sphinxcontrib-bibtex
+  - sphinxcontrib-tikz
+
+
+

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,8 @@
+formats:
+  - none
+
+conda:
+  file: docs/rtd_conda_env.yml
+
+python:
+   version: 2


### PR DESCRIPTION
This PR adds the new `readthedocs.yml` in the root directory described here: http://read-the-docs.readthedocs.org/en/latest/yaml-config.html

This comes with a conda environment that is used to quickly create an environment.