### PR TITLE
Initial laydown of comparison plots for TestW7.

### DIFF
--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pytest
 from astropy import units as u
+import tardis
 
 
 @pytest.fixture(scope="session")
@@ -16,6 +17,19 @@ def slow_tests_datadir():
 @pytest.fixture(scope="session")
 def data_path():
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "w7")
+
+
+@pytest.fixture(scope="session")
+def base_plot_dir():
+    githash_short = tardis.__githash__[0:7]
+    base_plot_dir = os.path.join("/tmp", "plots", githash_short)
+
+    # Remove plots generated from previous runs on same githash.
+    if os.path.exists(base_plot_dir):
+        os.rmdir(base_plot_dir)
+
+    os.makedirs(base_plot_dir)
+    return base_plot_dir
 
 
 @pytest.fixture(scope="session")

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -18,7 +18,8 @@ class TestW7(object):
 
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self, reference, data_path, atomic_data_fname):
+    def setup(self, request, reference, data_path, atomic_data_fname,
+              slow_tests_datadir, base_plot_dir):
         """
         This method does initial setup of creating configuration and performing
         a single run of integration test.
@@ -55,6 +56,12 @@ class TestW7(object):
 
         # Get the reference data through the fixture.
         self.reference = reference
+
+        # Form a base directory to save plots for `W7` setup.
+        # TODO: Rough prototyping, parametrize this as more setups are added.
+        self.name = "w7"
+        self.base_plot_dir = os.path.join(base_plot_dir, self.name)
+        os.makedirs(self.base_plot_dir)
 
     def test_j_estimators(self):
         assert_allclose(
@@ -152,7 +159,7 @@ class TestW7(object):
 
         # Figure is saved in `tmp` directory right now, till a suitable way of
         # saving them is decided.
-        plt.savefig(os.path.join(self.plot_savedir, "spectrum.png"))
+        plt.savefig(os.path.join(self.base_plot_dir, "spectrum.png"))
 
     def test_montecarlo_properties(self):
         assert_quantity_allclose(

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -49,9 +49,9 @@ class TestW7(object):
         tardis_config = Configuration.from_config_dict(config_yaml, self.atom_data)
 
         # We now do a run with prepared config and get radial1d model.
-        self.obtained_radial1d_model = Radial1DModel(tardis_config)
+        self.result = Radial1DModel(tardis_config)
         simulation = Simulation(tardis_config)
-        simulation.legacy_run_simulation(self.obtained_radial1d_model)
+        simulation.legacy_run_simulation(self.result)
 
         # Get the reference data through the fixture.
         self.reference = reference
@@ -59,73 +59,73 @@ class TestW7(object):
     def test_j_estimators(self):
         assert_allclose(
                 self.reference['j_estimators'],
-                self.obtained_radial1d_model.j_estimators)
+                self.result.j_estimators)
 
     def test_j_blue_estimators(self):
         assert_allclose(
                 self.reference['j_blue_estimators'],
-                self.obtained_radial1d_model.j_blue_estimators)
+                self.result.j_blue_estimators)
 
         assert_quantity_allclose(
                 self.reference['j_blues_norm_factor'],
-                self.obtained_radial1d_model.j_blues_norm_factor)
+                self.result.j_blues_norm_factor)
 
     def test_last_line_interactions(self):
         assert_allclose(
                 self.reference['last_line_interaction_in_id'],
-                self.obtained_radial1d_model.last_line_interaction_in_id)
+                self.result.last_line_interaction_in_id)
 
         assert_allclose(
                 self.reference['last_line_interaction_out_id'],
-                self.obtained_radial1d_model.last_line_interaction_out_id)
+                self.result.last_line_interaction_out_id)
 
         assert_allclose(
                 self.reference['last_line_interaction_shell_id'],
-                self.obtained_radial1d_model.last_line_interaction_shell_id)
+                self.result.last_line_interaction_shell_id)
 
         assert_quantity_allclose(
                 self.reference['last_line_interaction_angstrom'],
-                self.obtained_radial1d_model.last_line_interaction_angstrom)
+                self.result.last_line_interaction_angstrom)
 
     def test_nubar_estimators(self):
         assert_allclose(
                 self.reference['nubar_estimators'],
-                self.obtained_radial1d_model.nubar_estimators)
+                self.result.nubar_estimators)
 
     def test_ws(self):
         assert_allclose(
                 self.reference['ws'],
-                self.obtained_radial1d_model.ws)
+                self.result.ws)
 
     def test_luminosity_inner(self):
         assert_quantity_allclose(
                 self.reference['luminosity_inner'],
-                self.obtained_radial1d_model.luminosity_inner)
+                self.result.luminosity_inner)
 
     def test_spectrum(self):
         try:
             assert_quantity_allclose(
                 self.reference['luminosity_density_nu'],
-                self.obtained_radial1d_model.spectrum.luminosity_density_nu)
+                self.result.spectrum.luminosity_density_nu)
 
             assert_quantity_allclose(
                 self.reference['delta_frequency'],
-                self.obtained_radial1d_model.spectrum.delta_frequency)
+                self.result.spectrum.delta_frequency)
 
             assert_quantity_allclose(
                 self.reference['wavelength'],
-                self.obtained_radial1d_model.spectrum.wavelength)
+                self.result.spectrum.wavelength)
 
             assert_quantity_allclose(
                 self.reference['luminosity_density_lambda'],
-                self.obtained_radial1d_model.spectrum.luminosity_density_lambda)
+                self.result.spectrum.luminosity_density_lambda)
 
-            self.plot_spectrum(passed=True)
+            self.plot_spectrum(has_passed=True)
         except Exception as e:
-            self.plot_spectrum(passed=False)
+            self.plot_spectrum(has_passed=False)
             raise e
 
-    def plot_spectrum(self, passed):
+    def plot_spectrum(self, has_passed):
         plt.suptitle("Deviation in spectrum_quantities", fontweight="bold")
 
         # `ldl_` prefixed variables associated with `luminosity_density_lambda`.
@@ -133,40 +133,41 @@ class TestW7(object):
         # for different spectrum quantities all in one figure.
         ldl_ax = plt.subplot(111)
         ldl_ax.set_title("Deviation in luminosity_density_lambda")
-        ldl_ax.set_xlabel("N-th packet")
-        ldl_ax.set_ylabel("Relative error (1 - obtained / baseline)")
+        ldl_ax.set_xlabel("Wavelength")
+        ldl_ax.set_ylabel("Relative error (1 - result / reference)")
         deviation = 1 - (
-            self.obtained_radial1d_model.spectrum.luminosity_density_lambda.value /
+            self.result.spectrum.luminosity_density_lambda.value /
             self.reference['luminosity_density_lambda'].value)
 
-        if passed:
+        if has_passed:
             ldl_ax.text(0.8, 0.8, 'passed', transform=ldl_ax.transAxes,
-                          bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
-            ldl_ax.plot(deviation, "g+")
+                        bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
+            ldl_ax.plot(self.reference['wavelength'], deviation,
+                        color="green", marker=".")
         else:
-            ldl_ax.set_yscale("log")
             ldl_ax.text(0.8, 0.8, 'failed', transform=ldl_ax.transAxes,
-                          bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
-            ldl_ax.plot(deviation, "rx")
+                        bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
+            ldl_ax.plot(self.reference['wavelength'], deviation,
+                        color="red", marker=".")
 
         # Figure is saved in `tmp` directory right now, till a suitable way of
         # saving them is decided.
-        plt.savefig(os.path.join("/tmp", "spectrum_plot.png"))
+        plt.savefig(os.path.join(self.plot_savedir, "spectrum.png"))
 
     def test_montecarlo_properties(self):
         assert_quantity_allclose(
                 self.reference['montecarlo_luminosity'],
-                self.obtained_radial1d_model.montecarlo_luminosity)
+                self.result.montecarlo_luminosity)
 
         assert_quantity_allclose(
                 self.reference['montecarlo_virtual_luminosity'],
-                self.obtained_radial1d_model.montecarlo_virtual_luminosity)
+                self.result.montecarlo_virtual_luminosity)
 
         assert_quantity_allclose(
                 self.reference['montecarlo_nu'],
-                self.obtained_radial1d_model.montecarlo_nu)
+                self.result.montecarlo_nu)
 
     def test_shell_temperature(self):
         assert_quantity_allclose(
                 self.reference['t_rads'],
-                self.obtained_radial1d_model.t_rads)
+                self.result.t_rads)


### PR DESCRIPTION
This PR implements a new design pattern - having a `plot_foo` method in `TestW7` class, for each `test_foo` method. As a first prototype, `plot_spectrum` has been added.

-----
Checklist holds a track of work done so far and work _TODO_:
- [X] Method `plot_spectrum` to generate a plot for deviation in  `spectrum.luminosity_density_lambda` against `spectrum.wavelength` is added within.
- [X] Show whether that test passed or failed within the plot itself (a badge on top right of plot).
- [X] Enclose assertions in `try-except` and make suitable calls.
- [X] Form a directory structure for saving the plots.

#### Future enhancements
* Find a way to put in description about build status corresponding to the plots. (**[pytest-html](https://www.github.com/davehunt/pytest-html)**)
    * Commit hash of build.
    * Starting time, time taken.
    * Number of passes, failures, skips etc.