### PR TITLE
Embed comparison plots in Dokuwiki Report.

### DIFF
--- a/conda-requirements
+++ b/conda-requirements
@@ -11,3 +11,4 @@ numexpr==2.4.4
 Cython==0.21
 networkx==1.10
 pytest==2.6.3
+pytest-html==1.8.1

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -5,7 +5,6 @@ import yaml
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.tests.helper import remote_data
 
 from tardis.tests.tests_slow.report import DokuReport
 
@@ -19,13 +18,9 @@ def pytest_configure(config):
         config.option.integration_tests_config = yaml.load(
             open(integration_tests_configpath))
 
-        dokufile = tempfile.NamedTemporaryFile(delete=False)
-        # Report will be generated at this filepath by pytest-html plugin
-        config.option.dokufile = dokufile
-
         # prevent opening dokupath on slave nodes (xdist)
         if not hasattr(config, 'slaveinput'):
-            config.dokureport = DokuReport(config.option.dokufile,
+            config.dokureport = DokuReport(
                 config.option.integration_tests_config['dokuwiki'])
             config.pluginmanager.register(config.dokureport)
     # A common tempdir for storing plots / PDFs and other slow test related data
@@ -34,15 +29,11 @@ def pytest_configure(config):
     config.option.tempdir = tempdir_session
 
 
-@remote_data
 def pytest_unconfigure(config):
     integration_tests_configpath = config.getvalue("integration-tests")
     if integration_tests_configpath is not None:
         config.pluginmanager.unregister(config.dokureport)
 
-    # Remove the local report file. Keeping the report saved on local filesystem
-    # is not desired, hence deleted.
-    os.unlink(config.option.dokufile.name)
     print "Deleted temporary file containing html report."
     # Remove tempdir by recursive deletion
     shutil.rmtree(config.option.tempdir)

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -31,11 +31,11 @@ def pytest_configure(config):
 
         dokufile = tempfile.NamedTemporaryFile(delete=False)
         # Report will be generated at this filepath by pytest-html plugin
-        config.option.dokupath = dokufile.name
+        config.option.dokufile = dokufile
 
         # prevent opening dokupath on slave nodes (xdist)
         if not hasattr(config, 'slaveinput'):
-            config.dokureport = DokuReport(config.option.dokupath)
+            config.dokureport = DokuReport(config.option.dokufile)
             config.pluginmanager.register(config.dokureport)
     # A common tempdir for storing plots / PDFs and other slow test related data
     # generated during execution.
@@ -51,7 +51,7 @@ def pytest_unconfigure(config):
         # dokuwiki and finally deleted.
         if dokuwiki_available:
             githash = tardis.__githash__
-            report_content = open(config.option.htmlpath, 'rb').read()
+            report_content = open(config.option.dokufile.name, 'rb').read()
             report_content = report_content.replace("<!DOCTYPE html>", "")
 
             report_content = (
@@ -79,7 +79,7 @@ def pytest_unconfigure(config):
 
     # Remove the local report file. Keeping the report saved on local filesystem
     # is not desired, hence deleted.
-    os.unlink(config.option.dokupath)
+    os.unlink(config.option.dokufile.name)
     print "Deleted temporary file containing html report."
     # Remove tempdir by recursive deletion
     shutil.rmtree(config.option.tempdir)

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -18,6 +18,8 @@ def pytest_configure(config):
         config.option.integration_tests_config = yaml.load(
             open(integration_tests_configpath))
 
+        # Used by DokuReport class to show build environment details in report.
+        config._environment = []
         # prevent opening dokupath on slave nodes (xdist)
         if not hasattr(config, 'slaveinput'):
             config.dokureport = DokuReport(

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -33,8 +33,6 @@ def pytest_unconfigure(config):
     integration_tests_configpath = config.getvalue("integration-tests")
     if integration_tests_configpath is not None:
         config.pluginmanager.unregister(config.dokureport)
-
-    print "Deleted temporary file containing html report."
     # Remove tempdir by recursive deletion
     shutil.rmtree(config.option.tempdir)
 

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -63,7 +63,7 @@ class DokuReport(HTMLReport):
         except (TypeError, gaierror, dokuwiki.DokuWikiError):
             self.doku_conn = None
 
-    def _generate_report(self):
+    def _generate_report(self, session):
         """
         The method writes HTML report to a temporary logfile.
         """
@@ -120,6 +120,14 @@ class DokuReport(HTMLReport):
                 generated.strftime('%d-%b-%Y'),
                 generated.strftime('%H:%M:%S'))))
 
