### PR TITLE
Change the way YAMLLoader resolves some properties

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import re
 import pprint
 
 from astropy import constants, units as u
@@ -14,6 +13,7 @@ import tardis
 from tardis.io.model_reader import (
     read_density_file, calculate_density_after_time, read_abundances_file)
 from tardis.io.config_validator import ConfigurationValidator
+from tardis.io.util import YAMLLoader
 from tardis import atomic
 from tardis.util import (species_string_to_tuple, parse_quantity,
                          element_symbol2atomic_number, quantity_linspace)
@@ -726,77 +726,6 @@ class ConfigurationNameSpace(dict):
 
     def deepcopy(self):
         return ConfigurationNameSpace(copy.deepcopy(dict(self)))
-
-
-class YAMLLoader(yaml.Loader):
-    """
-    A custom YAML loader containing all the constructors required
-    to properly parse the tardis configuration.
-    """
-    @classmethod
-    def add_implicit_resolver(cls, tag, regexp, first=None):
-        """
-        Parameters
-        ----------
-
-        tag:
-            The YAML tag to implicitly apply to any YAML scalar that matches `regexp`
-
-        regexp:
-            The regular expression to match YAML scalars against `tag`
-
-
-        Notes
-        -----
-
-        This classmethod is a monkey-patch for a copy() related bug
-        in the original class method which affects this yaml.Loader subclass.
-
-        This class method is to be removed when this bug gets fixed upstream.
-
-        https://bitbucket.org/xi/pyyaml/issues/57/add_implicit_resolver-on-a-subclass-may
-        """
-        if 'yaml_implicit_resolvers' not in cls.__dict__:
-            yaml_implicit_resolvers = {}
-            for k, v in cls.yaml_implicit_resolvers.items():
-                yaml_implicit_resolvers[k] = copy.copy(v)
-            cls.yaml_implicit_resolvers = yaml_implicit_resolvers
-        if first is None:
-            first = [None]
-        for ch in first:
-            cls.yaml_implicit_resolvers.setdefault(ch, []).append((tag, regexp))
-
-    def construct_quantity(self, node):
-        """
-        A constructor for converting quantity-like YAML strings to
-        `astropy.units.Quantity` objects.
-
-        Parameters
-        ----------
-
-        node:
-            The YAML node to be constructed
-
-        Returns
-        -------
-
-        `astropy.units.Quantity`
-
-        """
-        data = self.construct_scalar(node)
-        value_str, unit_str = data.split(None, 1)
-        value = float(value_str)
-        if unit_str.strip() == 'log_lsun':
-            value = 10 ** (value + np.log10(constants.L_sun.cgs.value))
-            unit_str = 'erg/s'
-        return value * u.Unit(unit_str)
-
-
-YAMLLoader.add_constructor('!quantity', YAMLLoader.construct_quantity)
-# This regex matches anything that is a number (scientific notation supported) followed by whitespace
-# and any other characters (which should be a unit).
-pattern = re.compile(r'^-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?\s+.+$')
-YAMLLoader.add_implicit_resolver('!quantity', pattern)
 
 
 class Configuration(ConfigurationNameSpace):

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from numpy.testing import assert_almost_equal, assert_array_almost_equal
 from tardis.util import parse_quantity
+from tardis.io.util import YAMLLoader
 
 def data_path(filename):
     data_dir = os.path.dirname(__file__)
@@ -372,7 +373,7 @@ def test_custom_yaml_loader():
     default_conf = config_reader.Configuration.from_yaml(data_path(filename), test_parser=True,
                                                          loader=yaml.Loader)
     custom_conf = config_reader.Configuration.from_yaml(data_path(filename), test_parser=True,
-                                                        loader=config_reader.YAMLLoader)
+                                                        loader=YAMLLoader)
     assert len(default_conf) == len(custom_conf)
     assert set(default_conf.keys()) == set(custom_conf.keys())
     assert util.check_equality(default_conf, custom_conf)

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -3,10 +3,85 @@
 import pandas as pd
 import numpy as np
 import collections
