### PR TITLE
Fix issue #535: Treat rel. paths inside config relative to the config file

### DIFF
--- a/tardis/base.py
+++ b/tardis/base.py
@@ -23,11 +23,14 @@ def run_tardis(config, atom_data=None):
 
     from tardis.io import config_reader
     from tardis import model, simulation, atomic
+    import os
 
     try:
         config_dict = yaml.load(open(config))
+        config_dirname = os.path.dirname(config)
     except TypeError:
         config_dict = config
+        config_dirname = ''
 
     if atom_data is not None:
         try:
@@ -36,7 +39,7 @@ def run_tardis(config, atom_data=None):
             atom_data = atom_data
 
     tardis_config = config_reader.Configuration.from_config_dict(
-        config_dict, atom_data=atom_data)
+        config_dict, atom_data=atom_data, config_dirname=config_dirname)
     radial1d_mdl = model.Radial1DModel(tardis_config)
 
     simulation.run_radial1d(radial1d_mdl)

--- a/tardis/io/tests/data/tardis_configv1_artis_density.yml
+++ b/tardis/io/tests/data/tardis_configv1_artis_density.yml
@@ -9,7 +9,7 @@ atom_data: kurucz_atom_pure_simple.h5
 model:
     structure:
         type: file
-        filename: tardis/io/tests/data/artis_model.dat
+        filename: artis_model.dat
         filetype: artis
 
     abundances:

--- a/tardis/io/tests/data/tardis_configv1_artis_density_v_slice.yml
+++ b/tardis/io/tests/data/tardis_configv1_artis_density_v_slice.yml
@@ -9,7 +9,7 @@ atom_data: kurucz_atom_pure_simple.h5
 model:
     structure:
         type: file
-        filename: tardis/io/tests/data/artis_model.dat
+        filename: artis_model.dat
         filetype: artis
         v_inner_boundary: 9000 km/s
         v_outer_boundary: 20000 km/s

--- a/tardis/io/tests/data/tardis_configv1_ascii_density.yml
+++ b/tardis/io/tests/data/tardis_configv1_ascii_density.yml
@@ -9,7 +9,7 @@ atom_data: kurucz_atom_pure_simple.h5
 model:
     structure:
         type: file
-        filename: tardis/io/tests/data/tardis_simple_ascii_density_test.dat
+        filename: tardis_simple_ascii_density_test.dat
         filetype: simple_ascii
 
     abundances:

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -134,7 +134,8 @@ def test_last_no_of_packets():
     yaml_data = yaml.load(open(data_path('paper1_tardis_configv1.yml')))
     del yaml_data['montecarlo']['last_no_of_packets']
     config = config_reader.Configuration.from_config_dict(yaml_data,
-                                                          test_parser=True)
+                                                          test_parser=True,
+                                                          config_dirname=data_path(''))
     assert (config.montecarlo.last_no_of_packets ==
             config.montecarlo.no_of_packets)
 
@@ -144,7 +145,7 @@ class TestParseConfigV1ASCIIDensity:
         #general parsing of the paper config
         filename = 'tardis_configv1_ascii_density.yml'
         self.config = config_reader.Configuration.from_yaml(data_path(filename),
-                                                                  test_parser=True)
+                                                            test_parser=True)
         self.yaml_data = yaml.load(open(data_path(filename)))
 
 
@@ -163,7 +164,7 @@ class TestParseConfigV1ArtisDensity:
         #general parsing of the paper config
         filename = 'tardis_configv1_artis_density.yml'
         self.config = config_reader.Configuration.from_yaml(data_path(filename),
-                                                                  test_parser=True)
+                                                            test_parser=True)
         self.yaml_data = yaml.load(open(data_path(filename)))
 
 
@@ -186,11 +187,12 @@ class TestParseConfigV1ArtisDensityAbundances:
 
         self.yaml_data = yaml.load(open(data_path(filename)))
         self.yaml_data['model']['abundances'] = {'type': 'file',
-                                                 'filename': 'tardis/io/tests/data/artis_abundances.dat',
+                                                 'filename': 'artis_abundances.dat',
                                                  'filetype': 'artis'}
 
         self.config = config_reader.Configuration.from_config_dict(self.yaml_data,
-                                                                  test_parser=True)
+                                                                  test_parser=True,
+                                                                  config_dirname=data_path(''))
 
 
     def test_velocities(self):
@@ -209,11 +211,12 @@ class TestParseConfigV1ArtisDensityAbundancesVSlice:
 
         self.yaml_data = yaml.load(open(data_path(filename)))
         self.yaml_data['model']['abundances'] = {'type': 'file',
-                                                 'filename': 'tardis/io/tests/data/artis_abundances.dat',
+                                                 'filename': 'artis_abundances.dat',
                                                  'filetype': 'artis'}
 
         self.config = config_reader.Configuration.from_config_dict(self.yaml_data,
-                                                                  test_parser=True)
+                                                                  test_parser=True,
+                                                                  config_dirname=data_path(''))
 
 
     def test_velocities(self):