+        if session.config._environment:
+            environment = set(session.config._environment)
+            body.append(html.h2('Environment'))
+            body.append(html.table(
+                [html.tr(html.td(e[0]), html.td(e[1])) for e in sorted(
+                    environment, key=lambda e: e[0]) if e[1]],
+                id='environment'))
+
         body.extend(summary)
         body.extend(results)
 
@@ -152,7 +160,7 @@ class DokuReport(HTMLReport):
         This hook function is called by pytest when whole test run is completed.
         It calls the two helper methods `_generate_report` and `_save_report`.
         """
-        report_content = self._generate_report()
+        report_content = self._generate_report(session)
         self._save_report(report_content)
 
     def pytest_terminal_summary(self, terminalreporter):

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -1,6 +1,7 @@
 import datetime
 import pkg_resources
 import os
+import tempfile
 import time
 
 # For specifying error while exception handling
@@ -18,7 +19,8 @@ except ImportError:
 
 class DokuReport(HTMLReport):
 
-    def __init__(self, logfile, dokuwiki_details):
+    def __init__(self, dokuwiki_details):
+        logfile = tempfile.TemporaryFile()
         super(DokuReport, self).__init__(logfile.name)
         self.logfile = logfile
 
@@ -109,7 +111,7 @@ class DokuReport(HTMLReport):
 
         if self.doku_conn is not None:
             self.doku_conn.pages.set("reports:{0}".format(
-                    tardis.__githash__[:7]), self.logfile.read())
+                tardis.__githash__[:7]), self.logfile.read())
             print "Uploaded report on Dokuwiki."
 
         self.logfile.close()

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -55,15 +55,12 @@ class DokuReport(HTMLReport):
         super(DokuReport, self).__init__(" ")
         del self.logfile
 
-        if dokuwiki is not None:
-            try:
-                self.doku_conn = dokuwiki.DokuWiki(
-                    url=dokuwiki_details["url"],
-                    user=dokuwiki_details["username"],
-                    password=dokuwiki_details["password"])
-            except gaierror, dokuwiki.DokuWikiError:
-                self.doku_conn = None
-        else:
+        try:
+            self.doku_conn = dokuwiki.DokuWiki(
+                url=dokuwiki_details["url"],
+                user=dokuwiki_details["username"],
+                password=dokuwiki_details["password"])
+        except (TypeError, gaierror, dokuwiki.DokuWikiError):
             self.doku_conn = None
 
         # This variable will be set True when report gets uploaded on Dokuwiki.
@@ -147,14 +144,13 @@ class DokuReport(HTMLReport):
         file is made using `tempfile` built-in module, it gets deleted upon
         closing.
         """
-        if self.doku_conn is not None:
-            try:
-                self.doku_conn.pages.set("reports:{0}".format(
-                    tardis.__githash__[:7]), report_content)
-            except gaierror:
-                self.is_report_uploaded = False
-            else:
-                self.is_report_uploaded = True
+        try:
+            self.doku_conn.pages.set("reports:{0}".format(
+                tardis.__githash__[:7]), report_content)
+        except (gaierror, TypeError):
+            self.is_report_uploaded = False
+        else:
+            self.is_report_uploaded = True
 
     def pytest_sessionfinish(self, session):
         """

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -63,9 +63,6 @@ class DokuReport(HTMLReport):
         except (TypeError, gaierror, dokuwiki.DokuWikiError):
             self.doku_conn = None
 
-        # This variable will be set True when report gets uploaded on Dokuwiki.
-        self.is_report_uploaded = False
-
     def _generate_report(self):
         """
         The method writes HTML report to a temporary logfile.
