### PR TITLE
Fix Issue #534

### DIFF
--- a/tardis/model.py
+++ b/tardis/model.py
@@ -372,8 +372,7 @@ class TARDISSpectrum(object):
 
     @property
     def frequency(self):
-        return self._frequency[:-1]
-
+        return 0.5 * (self._frequency[1:] + self._frequency[:-1])
 
     @property
     def flux_nu(self):


### PR DESCRIPTION
This small PR addresses issue #534. TARDISSpectrum frequency now returns frequency bin midpoints instead of left edges.

Travis will fail, since the real spectrum is now slightly different (on the order of 1e-4 - 1e-2). We should wait until @karandesai-96's project has progressed to a point where the process of exchanging baseline data is facilitated.
