### PR TITLE
Enable generation of html report of integration tests, and upload to dokuwiki.

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import tardis
 from astropy.tests.pytest_plugins import *
 
@@ -47,8 +48,9 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    html_file = tempfile.NamedTemporaryFile(delete=False)
     # Html test report will be generated at this filepath by pytest-html plugin
-    config.option.htmlpath = "/tmp/{0}.html".format(tardis.__githash__)
+    config.option.htmlpath = html_file.name
 
 
 def pytest_unconfigure(config):
@@ -78,7 +80,7 @@ def pytest_unconfigure(config):
 
     # Remove the local report file. Keeping the report saved on local filesystem
     # is not desired, hence deleted.
-    os.remove(config.option.htmlpath)
+    os.unlink(config.option.htmlpath)
     print "Deleted html report previously existing at {0}".format(
         config.option.htmlpath
     )
@@ -224,7 +226,6 @@ def test_data_path():
 
 @pytest.fixture
 def included_he_atomic_data(test_data_path):
-    import os, tardis
     atomic_db_fname = os.path.join(test_data_path, 'chianti_he_db.h5')
     return AtomData.from_hdf5(atomic_db_fname)
 

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -77,10 +77,9 @@ def pytest_unconfigure(config):
 
         try:
             doku_conn = dokuwiki.DokuWiki(
-                url="http://opensupernova.org/~karandesai96/integration2",
-                user=config.getvalue("username"),
-                password=config.getvalue("password")
-            )
+                url=integration_tests_config["dokuwiki"]["url"],
+                user=integration_tests_config["dokuwiki"]["username"],
+                password=integration_tests_config["dokuwiki"]["password"])
         except gaierror, dokuwiki.DokuWikiError:
             print "Dokuwiki connection not established, report upload failed!"
         else:

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -1,5 +1,9 @@
+import tardis
 from astropy.tests.pytest_plugins import *
 
+# -------------------------------------------------------------------------
+# Initialization
+# -------------------------------------------------------------------------
 
 def pytest_addoption(parser):
     parser.addoption("--remote-data", action="store_true",
@@ -34,6 +38,11 @@ def pytest_addoption(parser):
 
     parser.addoption("--slow-test-data", dest="slow-test-data",
                      help="path to directory having baseline data for slow tests")
+
+
+def pytest_configure(config):
+    # Html test report will be generated at this filepath by pytest-html plugin
+    config.option.htmlpath = "/tmp/{0}.html".format(tardis.__githash__)
 
 
 def pytest_report_header(config):

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -51,12 +51,8 @@ def pytest_addoption(parser):
     parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
                      help="filename for atomic dataset")
 
-    parser.addoption("--slow-test-data", dest="slow-test-data",
-                     help="path to directory having baseline data for slow tests")
-
-    # Accept dokuwiki credentials through command line.
-    parser.addoption("--username", dest='username', help="Dokuwiki username")
-    parser.addoption("--password", dest='password',help="Dokuwiki password")
+    parser.addoption("--integration-tests", dest="integration-tests",
+                     help="path to configuration file for integration tests")
 
 
 def pytest_configure(config):
@@ -247,3 +243,15 @@ def included_he_atomic_data(test_data_path):
 def tardis_config_verysimple():
     return yaml.load(
         open('tardis/io/tests/data/tardis_configv1_verysimple.yml'))
+
+
+@pytest.fixture(scope="session")
+def integration_tests_config(request):
+    integration_tests_configpath = request.config.getvalue("integration-tests")
+    if integration_tests_configpath is None:
+        pytest.skip('--integration-tests was not specified')
+    else:
+        integration_tests_configpath = os.path.expandvars(
+            os.path.expanduser(integration_tests_configpath)
+        )
+        return yaml.load(open(integration_tests_configpath))

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -6,12 +6,10 @@ import tardis
 
 
 @pytest.fixture(scope="session")
-def slow_tests_datadir():
-    slow_tests_datadir = pytest.config.getvalue("slow-test-data")
-    if slow_tests_datadir is None:
-        pytest.skip('--slow-test-data was not specified')
-    else:
-        return os.path.expandvars(os.path.expanduser(slow_tests_datadir))
+def reference_datadir(integration_tests_config):
+    return os.path.expandvars(
+        os.path.expanduser(integration_tests_config["reference"])
+    )
 
 
 @pytest.fixture(scope="session")
@@ -33,7 +31,7 @@ def base_plot_dir():
 
 
 @pytest.fixture(scope="session")
-def reference(request, slow_tests_datadir):
+def reference(request, reference_datadir):
     """
     Fixture to ingest reference data for slow test from already available
     compressed binaries (.npz). All data is collected in one dict and
@@ -60,9 +58,9 @@ def reference(request, slow_tests_datadir):
     """
 
     # TODO: make this fixture ingest data from an HDF5 file.
-    ndarrays = dict(np.load(os.path.join(slow_tests_datadir, "ndarrays.npz")))
-    quantities = dict(np.load(os.path.join(slow_tests_datadir, "quantities.npz")))
-    spectrum = dict(np.load(os.path.join(slow_tests_datadir, "spectrum.npz")))
+    ndarrays = dict(np.load(os.path.join(reference_datadir, "ndarrays.npz")))
+    quantities = dict(np.load(os.path.join(reference_datadir, "quantities.npz")))
+    spectrum = dict(np.load(os.path.join(reference_datadir, "spectrum.npz")))
 
     # Associate CGS units to ndarrays of reference quantities.
     ndarrays.update(

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -19,7 +19,7 @@ class TestW7(object):
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, request, reference, data_path, atomic_data_fname,
-              slow_tests_datadir, base_plot_dir):
+              reference_datadir, base_plot_dir):
         """
         This method does initial setup of creating configuration and performing
         a single run of integration test.


### PR DESCRIPTION
This PR introduces a set of pytest functions which would be complaint with [pytest-html](https://www.github.com/davehunt/pytest-html). These fixtures introduce a layer of customization over default html report provided by plugin.

* As mentioned in README of **pytest-html**, to generate a report, an extra argument has to be included as:
```
--html=path/to/file.html
```

* This command line option no longer has to be specified, due to invocation of `pytest_configure` method, before test execution. It assigns a _tempfile_  path to `config.option.filepath` for writing html report.

* Another method `pytest_unconfigure`, serves as a global teardown. It uploads the test report to dokuwiki.

* The command line argument `--slow-tests-data` has been renamed to `--integration-tests` and it accepts a path to YAML configuration for running slow tests. All other related fixtures have been modified. For now the schema of configuration file is:
```yml
reference: "/absolute/path/to/reference/dir"

dokuwiki:
  username: "username"
  password: "password"
```

This configuration file is parsed as a dict in a fixture created in **conftest.py**.

The checklist here maintains the status of work on this PR:
- [x] Show commit hash of the build on which current test run is being executed.
- [x] Make pytest-html write the html report to a tempfile, and `--html` may no longer be required.
- [x] Upload report to dokuwiki and leave no trace of tempfiles in filesystem.
- [x] Accept configuration for integration test run as YAML instad of individual fixtures.
