### PR TITLE
Link images of comparison plots in DokuReport using hookwrapper.

### DIFF
--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -45,11 +45,10 @@ def pytest_runtest_makereport(item, call):
     # execute all other hooks to obtain the report object
     outcome = yield
     report = outcome.get_result()
-
     if report.when == "call":
         if "plot_object" in item.fixturenames:
             plot_obj = item.funcargs["plot_object"]
-            plot_obj.upload()
+            plot_obj.upload(report)
             report.extra = plot_obj.get_extras()
 
 

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -1,15 +1,13 @@
 import os
-import glob
 import shutil
 import tempfile
 import yaml
 import numpy as np
 import pytest
-from pytest_html import extras
 from astropy import units as u
 
 from tardis.tests.tests_slow.report import DokuReport
-import tardis
+from tardis.tests.tests_slow.plot_helpers import PlotUploader
 
 
 def pytest_configure(config):
@@ -56,46 +54,11 @@ def pytest_runtest_makereport(item, call):
 
 @pytest.fixture(scope="function")
 def plot_object(request):
-    class PlotUploader(object):
-        def __init__(self):
-            self._plots = list()
-            self.plot_links = list()
-
-        def add(self, plot, name):
-            """
-            Accept a `matplotlib.pyplot.figure` and add it to self._plots.
-            """
-            self._plots.append((plot, name))
-
-        def upload(self):
-            """
-            Upload the content in self._plots to dokuwiki.
-            """
-            dokuwiki_url = request.config.dokureport.dokuwiki_url
-            for plot, name in self._plots:
-                plot_file = tempfile.NamedTemporaryFile(suffix=".png")
-                plot.savefig(plot_file.name)
-
-                request.config.dokureport.doku_conn.medias.add(
-                    "plots:{0}_{1}.png".format(tardis.__githash__[0:7], name),
-                    plot_file.name
-                )
-                self.plot_links.append(extras.url(
-                    "{0}lib/exe/fetch.php?media=plots:{1}_{2}.png".format(
-                        dokuwiki_url, tardis.__githash__[0:7], name
-                    ), name)
-                )
-                plot_file.close()
-
-        def get_extras(self):
-            return self.plot_links
     plot_obj = PlotUploader()
     setattr(request.node, "plot_obj", plot_obj)
 
     def fin():
-        # Adding plots in this manner is temporary.
-        plot_obj.add()
-        plot_obj.upload()
+        plot_obj.upload(request)
     request.addfinalizer(fin)
     return plot_obj
 

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -54,9 +54,7 @@ def pytest_runtest_makereport(item, call):
 
 @pytest.fixture(scope="function")
 def plot_object(request):
-    plot_obj = PlotUploader(request)
-    setattr(request.node, "plot_obj", plot_obj)
-    return plot_obj
+    return PlotUploader(request)
 
 
 @pytest.fixture(scope="session")

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -48,17 +48,15 @@ def pytest_runtest_makereport(item, call):
 
     if report.when == "call":
         if "plot_object" in item.fixturenames:
-            report.extra = item.funcargs["plot_object"].get_extras()
+            plot_obj = item.funcargs["plot_object"]
+            plot_obj.upload()
+            report.extra = plot_obj.get_extras()
 
 
 @pytest.fixture(scope="function")
 def plot_object(request):
-    plot_obj = PlotUploader()
+    plot_obj = PlotUploader(request)
     setattr(request.node, "plot_obj", plot_obj)
-
-    def fin():
-        plot_obj.upload(request)
-    request.addfinalizer(fin)
     return plot_obj
 
 

--- a/tardis/tests/tests_slow/conftest.py
+++ b/tardis/tests/tests_slow/conftest.py
@@ -47,9 +47,8 @@ def pytest_runtest_makereport(item, call):
     report = outcome.get_result()
 
     if report.when == "call":
-        plot_obj = getattr(item, "plot_obj", None)
-        if plot_obj is not None:
-            report.extra = plot_obj.get_extras()
+        if "plot_object" in item.fixturenames:
+            report.extra = item.funcargs["plot_object"].get_extras()
 
 
 @pytest.fixture(scope="function")

