### PR TITLE
Update several files to match package_template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,12 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from ConfigParser import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 
@@ -120,9 +124,7 @@ setup(name=PACKAGENAME + '-sn',
       version=VERSION,
       description=DESCRIPTION,
       scripts=scripts,
-      requires=['astropy'],
       install_requires=['astropy'],
-      provides=[PACKAGENAME],
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,
       license=LICENSE,

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -32,14 +32,14 @@ else:
 # Astropy
 ###
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
+# Uncomment the following line to treat all DeprecationWarnings as
+# exceptions
 # enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
+# Uncomment and customize the following lines to add/remove entries from
+# the list of packages for which version numbers are displayed when running
+# the tests. Making it pass for KeyError is essential in some cases when
+# the package uses other astropy affiliated packages.
 try:
     PYTEST_HEADER_MODULES['Numpy'] = 'numpy'
     PYTEST_HEADER_MODULES['Scipy'] = 'scipy'
@@ -54,13 +54,13 @@ try:
 except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
     pass
 
-## Uncomment the following lines to display the version number of the
-## package rather than the version number of Astropy in the top line when
-## running the tests.
+# Uncomment the following lines to display the version number of the
+# package rather than the version number of Astropy in the top line when
+# running the tests.
 import os
 
-## This is to figure out the affiliated package version, rather than
-## using Astropy's
+# This is to figure out the affiliated package version, rather than
+# using Astropy's
 try:
     from .version import version
 except ImportError:
@@ -126,12 +126,6 @@ def pytest_unconfigure(config):
     print "Deleted temporary file containing html report."
 
 # -------------------------------------------------------------------------
-# hooks for influencing reporting (invoked from _pytest_terminal)
-# -------------------------------------------------------------------------
-
-
-
-# -------------------------------------------------------------------------
 # project specific fixtures
 # -------------------------------------------------------------------------
 
@@ -155,14 +149,17 @@ def kurucz_atomic_data(atomic_data_fname):
     else:
         return atomic_data
 
+
 @pytest.fixture
 def test_data_path():
     return os.path.join(tardis.__path__[0], 'tests', 'data')
+
 
 @pytest.fixture
 def included_he_atomic_data(test_data_path):
     atomic_db_fname = os.path.join(test_data_path, 'chianti_he_db.h5')
     return AtomData.from_hdf5(atomic_db_fname)
+
 
 @pytest.fixture
 def tardis_config_verysimple():

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -1,10 +1,21 @@
+# this contains imports plugins that configure py.test for astropy tests.
+# by importing them here in conftest.py they are discoverable by py.test
+# no matter how it is invoked within the source tree.
+
+from astropy.tests.pytest_plugins import *
+from astropy.tests.pytest_plugins import (
+        pytest_addoption as _pytest_add_option,
+        pytest_configure as _pytest_configure,
+        pytest_unconfigure as _pytest_unconfigure
+        )
+
 import yaml
 import tempfile
 import tardis
+import pytest
 from tardis.atomic import AtomData
 from tardis.io.config_reader import Configuration
 from tardis.io.util import yaml_load_config_file
-from astropy.tests.pytest_plugins import *
 
 # For specifying error while exception handling
 from socket import gaierror
@@ -16,39 +27,58 @@ except ImportError:
 else:
     dokuwiki_available = True
 
+
+###
+# Astropy
+###
+
+## Uncomment the following line to treat all DeprecationWarnings as
+## exceptions
+# enable_deprecations_as_exceptions()
+
+## Uncomment and customize the following lines to add/remove entries from
+## the list of packages for which version numbers are displayed when running
+## the tests. Making it pass for KeyError is essential in some cases when
+## the package uses other astropy affiliated packages.
+try:
+    PYTEST_HEADER_MODULES['Numpy'] = 'numpy'
+    PYTEST_HEADER_MODULES['Scipy'] = 'scipy'
+    PYTEST_HEADER_MODULES['Pandas'] = 'pandas'
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['Yaml'] = 'yaml'
+    PYTEST_HEADER_MODULES['Cython'] = 'cython'
+    PYTEST_HEADER_MODULES['h5py'] = 'h5py'
+    PYTEST_HEADER_MODULES['Matplotlib'] = 'matplotlib'
+    PYTEST_HEADER_MODULES['Ipython'] = 'IPython'
+#     del PYTEST_HEADER_MODULES['h5py']
+except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
+    pass
+
+## Uncomment the following lines to display the version number of the
+## package rather than the version number of Astropy in the top line when
+## running the tests.
+import os
+
+## This is to figure out the affiliated package version, rather than
+## using Astropy's
+try:
+    from .version import version
+except ImportError:
+    version = 'dev'
+
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version
+except NameError:   # Needed to support Astropy <= 1.0.0
+    pass
+
 # -------------------------------------------------------------------------
 # Initialization
 # -------------------------------------------------------------------------
 
 
 def pytest_addoption(parser):
-    parser.addoption("--remote-data", action="store_true",
-                     help="run tests with online data")
-    parser.addoption("--open-files", action="store_true",
-                     help="fail if any test leaves files open")
-
-    parser.addoption("--doctest-plus", action="store_true",
-                     help="enable running doctests with additional "
-                     "features not found in the normal doctest "
-                     "plugin")
-
-    parser.addoption("--doctest-rst", action="store_true",
-                     help="enable running doctests in .rst documentation")
-
-    parser.addini("doctest_plus", "enable running doctests with additional "
-                  "features not found in the normal doctest plugin")
-
-    parser.addini("doctest_norecursedirs",
-                  "like the norecursedirs option but applies only to doctest "
-                  "collection", type="args", default=())
-
-    parser.addini("doctest_rst",
-                  "Run the doctests in the rst documentation",
-                  default=False)
-
-    parser.addoption('--repeat', action='store',
-                     help='Number of times to repeat each test')
-
+    _pytest_add_option(parser)
     parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
                      help="filename for atomic dataset")
 
