### PR TITLE
Shift slow test related pytest hooks in lower level conftest.py

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -4,12 +4,9 @@
 
 from astropy.tests.pytest_plugins import *
 from astropy.tests.pytest_plugins import (
-        pytest_addoption as _pytest_add_option,
-        pytest_configure as _pytest_configure,
-        pytest_unconfigure as _pytest_unconfigure
-        )
+        pytest_addoption as _pytest_add_option
+    )
 
-import yaml
 import tardis
 import pytest
 from tardis.atomic import AtomData

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -5,6 +5,7 @@ import yaml
 import numpy as np
 import pytest
 from astropy import units as u
+from astropy.tests.helper import remote_data
 import tardis
 
 # For specifying error while exception handling
@@ -28,6 +29,7 @@ def pytest_configure(config):
     config.option.htmlpath = html_file.name
 
 
+@remote_data
 def pytest_unconfigure(config):
     # Html report created by pytest-html plugin is read here, uploaded to
     # dokuwiki and finally deleted.

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -39,34 +39,36 @@ def pytest_configure(config):
 
 @remote_data
 def pytest_unconfigure(config):
-    # Html report created by pytest-html plugin is read here, uploaded to
-    # dokuwiki and finally deleted.
-    if dokuwiki_available:
-        githash = tardis.__githash__
-        report_content = open(config.option.htmlpath, 'rb').read()
-        report_content = report_content.replace("<!DOCTYPE html>", "")
+    integration_tests_configpath = config.getvalue("integration-tests")
+    if integration_tests_configpath is not None:
+        # Html report created by pytest-html plugin is read here, uploaded to
+        # dokuwiki and finally deleted.
+        if dokuwiki_available:
+            githash = tardis.__githash__
+            report_content = open(config.option.htmlpath, 'rb').read()
+            report_content = report_content.replace("<!DOCTYPE html>", "")
 
-        report_content = (
-            "Test executed on commit "
-            "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{0}]]\n\n"
-            "{1}".format(githash, report_content)
-        )
+            report_content = (
+                "Test executed on commit "
+                "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{0}]]\n\n"
+                "{1}".format(githash, report_content)
+            )
 
-        # These steps are already performed by `integration_tests_config` but
-        # all the fixtures are teared down and no longer usable, when this
-        # method is being called by pytest, hence they are called as functions.
-        integration_tests_config = config.option.integration_tests_config
-        try:
-            doku_conn = dokuwiki.DokuWiki(
-                url=integration_tests_config["dokuwiki"]["url"],
-                user=integration_tests_config["dokuwiki"]["username"],
-                password=integration_tests_config["dokuwiki"]["password"])
-        except gaierror, dokuwiki.DokuWikiError:
-            print "Dokuwiki connection not established, report upload failed!"
-        else:
-            # Upload report on dokuwiki. Temporary link due to prototyping purposes.
-            doku_conn.pages.set("reports:{0}".format(githash[:7]), report_content)
-            print "Uploaded report on Dokuwiki."
+            # These steps are already performed by `integration_tests_config` but
+            # all the fixtures are teared down and no longer usable, when this
+            # method is being called by pytest, hence they are called as functions.
+            integration_tests_config = config.option.integration_tests_config
+            try:
+                doku_conn = dokuwiki.DokuWiki(
+                    url=integration_tests_config["dokuwiki"]["url"],
+                    user=integration_tests_config["dokuwiki"]["username"],
+                    password=integration_tests_config["dokuwiki"]["password"])
+            except gaierror, dokuwiki.DokuWikiError:
+                print "Dokuwiki connection not established, report upload failed!"
+            else:
+                # Upload report on dokuwiki. Temporary link due to prototyping purposes.
+                doku_conn.pages.set("reports:{0}".format(githash[:7]), report_content)
+                print "Uploaded report on Dokuwiki."
 
     # Remove the local report file. Keeping the report saved on local filesystem
     # is not desired, hence deleted.

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import yaml
 import numpy as np
@@ -18,6 +19,10 @@ else:
 
 
 def pytest_configure(config):
+    # A common tempdir for storing plots / PDFs and other slow test related data
+    # generated during execution.
+    tempdir_session = tempfile.mkdtemp()
+    config.option.tempdir = tempdir_session
     html_file = tempfile.NamedTemporaryFile(delete=False)
     # Html test report will be generated at this filepath by pytest-html plugin
     config.option.htmlpath = html_file.name
@@ -58,6 +63,8 @@ def pytest_unconfigure(config):
     # is not desired, hence deleted.
     os.unlink(config.option.htmlpath)
     print "Deleted temporary file containing html report."
+    # Remove tempdir by recursive deletion
+    shutil.rmtree(config.option.tempdir)
 
 
 @pytest.fixture(scope="session")
@@ -82,19 +89,6 @@ def reference_datadir(integration_tests_config):
 @pytest.fixture(scope="session")
 def data_path():
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "w7")
-
-
-@pytest.fixture(scope="session")
-def base_plot_dir():
-    githash_short = tardis.__githash__[0:7]
-    base_plot_dir = os.path.join("/tmp", "plots", githash_short)
-
-    # Remove plots generated from previous runs on same githash.
-    if os.path.exists(base_plot_dir):
-        os.rmdir(base_plot_dir)
-
-    os.makedirs(base_plot_dir)
-    return base_plot_dir
 
 
 @pytest.fixture(scope="session")

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -1,8 +1,75 @@
 import os
