### PR TITLE
Enable skipping slow tests.

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -32,6 +32,10 @@ def pytest_addoption(parser):
     parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
                      help="filename for atomic dataset")
 
+    parser.addoption("--with-slow", action="store_true",
+                     help="include running slow tests during run")
+
+
 def pytest_report_header(config):
 
     stdoutencoding = getattr(sys.stdout, 'encoding') or 'ascii'

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -32,7 +32,7 @@ def pytest_addoption(parser):
     parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
                      help="filename for atomic dataset")
 
-    parser.addoption("--with-slow", action="store_true",
+    parser.addoption("--slow", action="store_true",
                      help="include running slow tests during run")
 
 


### PR DESCRIPTION
Certain tests can be skipped in normal run of tests and would be executed only on the provision of `--run-slow` parameter. This means:
* `./setup.py test` will skip all slow marked tests inherently.
* `./setup.py test --slow` will include all the tests while running.