+import yaml
+import copy
+import re
+from astropy import constants, units as u
 from tardis.util import element_symbol2atomic_number
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+class YAMLLoader(yaml.Loader):
+    """
+    A custom YAML loader containing all the constructors required
+    to properly parse the tardis configuration.
+    """
+    @classmethod
+    def add_implicit_resolver(cls, tag, regexp, first=None):
+        """
+        Parameters
+        ----------
+
+        tag:
+            The YAML tag to implicitly apply to any YAML scalar that matches `regexp`
+
+        regexp:
+            The regular expression to match YAML scalars against `tag`
+
+
+        Notes
+        -----
+
+        This classmethod is a monkey-patch for a copy() related bug
+        in the original class method which affects this yaml.Loader subclass.
+
+        This class method is to be removed when this bug gets fixed upstream.
+
+        https://bitbucket.org/xi/pyyaml/issues/57/add_implicit_resolver-on-a-subclass-may
+        """
+        if 'yaml_implicit_resolvers' not in cls.__dict__:
+            yaml_implicit_resolvers = {}
+            for k, v in cls.yaml_implicit_resolvers.items():
+                yaml_implicit_resolvers[k] = copy.copy(v)
+            cls.yaml_implicit_resolvers = yaml_implicit_resolvers
+        if first is None:
+            first = [None]
+        for ch in first:
+            cls.yaml_implicit_resolvers.setdefault(ch, []).append((tag, regexp))
+
+    def construct_quantity(self, node):
+        """
+        A constructor for converting quantity-like YAML strings to
+        `astropy.units.Quantity` objects.
+
+        Parameters
+        ----------
+
+        node:
+            The YAML node to be constructed
+
+        Returns
+        -------
+
+        `astropy.units.Quantity`
+
+        """
+        data = self.construct_scalar(node)
+        value_str, unit_str = data.split(None, 1)
+        value = float(value_str)
+        if unit_str.strip() == 'log_lsun':
+            value = 10 ** (value + np.log10(constants.L_sun.cgs.value))
+            unit_str = 'erg/s'
+        return value * u.Unit(unit_str)
+
+
+YAMLLoader.add_constructor('!quantity', YAMLLoader.construct_quantity)
+# This regex matches anything that is a number (scientific notation supported) followed by whitespace
+# and any other characters (which should be a unit).
+pattern = re.compile(r'^-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?\s+.+$')
+YAMLLoader.add_implicit_resolver('!quantity', pattern)
 
 
 def parse_abundance_dict_to_dataframe(abundance_dict):

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -120,6 +120,8 @@ class YAMLLoader(yaml.Loader):
 YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)
 YAMLLoader.add_implicit_resolver(u'!quantity',
                                  MockRegexPattern(quantity_from_str))
+YAMLLoader.add_implicit_resolver(u'tag:yaml.org,2002:float',
+                                 MockRegexPattern(float))
 
 
 def parse_abundance_dict_to_dataframe(abundance_dict):

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -5,12 +5,58 @@ import numpy as np
 import collections
 import yaml
 import copy
-import re
 from astropy import constants, units as u
 from tardis.util import element_symbol2atomic_number
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+def quantity_from_str(text):
+    """
+    Convert a string to `astropy.units.Quantity`
+    Parameters
+    ----------
+    text:
+        The string to convert to `astropy.units.Quantity`
+    Returns
+    -------
+    `astropy.units.Quantity`
+    """
+    value_str, unit = text.split(None, 1)
+    value = float(value_str)
+    if unit.strip() == 'log_lsun':
+        value = 10 ** (value + np.log10(constants.L_sun.cgs.value))
+        unit = 'erg/s'
+    return u.Quantity(value, unit)
+
+
+class MockRegexPattern(object):
+    """
+    A mock class to be used in place of a compiled regular expression
+    when a type check is needed instead of a regex match.
+
+    Note: This is usually a lot slower than regex matching.
+    """
+    def __init__(self, target_type):
+        self.type = target_type
+
+    def match(self, text):
+        """
+
+        Parameters
+        ----------
+        text:
+            A string to be passed to `target_type` for conversion.
+        Returns
+        -------
+        `True` if `text` can be converted to `target_type`.
+        """
+        try:
+            self.type(text)
+        except ValueError:
+            return False
+        return True
 
 
 class YAMLLoader(yaml.Loader):
@@ -53,7 +99,7 @@ class YAMLLoader(yaml.Loader):
 
     def construct_quantity(self, node):
         """
-        A constructor for converting quantity-like YAML strings to
+        A constructor for converting quantity-like YAML nodes to
         `astropy.units.Quantity` objects.
 
         Parameters
@@ -69,19 +115,11 @@ class YAMLLoader(yaml.Loader):
 
         """
         data = self.construct_scalar(node)
-        value_str, unit_str = data.split(None, 1)
-        value = float(value_str)
-        if unit_str.strip() == 'log_lsun':
-            value = 10 ** (value + np.log10(constants.L_sun.cgs.value))
-            unit_str = 'erg/s'
-        return value * u.Unit(unit_str)
+        return quantity_from_str(data)
 
-
-YAMLLoader.add_constructor('!quantity', YAMLLoader.construct_quantity)
-# This regex matches anything that is a number (scientific notation supported) followed by whitespace
-# and any other characters (which should be a unit).
-pattern = re.compile(r'^-?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?\s+.+$')
-YAMLLoader.add_implicit_resolver('!quantity', pattern)
+YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)
+YAMLLoader.add_implicit_resolver(u'!quantity',
+                                 MockRegexPattern(quantity_from_str))
 
 
 def parse_abundance_dict_to_dataframe(abundance_dict):


### PR DESCRIPTION
When specifying an implicit resolver for a YAML property, a regular expression to match this property type is required. That's what I did in #515 for parsing quantities as objects.

The problem with this is that we need a fairly complex regular expression to match all cases, and in my regex I had indeed missed one: infinity valued quantities weren't parsed as quantities. Also, quantity units weren't checked if they were valid, since this would lead to a huge regex (for all units), and reinventing the wheel.

In a discussion with @wkerzendorf we both agreed that just correcting the regex to recognize infinity as a valid quantity value might not completely solve the issue, since it is possible that my regex can still miss something.

So, I implemented his proposal which was a minimal mock class for re patterns which instead of checking if a string could be quantity based on a regular expression it would actually try to convert it to a Quantity.

It needs to be mentioned that this is quite hackish, and while it is much more reliable in telling if a string can be a quantity, it is also 2-3 times slower than regex matching.