@@ -57,12 +87,14 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    _pytest_configure(config)
     html_file = tempfile.NamedTemporaryFile(delete=False)
     # Html test report will be generated at this filepath by pytest-html plugin
     config.option.htmlpath = html_file.name
 
 
 def pytest_unconfigure(config):
+    _pytest_unconfigure()
     # Html report created by pytest-html plugin is read here, uploaded to
     # dokuwiki and finally deleted.
     if dokuwiki_available:
@@ -97,113 +129,6 @@ def pytest_unconfigure(config):
 # hooks for influencing reporting (invoked from _pytest_terminal)
 # -------------------------------------------------------------------------
 
-
-def pytest_report_header(config):
-
-    stdoutencoding = getattr(sys.stdout, 'encoding') or 'ascii'
-
-    s = "\n"
-    if six.PY2:
-        args = [x.decode('utf-8') for x in config.args]
-    else:
-        args = config.args
-    s += "Running tests in {0}.\n\n".format(" ".join(args))
-
-    from platform import platform
-    plat = platform()
-    if isinstance(plat, bytes):
-        plat = plat.decode(stdoutencoding, 'replace')
-    s += "Platform: {0}\n\n".format(plat)
-    s += "Executable: {0}\n\n".format(sys.executable)
-    s += "Full Python Version: \n{0}\n\n".format(sys.version)
-
-    s += "encodings: sys: {0}, locale: {1}, filesystem: {2}".format(
-        sys.getdefaultencoding(),
-        locale.getpreferredencoding(),
-        sys.getfilesystemencoding())
-    if sys.version_info < (3, 3, 0):
-        s += ", unicode bits: {0}".format(
-            int(math.log(sys.maxunicode, 2)))
-    s += '\n'
-
-    s += "byteorder: {0}\n".format(sys.byteorder)
-    s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
-        sys.float_info)
-
-    import numpy
-    s += "numpy: {0}\n".format(numpy.__version__)
-
-    try:
-        import scipy
-    except ImportError:
-        s += "scipy: not available\n"
-    else:
-        s += "scipy: {0}\n".format(scipy.__version__)
-
-    try:
-        import pandas
-    except ImportError:
-        s += "pandas: not available\n"
-    else:
-        s += "pandas: {0}\n".format(pandas.__version__)
-
-    try:
-        import astropy
-    except ImportError:
-        s += "astropy: not available\n"
-    else:
-        s += "astropy: {0}\n".format(astropy.__version__)
-
-    try:
-        import yaml
-    except ImportError:
-        s += "yaml: not available\n"
-    else:
-        s += "yaml: {0}\n".format(yaml.__version__)
-
-    try:
-        import cython
-    except ImportError:
-        s += "cython: not available\n"
-    else:
-        s += "cython: {0}\n".format(cython.__version__)
-
-    try:
-        import h5py.version
-    except ImportError:
-        s += "h5py: not available\n"
-    else:
-        s += "h5py: {0}\n".format(h5py.version.version)
-
-    try:
-        import matplotlib
-    except ImportError:
-        s += "matplotlib: not available\n"
-    else:
-        s += "matplotlib: {0}\n".format(matplotlib.__version__)
-
-    try:
-        import IPython
-    except ImportError:
-        s += "ipython: not available\n"
-    else:
-        s += "ipython: {0}\n".format(IPython.__version__)
-
-    special_opts = ["remote_data", "pep8"]
-    opts = []
-    for op in special_opts:
-        if getattr(config.option, op, None):
-            opts.append(op)
-    if opts:
-        s += "Using Astropy options: {0}.\n".format(" ".join(opts))
-
-    if six.PY3 and (config.getini('doctest_rst') or config.option.doctest_rst):
-        s += "Running doctests in .rst files is not supported on Python 3.x\n"
-
-    if not six.PY3:
-        s = s.encode(stdoutencoding, 'replace')
-
-    return s
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
With this change we will always use the latest version of
astropy.tests.pytest_plugins because we don't redefine their functions.

Some cleanup was done, too.

Currently pytest_configure and pytest_unconfigure are still defined in
tardis/conftest.py but these will be removed by a future commit by
@karandesai-96.

This fixes issue with `config_dir` and astropy> 1.1