@@ -234,7 +237,8 @@ class TestParseConfigV1UniformDensity:
         self.yaml_data = yaml.load(open(data_path(filename)))
 
         self.config = config_reader.Configuration.from_config_dict(self.yaml_data,
-                                                                  test_parser=True)
+                                                                  test_parser=True,
+                                                                  config_dirname=data_path(''))
 
     def test_density(self):
         assert_array_almost_equal(self.config.structure.mean_densities.to(u.Unit('g / cm3')).value,
@@ -250,7 +254,8 @@ class TestParseConfigTinner:
         self.yaml_data['plasma']['initial_t_inner'] = "2508 K"
 
         self.config = config_reader.Configuration.from_config_dict(self.yaml_data,
-                                                                  test_parser=True)
+                                                                  test_parser=True,
+                                                                  config_dirname=data_path(''))
 
     def test_initial_temperature(self):
         assert_almost_equal(self.config.plasma.t_inner.value, 2508)
@@ -263,11 +268,12 @@ class TestParseConfigV1ArtisDensityAbundancesAllAscii:
         filename = 'tardis_configv1_ascii_density_abund.yml'
 
         self.yaml_data = yaml.load(open(data_path(filename)))
-        self.yaml_data['model']['structure']['filename'] = 'tardis/io/tests/data/density.dat'
-        self.yaml_data['model']['abundances']['filename'] = 'tardis/io/tests/data/abund.dat'
-    
+        self.yaml_data['model']['structure']['filename'] = 'density.dat'
+        self.yaml_data['model']['abundances']['filename'] = 'abund.dat'
+
         self.config = config_reader.Configuration.from_config_dict(self.yaml_data,
-                                                                  test_parser=True)
+                                                                  test_parser=True,
+                                                                  config_dirname=data_path(''))
 
 
     def test_velocities(self):
@@ -299,8 +305,8 @@ class TestParseConfigV1ArtisDensityAbundancesAllAscii:
         assert_almost_equal(self.config.structure.mean_densities[4].to(u.Unit('g/cm3')).value, 8.5733893e-11/ 13.0**3 )
         assert_almost_equal(self.config.structure.mean_densities[5].to(u.Unit('g/cm3')).value, 5.3037103e-11/ 13.0**3 )
         assert_almost_equal(self.config.structure.mean_densities[6].to(u.Unit('g/cm3')).value, 3.3999447e-11/ 13.0**3 )
-        
-        
+
+
 def test_ascii_reader_power_law():
     with open(data_path('tardis_configv1_density_power_law_test.yml')) as f:
         yaml_data = yaml.load(f)
@@ -309,25 +315,26 @@ def test_ascii_reader_power_law():
     t_explosion = density_data['time_0']
     rho_0 = density_data['rho_0']
     exponent = density_data['exponent']
-    
+
     v_inner =  yaml_data['model']['structure']['velocity']['start']
     v_outer =  yaml_data['model']['structure']['velocity']['stop']
-    my_conf = config_reader.Configuration.from_yaml(data_path('tardis_configv1_density_power_law_test.yml'),test_parser=True)
+    my_conf = config_reader.Configuration.from_yaml(data_path('tardis_configv1_density_power_law_test.yml'),
+                                                    test_parser=True)
     structure = my_conf['structure']
-    
+
     expected_densites = [3.29072513e-14,  2.70357804e-14,  2.23776573e-14,
                          1.86501954e-14,  1.56435277e-14,  1.32001689e-14, 1.12007560e-14,
                          9.55397475e-15,  8.18935779e-15, 7.05208050e-15,  6.09916083e-15,
                          5.29665772e-15, 4.61758699e-15,  4.04035750e-15,  3.54758837e-15,
                          3.12520752e-15,  2.76175961e-15,  2.44787115e-15, 2.17583442e-15,
                          1.93928168e-15]
-    
+
     assert structure['no_of_shells'] == 20
     for i, mdens in enumerate(expected_densites):
         assert_almost_equal(structure['mean_densities'][i].to(
             u.Unit('g / (cm3)')).value, mdens)
-       
-    
+
+
 def test_ascii_reader_exponential_law():
     with open(data_path('tardis_configv1_density_exponential_test.yml')) as f:
         yaml_data = yaml.load(f)
@@ -336,20 +343,21 @@ def test_ascii_reader_exponential_law():
     t_explosion = density_data['time_0']
     rho_0 = density_data['rho_0']
     v0 = density_data['v_0']
-    
+
     v_inner =  yaml_data['model']['structure']['velocity']['start']
     v_outer =  yaml_data['model']['structure']['velocity']['stop']
-    my_conf = config_reader.Configuration.from_yaml(data_path('tardis_configv1_density_exponential_test.yml'),test_parser=True)
+    my_conf = config_reader.Configuration.from_yaml(data_path('tardis_configv1_density_exponential_test.yml'),
+                                                    test_parser=True)
     structure = my_conf['structure']
-    
+
     expected_densites = [5.18114795e-14,  4.45945537e-14,  3.83828881e-14, 3.30364579e-14,  2.84347428e-14,  2.44740100e-14, 2.10649756e-14,  1.81307925e-14,  1.56053177e-14, 1.34316215e-14,  1.15607037e-14,  9.95038990e-15, 8.56437996e-15,  7.37143014e-15,  6.34464872e-15, 5.46088976e-15,  4.70023138e-15,  4.04552664e-15, 3.48201705e-15,  2.99699985e-15]
     expected_unit = 'g / (cm3)'
-    
+
     assert structure['no_of_shells'] == 20
     for i, mdens in enumerate(expected_densites):
         assert_almost_equal(structure['mean_densities'][i].value,mdens)
         assert structure['mean_densities'][i].unit ==  u.Unit(expected_unit)
-    
-    
-    
+
+
+
 #write tests for inner and outer boundary indices


### PR DESCRIPTION
This is a quickfix for issue #535. File paths in the config file are now treated as relative to the location of the config file.