### PR TITLE
[TEP002] Add a to_hdf method to the Radial1DModel

### DIFF
--- a/tardis/model.py
+++ b/tardis/model.py
@@ -90,6 +90,9 @@ class Radial1DModel(object):
 
         self.t_inner = tardis_config.plasma.t_inner
 
+        self.v_inner = tardis_config.structure.v_inner
+        self.v_outer = tardis_config.structure.v_outer
+        self.v_middle = 0.5 * (self.v_inner + self.v_outer)
 
         self.ws = self.calculate_geometric_w(
             tardis_config.structure.r_middle,
@@ -97,7 +100,7 @@ class Radial1DModel(object):
 
         if tardis_config.plasma.t_rads is None:
             self.t_rads = self._init_t_rad(
-                self.t_inner, tardis_config.structure.v_inner[0], self.v_middle)
+                self.t_inner, self.v_inner[0], self.v_middle)
         else:
             self.t_rads = tardis_config.plasma.t_rads
 
@@ -115,8 +118,8 @@ class Radial1DModel(object):
             link_t_rad_t_electron=0.9,
             helium_treatment=tardis_config.plasma.helium_treatment,
             heating_rate_data_file=heating_rate_data_file,
-            v_inner=tardis_config.structure.v_inner,
-            v_outer=tardis_config.structure.v_outer)
+            v_inner=self.v_inner,
+            v_outer=self.v_outer)
 
         distance = tardis_config.supernova.get('distance', None)
         self.spectrum = TARDISSpectrum(
@@ -164,11 +167,6 @@ class Radial1DModel(object):
     @property
     def t_inner(self):
         return self._t_inner
-
-    @property
-    def v_middle(self):
-        structure = self.tardis_config.structure
-        return 0.5 * (structure.v_inner + structure.v_outer)
 
     @t_inner.setter
     def t_inner(self, value):

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -250,116 +250,62 @@ class Radial1DModel(object):
         self.spectrum.to_ascii(fname)
         self.spectrum_virtual.to_ascii('virtual_' + fname)
 
-
-    def to_hdf5(self, buffer_or_fname, path='', close_h5=True):
+    def to_hdf(self, path_or_buf, path='', plasma_properties=None):
         """
-            This allows the model to be written to an HDF5 file for later analysis. Currently, the saved properties
-            are specified hard coded in include_from_model_in_hdf5. This is a dict where the key corresponds to the
-            name of the property and the value describes the type. If the value is None the property can be dumped
-            to hdf via its attribute to_hdf or by converting it to a pd.DataFrame. For more complex properties
-            which can not simply be dumped to an hdf file the dict can contain a function which is called with
-            the parameters key, path, and  hdf_store. This function then should dump the data to the given
-            hdf_store object. To dump  properties of sub-properties of  the model, you can use a dict as value.
-            This dict is then treated in the same way as described above.
+        Store the model and the runner to an HDF structure.
+        Properties that have 1D arrays as their values are stored
+        as columns of a pandas.DataFrame under `path`, called arrays.
+        Properties that have a scalar value are stored as labeled
+        elements in a pandas.Series under `path`, called scalars.
+
+        All Quantities will be stored as their SI values and without
+        their unit.
 
         Parameters
         ----------
+        path_or_buf
+            Path or buffer to the HDF store
+        path : str
+            Path inside the HDF store to store the plasma
+        plasma_properties
+            `None` or a `PlasmaPropertyCollection` which will
+            be passed as the collection argument to the
+            plasma.to_hdf method.
 
-        buffer_or_fname: buffer or ~str
-            buffer or filename for HDF5 file (see pandas.HDFStore for description)
-        path: ~str, optional
-            path in the HDF5 file
-        close_h5: ~bool
-            close the HDF5 file or not.
+        Returns
+        -------
+        None
+
         """
-
-
-        # Functions to save properties of the model without to_hdf attribute and no simple conversion to a pd.DataFrame.
-        #This functions are always called with the parameters key, path and,  hdf_store.
-        def _save_luminosity_density(key, path, hdf_store):
-
-            luminosity_density = pd.DataFrame.from_dict(dict(wave=self.spectrum.wavelength.value,
-                                                             flux=self.spectrum.luminosity_density_lambda.value))
-            luminosity_density.to_hdf(hdf_store, os.path.join(path, key))
-
-        def _save_spectrum_virtual(key, path, hdf_store):
-            if self.spectrum_virtual.luminosity_density_lambda is not None:
-                luminosity_density_virtual = pd.DataFrame.from_dict(dict(wave=self.spectrum_virtual.wavelength.value,
-                                                                         flux=self.spectrum_virtual.luminosity_density_lambda.value))
-                luminosity_density_virtual.to_hdf(hdf_store, os.path.join(path, key))
-
-        def _save_configuration_dict(key, path, hdf_store):
-            configuration_dict = dict(t_inner=self.t_inner.value,time_of_simulation=self.time_of_simulation)
-            configuration_dict_path = os.path.join(path, 'configuration')
-            pd.Series(configuration_dict).to_hdf(hdf_store, configuration_dict_path)
-
-        include_from_plasma_ = {'level_number_density': None, 'ion_number_density': None, 'tau_sobolevs': None,
-                                'electron_densities': None,
-                                't_rad': None, 'w': None}
-        include_from_runner_ = {'virt_packet_last_interaction_type': None, 'virt_packet_last_line_interaction_in_id': None,
-                                'virt_packet_last_line_interaction_out_id': None, 'virt_packet_last_interaction_in_nu': None,
-                                'virt_packet_nus': None, 'virt_packet_energies': None}
-        include_from_model_in_hdf5 = {'plasma_array': include_from_plasma_, 'j_blues': None,
-                                      'runner': include_from_runner_,
-                                      'last_line_interaction_in_id': None,
-                                      'last_line_interaction_out_id': None,
-                                      'last_line_interaction_shell_id': None, 'montecarlo_nu': None,
-                                      'luminosity_density': _save_luminosity_density,
-                                      'luminosity_density_virtual': _save_spectrum_virtual,
-                                      'configuration_dict': _save_configuration_dict,
-                                      'last_line_interaction_angstrom': None}
-
-        if isinstance(buffer_or_fname, basestring):
-            hdf_store = pd.HDFStore(buffer_or_fname)
-        elif isinstance(buffer_or_fname, pd.HDFStore):
-            hdf_store = buffer_or_fname
-        else:
-            raise IOError('Please specify either a filename or an HDFStore')
-        logger.info('Writing to path %s', path)
-
-        def _get_hdf5_path(path, property_name):
-            return os.path.join(path, property_name)
-
-        def _to_smallest_pandas(object):
-            try:
-                return pd.Series(object)
-            except Exception:
-                return pd.DataFrame(object)
-
-
-        def _save_model_property(object, property_name, path, hdf_store):
-            property_path = _get_hdf5_path(path, property_name)
-
-            try:
-                object.to_hdf(hdf_store, property_path)
-            except AttributeError:
-                _to_smallest_pandas(object).to_hdf(hdf_store, property_path)
-
-
-        for key in include_from_model_in_hdf5:
-            if include_from_model_in_hdf5[key] is None:
-                _save_model_property(getattr(self, key), key, path, hdf_store)
-            elif callable(include_from_model_in_hdf5[key]):
-                include_from_model_in_hdf5[key](key, path, hdf_store)
+        scalars = {}
+        one_d_arrays = pd.DataFrame()
+        properties = ['t_inner', 'ws', 't_rads', 'v_inner', 'v_outer']
+        for p in properties:
+            output_value = getattr(self, p)
+            if hasattr(output_value, 'si'):
+                output_value = output_value.si.value
+            if np.isscalar(output_value):
+                scalars[p] = output_value
+            elif hasattr(output_value, 'shape') and output_value.ndim == 1:
+                one_d_arrays[p] = output_value
             else:
-                try:
-                    for subkey in include_from_model_in_hdf5[key]:
-                        if include_from_model_in_hdf5[key][subkey] is None:
-                            _save_model_property(getattr(getattr(self, key), subkey), subkey, os.path.join(path, key),
-                                                 hdf_store)
-                        elif callable(include_from_model_in_hdf5[key][subkey]):
-                            include_from_model_in_hdf5[key][subkey](subkey, os.path.join(path, key), hdf_store)
-                        else:
-                            logger.critical('Can not save %s', str(os.path.join(path, key, subkey)))
-                except:
-                    logger.critical('An error occurred while dumping %s to HDF.', str(os.path.join(path, key)))
+                data = pd.DataFrame(output_value)
+                data.to_hdf(path_or_buf, os.path.join(path, 'model', p))
+        pd.Series(scalars).to_hdf(path_or_buf, os.path.join(path,
+                                                            'model',
+                                                            'scalars'))
+        one_d_arrays.to_hdf(path_or_buf, os.path.join(path,
+                                                      'model',
+                                                      'arrays'))
+
+        self.plasma.to_hdf(path_or_buf, os.path.join(path, 'model'),
+                           False, plasma_properties)
+
+        metadata = pd.Series({'atom_data_uuid': self.atom_data.uuid1})
+        metadata.to_hdf(path_or_buf,
+                                 os.path.join(path, 'model', 'metadata'))
 
 
-        hdf_store.flush()
-        if close_h5:
-            hdf_store.close()
-        else:
-            return hdf_store
 
 class TARDISSpectrum(object):
     """


### PR DESCRIPTION
Added a `model.to_hdf` method which in turn calls `plasma.to_hdf` and also stores `t_inner`, `ws`, `t_rads`, `v_inner`, `v_outer`.

Additionally, `atom_data_uuid` is also stored in a Series under the HDF structure path `model/metadata`.