### PR TITLE
Provide tardis.yaml_load shortcut

### DIFF
--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -8,6 +8,7 @@ from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
 from tardis.base import run_tardis
+from tardis.io.util import yaml_load_config_file as yaml_load
 
 logging.captureWarnings(True)
 logger = logging.getLogger('tardis')


### PR DESCRIPTION
This is a shortcut to yaml.load which uses the modified yaml loader that
is able to load quantities and all floats.

Usage:
```python
import tardis
config = tardis.yaml_load('config.yml')
mdl = tardis.run_tardis(config)
```