--- a/tardis/tests/tests_slow/plot_helpers.py
+++ b/tardis/tests/tests_slow/plot_helpers.py
@@ -1,0 +1,38 @@
+import tempfile
+from pytest_html import extras
+import tardis
+
+
+class PlotUploader(object):
+    def __init__(self):
+        self._plots = list()
+        self.plot_links = list()
+
+    def add(self, plot, name):
+        """
+        Accept a `matplotlib.pyplot.figure` and add it to self._plots.
+        """
+        self._plots.append((plot, name))
+
+    def upload(self, request):
+        """
+        Upload the content in self._plots to dokuwiki.
+        """
+        dokuwiki_url = request.config.dokureport.dokuwiki_url
+        for plot, name in self._plots:
+            plot_file = tempfile.NamedTemporaryFile(suffix=".png")
+            plot.savefig(plot_file.name)
+
+            request.config.dokureport.doku_conn.medias.add(
+                "plots:{0}_{1}.png".format(tardis.__githash__[0:7], name),
+                plot_file.name
+            )
+            self.plot_links.append(extras.url(
+                "{0}lib/exe/fetch.php?media=plots:{1}_{2}.png".format(
+                    dokuwiki_url, tardis.__githash__[0:7], name
+                ), name)
+            )
+            plot_file.close()
+
+    def get_extras(self):
+        return self.plot_links

--- a/tardis/tests/tests_slow/plot_helpers.py
+++ b/tardis/tests/tests_slow/plot_helpers.py
@@ -4,6 +4,15 @@ from pytest_html import extras
 import tardis
 
 
+thumbnail_html = """
+<div class="image" style="float: left">
+    <a href="#">
+        <img src= "{dokuwiki_url}lib/exe/fetch.php?media=plots:{githash}_{name}.png" />
+    </a>
+</div>
+"""
+
+
 class PlotUploader(object):
     def __init__(self, request):
         self.request = request
@@ -39,15 +48,13 @@ class PlotUploader(object):
                 plot_file.name
             )
 
-            thumbnail_html = """
-            <div class="image" style="float: left">
-                <a href="#">
-                    <img src= "{0}lib/exe/fetch.php?media=plots:{1}_{2}.png" />
-                </a>
-            </div>
-            """.format(self.dokuwiki_url, tardis.__githash__[0:7], name)
-
-            self.plot_html.append(extras.html(thumbnail_html))
+            self.plot_html.append(extras.html(
+                thumbnail_html.format(
+                    dokuwiki_url=self.dokuwiki_url,
+                    githash=tardis.__githash__[0:7],
+                    name=name)
+                )
+            )
             plot_file.close()
 
     def get_extras(self):