+import tempfile
+import yaml
 import numpy as np
 import pytest
 from astropy import units as u
 import tardis
+
+# For specifying error while exception handling
+from socket import gaierror
+
+try:
+    import dokuwiki
+except ImportError:
+    dokuwiki_available = False
+else:
+    dokuwiki_available = True
+
+
+def pytest_configure(config):
+    html_file = tempfile.NamedTemporaryFile(delete=False)
+    # Html test report will be generated at this filepath by pytest-html plugin
+    config.option.htmlpath = html_file.name
+
+
+def pytest_unconfigure(config):
+    # Html report created by pytest-html plugin is read here, uploaded to
+    # dokuwiki and finally deleted.
+    if dokuwiki_available:
+        githash = tardis.__githash__
+        report_content = open(config.option.htmlpath, 'rb').read()
+        report_content = report_content.replace("<!DOCTYPE html>", "")
+
+        report_content = (
+            "Test executed on commit "
+            "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{0}]]\n\n"
+            "{1}".format(githash, report_content)
+        )
+
+        # These steps are already performed by `integration_tests_config` but
+        # all the fixtures are teared down and no longer usable, when this
+        # method is being called by pytest, hence they are called as functions.
+        integration_tests_configdict = integration_tests_config()
+
+        try:
+            doku_conn = dokuwiki.DokuWiki(
+                url=integration_tests_configdict["dokuwiki"]["url"],
+                user=integration_tests_configdict["dokuwiki"]["username"],
+                password=integration_tests_configdict["dokuwiki"]["password"])
+        except gaierror, dokuwiki.DokuWikiError:
+            print "Dokuwiki connection not established, report upload failed!"
+        else:
+            # Upload report on dokuwiki. Temporary link due to prototyping purposes.
+            doku_conn.pages.set("reports:{0}".format(githash[:7]), report_content)
+            print "Uploaded report on Dokuwiki."
+
+    # Remove the local report file. Keeping the report saved on local filesystem
+    # is not desired, hence deleted.
+    os.unlink(config.option.htmlpath)
+    print "Deleted temporary file containing html report."
+
+
+@pytest.fixture(scope="session")
+def integration_tests_config():
+    integration_tests_configpath = pytest.config.getvalue("integration-tests")
+    if integration_tests_configpath is None:
+        pytest.skip('--integration-tests was not specified')
+    else:
+        integration_tests_configpath = os.path.expandvars(
+            os.path.expanduser(integration_tests_configpath)
+        )
+        return yaml.load(open(integration_tests_configpath))
 
 
 @pytest.fixture(scope="session")

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -11,6 +11,8 @@ from tardis.model import Radial1DModel
 from tardis.io.config_reader import Configuration
 
 
+@pytest.mark.skipif(not pytest.config.getvalue("integration-tests"),
+                    reason="integration tests are not included in this run")
 class TestW7(object):
     """
     Slow integration test for Stratified W7 setup.

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -19,7 +19,7 @@ class TestW7(object):
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, request, reference, data_path, atomic_data_fname,
-              reference_datadir, base_plot_dir):
+              reference_datadir):
         """
         This method does initial setup of creating configuration and performing
         a single run of integration test.
@@ -60,7 +60,7 @@ class TestW7(object):
         # Form a base directory to save plots for `W7` setup.
         # TODO: Rough prototyping, parametrize this as more setups are added.
         self.name = "w7"
-        self.base_plot_dir = os.path.join(base_plot_dir, self.name)
+        self.base_plot_dir = os.path.join(request.config.option.tempdir, self.name)
         os.makedirs(self.base_plot_dir)
 
     def test_j_estimators(self):


### PR DESCRIPTION
There were two primary issues with infrastructure of integration tests developed till now:
* With the merge of #570 , the html report was uploaded on dokuwiki. Html report was generated using pytest-html plugin, which requires `--html` command line option to specify path to save the report locally. But with the help of tempfile module, and also pytest hooks: `pytest_configure` and `pytest_unconfigure` declared in top level conftest.py, the report was saved in a temp file, uploaded to dokuwiki and finally deleted. 
* Astropy test helpers were imported as `*` in top level conftest.py and the configure-unconfigure hooks I declared, actually had overwritten the former ones. This loosened the protection of `@remote_data` marker provided by astropy test helpers.

    * **Fix**: All these hooks are moved in lower level conftest.py . It also helps to keep slow tests related hooks and fixtures separate.

* The plots were saved in `/tmp/plots/w7/tardis.__githash__`. I used `os.rmdir` to cleanup the temp directory. But `os.rmdir` cannot remove non empty directories. Hence running multiple tests successively on same commit required manual deletion of that directory, else the tests would raise `OSError`.

    * **Fix**: This directory path was provided using `mkdtemp()` method of tempfile module. During `pytest_unconfigure`, recursive deletion was performed using `shutil` module.