@@ -148,9 +145,7 @@ class DokuReport(HTMLReport):
             self.doku_conn.pages.set("reports:{0}".format(
                 tardis.__githash__[:7]), report_content)
         except (gaierror, TypeError):
-            self.is_report_uploaded = False
-        else:
-            self.is_report_uploaded = True
+            pass
 
     def pytest_sessionfinish(self, session):
         """
@@ -166,7 +161,13 @@ class DokuReport(HTMLReport):
         summary at the end. Here, the success / failure of upload of report
         to dokuwiki is logged.
         """
-        if self.is_report_uploaded:
+        try:
+            uploaded_report = self.doku_conn.pages.get(
+                "reports:{0}".format(tardis.__githash__[0:7]))
+        except (gaierror, TypeError):
+            uploaded_report = ""
+
+        if len(uploaded_report) > 0:
             terminalreporter.write_sep(
                 "-", "Successfully uploaded report to Dokuwiki")
         else:

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -62,6 +62,9 @@ class DokuReport(HTMLReport):
                 password=dokuwiki_details["password"])
         except (TypeError, gaierror, dokuwiki.DokuWikiError):
             self.doku_conn = None
+            self.dokuwiki_url = ""
+        else:
+            self.dokuwiki_url = dokuwiki_details["url"]
 
     def _generate_report(self, session):
         """
@@ -178,6 +181,12 @@ class DokuReport(HTMLReport):
         if len(uploaded_report) > 0:
             terminalreporter.write_sep(
                 "-", "Successfully uploaded report to Dokuwiki")
+            terminalreporter.write_sep(
+                "-", "URL: {0}doku.php?id=reports:{1}".format(
+                    self.dokuwiki_url, tardis.__githash__[0:7]
+                )
+            )
+
         else:
             terminalreporter.write_sep(
                 "-", "Connection not established, upload failed.")

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -1,5 +1,90 @@
+import datetime
+import pkg_resources
+import os
+import time
+
+from py.xml import html, raw
 from pytest_html.plugin import HTMLReport
 
 
 class DokuReport(HTMLReport):
-    pass
+
+    def __init__(self, logfile):
+        super(DokuReport, self).__init__(logfile.name)
+        self.logfile = logfile
+
+    def _generate_report(self):
+        suite_stop_time = time.time()
+        suite_time_delta = suite_stop_time - self.suite_start_time
+        numtests = self.passed + self.failed + self.xpassed + self.xfailed
+        generated = datetime.datetime.now()
+
+        style_css = pkg_resources.resource_string(
+            __name__, os.path.join('resources', 'style.css'))
+
+        head = html.head(
+            html.meta(charset='utf-8'),
+            html.title('Test Report'),
+            html.style(raw(style_css)))
+
+        summary = [html.h2('Summary'), html.p(
+            '{0} tests ran in {1:.2f} seconds.'.format(
+                numtests, suite_time_delta),
+            html.br(),
+            html.span('{0} passed'.format(
+                self.passed), class_='passed'), ', ',
+            html.span('{0} skipped'.format(
+                self.skipped), class_='skipped'), ', ',
+            html.span('{0} failed'.format(
+                self.failed), class_='failed'), ', ',
+            html.span('{0} errors'.format(
+                self.errors), class_='error'), '.',
+            html.br(),
+            html.span('{0} expected failures'.format(
+                self.xfailed), class_='skipped'), ', ',
+            html.span('{0} unexpected passes'.format(
+                self.xpassed), class_='failed'), '.')]
+
+        results = [html.h2('Results'), html.table([html.thead(
+            html.tr([
+                html.th('Result',
+                        class_='sortable initial-sort result',
+                        col='result'),
+                html.th('Test', class_='sortable', col='name'),
+                html.th('Duration',
+                        class_='sortable numeric',
+                        col='duration'),
+                html.th('Links')]), id='results-table-head'),
+            html.tbody(*self.test_logs, id='results-table-body')],
+            id='results-table')]
+
+        main_js = pkg_resources.resource_string(
+            __name__, os.path.join('resources', 'main.js'))
+
+        body = html.body(
+            html.script(raw(main_js)),
+            html.p('Report generated on {0} at {1}'.format(
+                generated.strftime('%d-%b-%Y'),
+                generated.strftime('%H:%M:%S'))))
+
+        body.extend(summary)
+        body.extend(results)
+
+        doc = html.html(head, body)
+
+        self.logfile.write('<!DOCTYPE html>')
+        unicode_doc = doc.unicode(indent=2)
+
+        self.logfile.write(unicode_doc)
+
+    def _save_report(self):
+        # Go back to the beginning to read everything
+        self.logfile.seek(0)
+
+        # TODO: Add mechanism to upload report in dokuwiki.
+
+        self.logfile.close()
+
+    def pytest_sessionfinish(self, session):
+        self._generate_report()
+        self._save_report()

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -1,0 +1,5 @@
+from pytest_html.plugin import HTMLReport
+
+
+class DokuReport(HTMLReport):
+    pass

--- a/tardis_ci/tardis_ci_env27.yml
+++ b/tardis_ci/tardis_ci_env27.yml
@@ -32,7 +32,7 @@ dependencies:
   - sphinxcontrib-bibtex
   - sphinxcontrib-tikz
   - coveralls
-  - pytest-html=1.8.1
+  - pytest-html==1.8.1
 
 
 

--- a/tardis_ci/tardis_ci_env27.yml
+++ b/tardis_ci/tardis_ci_env27.yml
@@ -14,6 +14,7 @@ dependencies:
 - Cython=0.21
 - networkx=1.10
 - pytest=2.9.1
+- pytest-html=1.8.0
 
 # RTD requirements
 - sphinx=1.4.1

--- a/tardis_ci/tardis_ci_env27.yml
+++ b/tardis_ci/tardis_ci_env27.yml
@@ -14,7 +14,6 @@ dependencies:
 - Cython=0.21
 - networkx=1.10
 - pytest=2.9.1
-- pytest-html=1.8.0
 
 # RTD requirements
 - sphinx=1.4.1
@@ -33,6 +32,7 @@ dependencies:
   - sphinxcontrib-bibtex
   - sphinxcontrib-tikz
   - coveralls
+  - pytest-html=1.8.1
 
 
 

--- a/tardis_ci/tardis_rtd_env27.yml
+++ b/tardis_ci/tardis_rtd_env27.yml
@@ -25,7 +25,7 @@ dependencies:
   - sphinx_bootstrap_theme
   - sphinxcontrib-bibtex
   - sphinxcontrib-tikz
-  - pytest-html=1.8.1
+  - pytest-html==1.8.1
 
 
 

--- a/tardis_ci/tardis_rtd_env27.yml
+++ b/tardis_ci/tardis_rtd_env27.yml
@@ -14,6 +14,8 @@ dependencies:
 - Cython=0.21
 - networkx=1.10
 - pytest=2.6.3
+- pytest-html=1.8.0
+
 # RTD requirements
 - sphinx=1.4.1
 - nbconvert=4.2.0

--- a/tardis_ci/tardis_rtd_env27.yml
+++ b/tardis_ci/tardis_rtd_env27.yml
@@ -14,7 +14,6 @@ dependencies:
 - Cython=0.21
 - networkx=1.10
 - pytest=2.6.3
-- pytest-html=1.8.0
 
 # RTD requirements
 - sphinx=1.4.1
@@ -26,6 +25,7 @@ dependencies:
   - sphinx_bootstrap_theme
   - sphinxcontrib-bibtex
   - sphinxcontrib-tikz
+  - pytest-html=1.8.1
 
 
 


### PR DESCRIPTION
This PR introduces a mechanism which adds comparison plot generated by `TestW7.plot_spectrum()` method, to the dokuwiki report. The image is saved by `plot_spectrum` in a session wide temporary directory, and this file path is provided to the `DokuReport` class by the corresponding test method (here `test_spectrum`).

Reading the image and base64 encoding is done within the class and it is uploaded at an appropriate place in the plot.