--- a/tardis/tests/tests_slow/plot_helpers.py
+++ b/tardis/tests/tests_slow/plot_helpers.py
@@ -28,7 +28,7 @@ class PlotUploader(object):
             if report.passed:
                 axes.text(0.8, 0.8, 'passed', transform=axes.transAxes,
                             bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
-            elif report.failed:
+            else:
                 axes.text(0.8, 0.8, 'failed', transform=axes.transAxes,
                             bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
 

--- a/tardis/tests/tests_slow/plot_helpers.py
+++ b/tardis/tests/tests_slow/plot_helpers.py
@@ -15,21 +15,39 @@ thumbnail_html = """
 
 class PlotUploader(object):
     def __init__(self, request):
+        """A helper class to collect plots from integration tests and upload
+        them to DokuWiki.
+
+        Parameters
+        ----------
+        request : _pytest.python.RequestObject
+
+        """
         self.request = request
         self._plots = list()
         self.plot_html = list()
         self.dokuwiki_url = self.request.config.dokureport.dokuwiki_url
 
     def add(self, plot, name):
-        """
-        Accept a `matplotlib.pyplot.figure` and add it to self._plots.
+        """Accept a plot figure and add it to ``self._plots``.
+
+        Parameters
+        ----------
+        plot : matplotlib.pyplot.figure
+        name : str
+
         """
         self._plots.append((plot, name))
 
     def upload(self, report):
+        """Upload the content in self._plots to dokuwiki.
+
+        Parameters
+        ----------
+        report : _pytest.runner.TestReport
+
         """
-        Upload the content in self._plots to dokuwiki.
-        """
+
         for plot, name in self._plots:
             plot_file = tempfile.NamedTemporaryFile(suffix=".png")
             axes = plot.axes[0]
@@ -58,4 +76,11 @@ class PlotUploader(object):
             plot_file.close()
 
     def get_extras(self):
+        """Return ``self.plot_html`` which is further added into html report.
+
+        Returns
+        -------
+        list
+             List of strings containing raw html snippet to embed images.
+        """
         return self.plot_html

--- a/tardis/tests/tests_slow/plot_helpers.py
+++ b/tardis/tests/tests_slow/plot_helpers.py
@@ -1,12 +1,15 @@
 import tempfile
+
 from pytest_html import extras
 import tardis
 
 
 class PlotUploader(object):
-    def __init__(self):
+    def __init__(self, request):
+        self.request = request
         self._plots = list()
-        self.plot_links = list()
+        self.plot_html = list()
+        self.dokuwiki_url = self.request.config.dokureport.dokuwiki_url
 
     def add(self, plot, name):
         """
@@ -14,25 +17,29 @@ class PlotUploader(object):
         """
         self._plots.append((plot, name))
 
-    def upload(self, request):
+    def upload(self):
         """
         Upload the content in self._plots to dokuwiki.
         """
-        dokuwiki_url = request.config.dokureport.dokuwiki_url
         for plot, name in self._plots:
             plot_file = tempfile.NamedTemporaryFile(suffix=".png")
             plot.savefig(plot_file.name)
 
-            request.config.dokureport.doku_conn.medias.add(
+            self.request.config.dokureport.doku_conn.medias.add(
                 "plots:{0}_{1}.png".format(tardis.__githash__[0:7], name),
                 plot_file.name
             )
-            self.plot_links.append(extras.url(
-                "{0}lib/exe/fetch.php?media=plots:{1}_{2}.png".format(
-                    dokuwiki_url, tardis.__githash__[0:7], name
-                ), name)
-            )
+
+            thumbnail_html = """
+            <div class="image" style="float: left">
+                <a href="#">
+                    <img src= "{0}lib/exe/fetch.php?media=plots:{1}_{2}.png" />
+                </a>
+            </div>
+            """.format(self.dokuwiki_url, tardis.__githash__[0:7], name)
+
+            self.plot_html.append(extras.html(thumbnail_html))
             plot_file.close()
 
     def get_extras(self):
-        return self.plot_links
+        return self.plot_html

--- a/tardis/tests/tests_slow/plot_helpers.py
+++ b/tardis/tests/tests_slow/plot_helpers.py
@@ -17,12 +17,21 @@ class PlotUploader(object):
         """
         self._plots.append((plot, name))
 
-    def upload(self):
+    def upload(self, report):
         """
         Upload the content in self._plots to dokuwiki.
         """
         for plot, name in self._plots:
             plot_file = tempfile.NamedTemporaryFile(suffix=".png")
+            axes = plot.axes[0]
+
+            if report.passed:
+                axes.text(0.8, 0.8, 'passed', transform=axes.transAxes,
+                            bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
+            elif report.failed:
+                axes.text(0.8, 0.8, 'failed', transform=axes.transAxes,
+                            bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
+
             plot.savefig(plot_file.name)
 
             self.request.config.dokureport.doku_conn.medias.add(

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -144,6 +144,11 @@ class DokuReport(HTMLReport):
             )
         )
         report_content += doc.unicode(indent=2)
+
+        # Quick hack for preventing log to be placed in narrow left out space
+        report_content = report_content.replace(
+            u'class="log"', u'class="log" style="clear: both"'
+        )
         return report_content
 
     def _save_report(self, report_content):

--- a/tardis/tests/tests_slow/report.py
+++ b/tardis/tests/tests_slow/report.py
@@ -186,7 +186,6 @@ class DokuReport(HTMLReport):
                     self.dokuwiki_url, tardis.__githash__[0:7]
                 )
             )
-
         else:
             terminalreporter.write_sep(
                 "-", "Connection not established, upload failed.")

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -178,7 +178,19 @@ class TestW7(object):
         ax.set_xlabel("Shell id")
         ax.set_ylabel("t_rads")
 
-        ax.plot(self.result.t_rads, color="blue", marker=".")
+        result_line = ax.plot(self.result.t_rads, color="blue",
+                              marker=".", label="Result")
+        reference_line = ax.plot(self.reference['t_rads'], color="green",
+                                 marker=".", label="Reference")
         ax.axis([0, 28, 5000, 10000])
 
+        error_ax = ax.twinx()
+        error_line = error_ax.plot((1 - self.result.t_rads / self.reference['t_rads']),
+                                   color="red", marker=".", label="Rel. Error")
+        error_ax.set_ylabel("Relative error (1 - result / reference)")
+
+        lines = result_line + reference_line + error_line
+        labels = [l.get_label() for l in lines]
+
+        ax.legend(lines, labels, loc="lower left")
         return figure

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -128,11 +128,12 @@ class TestW7(object):
             assert_quantity_allclose(
                 self.reference['luminosity_density_lambda'],
                 self.result.runner.spectrum.luminosity_density_lambda)
-
-            plot = self.plot_spectrum(has_passed=True)
         except Exception as e:
             plot = self.plot_spectrum(has_passed=False)
             raise e
+        else:
+            plot = self.plot_spectrum(has_passed=True)
+
         plot_object.add(plot, "spectrum")
 
     def plot_spectrum(self, has_passed):
@@ -176,7 +177,35 @@ class TestW7(object):
                 self.reference['montecarlo_nu'],
                 self.result.montecarlo_nu)
 
