### PR TITLE
[config] Set the exponent property as mandatory when density is exponential

### DIFF
--- a/tardis/data/tardis_config_definition.yml
+++ b/tardis/data/tardis_config_definition.yml
@@ -198,7 +198,7 @@ model:
                 _branch85_w7: []
                 +branch85_w7: ['w7_time_0', 'w7_rho_0', 'w7_v_0']
                 _power_law: ['time_0', 'rho_0', 'v_0', 'exponent']
-                _exponential: ['time_0', 'rho_0', 'v_0']
+                _exponential: ['time_0', 'rho_0', 'v_0', 'exponent']
 
             w7_time_0:
                 property_type: quantity


### PR DESCRIPTION
When `model.structure.density` is of type `exponential`, the `exponent` property was not specified in the config definition neither as required nor as optional, making the validator allowing the following as valid input (note that exponent is missing).

```yaml
density:
  type : exponential
  time_0: 2. day
  rho_0: 6.e-10 g/cm^3
  v_0: 3000.  km/s
```

With this PR I'm adding the `exponent` property as a mandatory one for the `exponential` density type. 

I mainly open a new PR for that because I want to avoid semantic differences between `tardis_config_definition.yml` and the new json schema at #549 