-    def test_shell_temperature(self):
-        assert_quantity_allclose(
+    def test_shell_temperature(self, plot_object):
+        try:
+            assert_quantity_allclose(
                 self.reference['t_rads'],
                 self.result.t_rads)
+        except Exception as e:
+            plot = self.plot_t_rads(has_passed=False)
+            raise e
+        else:
+            plot = self.plot_t_rads(has_passed=True)
+
+        plot_object.add(plot, "t_rads")
+
+    def plot_t_rads(self, has_passed):
+        plt.suptitle("Shell temperature for packets", fontweight="bold")
+        figure = plt.figure()
+
+        ax = figure.add_subplot(111)
+        ax.set_xlabel("Shell id")
+        ax.set_ylabel("t_rads")
+
+        if has_passed:
+            ax.text(0.8, 0.8, 'passed', transform=ax.transAxes,
+                    bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
+            ax.plot(self.result.t_rads, color="green", marker=".")
+        else:
+            ax.text(0.8, 0.8, 'failed', transform=ax.transAxes,
+                    bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
+            ax.plot(self.result.t_rads, color="red", marker=".")
+        ax.axis([0, 28, 5000, 10000])
+
+        return figure

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -111,7 +111,7 @@ class TestW7(object):
                 self.reference['luminosity_inner'],
                 self.result.luminosity_inner)
 
-    def test_spectrum(self, plot_obj):
+    def test_spectrum(self, plot_object):
         try:
             assert_quantity_allclose(
                 self.reference['luminosity_density_nu'],
@@ -129,18 +129,20 @@ class TestW7(object):
                 self.reference['luminosity_density_lambda'],
                 self.result.runner.spectrum.luminosity_density_lambda)
 
-            self.plot_spectrum(has_passed=True)
+            plot = self.plot_spectrum(has_passed=True)
         except Exception as e:
-            self.plot_spectrum(has_passed=False)
+            plot = self.plot_spectrum(has_passed=False)
             raise e
+        plot_object.add(plot, "spectrum")
 
     def plot_spectrum(self, has_passed):
         plt.suptitle("Deviation in spectrum_quantities", fontweight="bold")
+        figure = plt.figure()
 
         # `ldl_` prefixed variables associated with `luminosity_density_lambda`.
         # Axes of subplot are extracted, if we wish to make multiple plots
         # for different spectrum quantities all in one figure.
-        ldl_ax = plt.subplot(111)
+        ldl_ax = figure.add_subplot(111)
         ldl_ax.set_title("Deviation in luminosity_density_lambda")
         ldl_ax.set_xlabel("Wavelength")
         ldl_ax.set_ylabel("Relative error (1 - result / reference)")
@@ -159,9 +161,7 @@ class TestW7(object):
             ldl_ax.plot(self.reference['wavelength'], deviation,
                         color="red", marker=".")
 
-        # Figure is saved in `tmp` directory right now, till a suitable way of
-        # saving them is decided.
-        plt.savefig(os.path.join(self.base_plot_dir, "spectrum.png"))
+        return figure
 
     def test_montecarlo_properties(self):
         assert_quantity_allclose(

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -112,31 +112,25 @@ class TestW7(object):
                 self.result.luminosity_inner)
 
     def test_spectrum(self, plot_object):
-        try:
-            assert_quantity_allclose(
-                self.reference['luminosity_density_nu'],
-                self.result.runner.spectrum.luminosity_density_nu)
+        plot_object.add(self.plot_spectrum(), "spectrum")
 
-            assert_quantity_allclose(
-                self.reference['delta_frequency'],
-                self.result.runner.spectrum.delta_frequency)
+        assert_quantity_allclose(
+            self.reference['luminosity_density_nu'],
+            self.result.runner.spectrum.luminosity_density_nu)
 
-            assert_quantity_allclose(
-                self.reference['wavelength'],
-                self.result.runner.spectrum.wavelength)
+        assert_quantity_allclose(
+            self.reference['delta_frequency'],
+            self.result.runner.spectrum.delta_frequency)
 
-            assert_quantity_allclose(
-                self.reference['luminosity_density_lambda'],
-                self.result.runner.spectrum.luminosity_density_lambda)
-        except Exception as e:
-            plot = self.plot_spectrum(has_passed=False)
-            raise e
-        else:
-            plot = self.plot_spectrum(has_passed=True)
+        assert_quantity_allclose(
+            self.reference['wavelength'],
+            self.result.runner.spectrum.wavelength)
 
-        plot_object.add(plot, "spectrum")
+        assert_quantity_allclose(
+            self.reference['luminosity_density_lambda'],
+            self.result.runner.spectrum.luminosity_density_lambda)
 
-    def plot_spectrum(self, has_passed):
+    def plot_spectrum(self):
         plt.suptitle("Deviation in spectrum_quantities", fontweight="bold")
         figure = plt.figure()
 
@@ -151,16 +145,8 @@ class TestW7(object):
             self.result.runner.spectrum.luminosity_density_lambda.value /
             self.reference['luminosity_density_lambda'].value)
 
-        if has_passed:
-            ldl_ax.text(0.8, 0.8, 'passed', transform=ldl_ax.transAxes,
-                        bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
-            ldl_ax.plot(self.reference['wavelength'], deviation,
-                        color="green", marker=".")
-        else:
-            ldl_ax.text(0.8, 0.8, 'failed', transform=ldl_ax.transAxes,
-                        bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
-            ldl_ax.plot(self.reference['wavelength'], deviation,
-                        color="red", marker=".")
+        ldl_ax.plot(self.reference['wavelength'], deviation,
+                    color="blue", marker=".")
 
         return figure
 
@@ -178,19 +164,13 @@ class TestW7(object):
                 self.result.montecarlo_nu)
 
     def test_shell_temperature(self, plot_object):
-        try:
-            assert_quantity_allclose(
-                self.reference['t_rads'],
-                self.result.t_rads)
-        except Exception as e:
-            plot = self.plot_t_rads(has_passed=False)
-            raise e
-        else:
-            plot = self.plot_t_rads(has_passed=True)
+        plot_object.add(self.plot_t_rads(), "t_rads")
 
-        plot_object.add(plot, "t_rads")
+        assert_quantity_allclose(
+            self.reference['t_rads'],
+            self.result.t_rads)
 
-    def plot_t_rads(self, has_passed):
+    def plot_t_rads(self):
         plt.suptitle("Shell temperature for packets", fontweight="bold")
         figure = plt.figure()
 
@@ -198,14 +178,7 @@ class TestW7(object):
         ax.set_xlabel("Shell id")
         ax.set_ylabel("t_rads")
 
-        if has_passed:
-            ax.text(0.8, 0.8, 'passed', transform=ax.transAxes,
-                    bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
-            ax.plot(self.result.t_rads, color="green", marker=".")
-        else:
-            ax.text(0.8, 0.8, 'failed', transform=ax.transAxes,
-                    bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
-            ax.plot(self.result.t_rads, color="red", marker=".")
+        ax.plot(self.result.t_rads, color="blue", marker=".")
         ax.axis([0, 28, 5000, 10000])
 
         return figure

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -111,7 +111,7 @@ class TestW7(object):
                 self.reference['luminosity_inner'],
                 self.result.luminosity_inner)
 
-    def test_spectrum(self):
+    def test_spectrum(self, plot_obj):
         try:
             assert_quantity_allclose(
                 self.reference['luminosity_density_nu'],


### PR DESCRIPTION
This PR introduces a common object for temporary holding comparison plots and uploading them on DokuWiki. For this purpose, a fixture named `plot_object` has been created in **tests_slow/conftest.py**. It returns an object of `PlotUploader` class.

Inclusions in this PR:
- [X] `PlotUploader` class in **tests_slow/plot_helpers.py**
- [X] `plot_object` fixture in **tests_slow/conftest.py** which returns object of `PlotUploader`class.
- [X] `plot_spectrum` of ``TestW7` returns a figure which is passed directly to `PlotUploader.upload()`
- [X] `PlotUploader.upload()` handles upload to dokuwiki.
