### PR TITLE
[TEP002] Add a to_hdf method to the Simulation

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -211,17 +211,23 @@ class Simulation(object):
                              'neither damped nor specific '
                              '- input is {0}'.format(convergence_strategy.type))
 
-    def legacy_run_simulation(self, model, hdf_path_or_buf=None, hdf_mode='full'):
+    def legacy_run_simulation(self, model, hdf_path_or_buf=None,
+                              hdf_mode='full', hdf_last_only=True):
         """
 
         Parameters
         ----------
         model : tardis.model.Radial1DModel
-        hdf_path_or_buf : str or None
+        hdf_path_or_buf : str, optional
             A path to store the data of each simulation iteration
-        hdf_mode : {'full', 'input'}
+            (the default value is None, which means that nothing
+            will be stored).
+        hdf_mode : {'full', 'input'}, optional
             If 'full' all plasma properties will be stored to HDF,
             if 'input' only input plasma properties will be stored.
+        hdf_last_only: bool, optional
+            If True, only the last iteration of the simulation will
+            be stored to the HDFStore.
 
         Returns
         -------
@@ -275,7 +281,7 @@ class Simulation(object):
 
             model.calculate_j_blues(init_detailed_j_blues=False)
             model.update_plasmas(initialize_nlte=False)
-            if hdf_path_or_buf is not None:
+            if hdf_path_or_buf is not None and not hdf_last_only:
                 self.to_hdf(model, hdf_path_or_buf,
                             'simulation{}'.format(iterations_executed),
                             plasma_properties)
@@ -414,20 +420,26 @@ class Simulation(object):
         None
         """
         self.runner.to_hdf(path_or_buf, path, False)
-        model.to_hdf(path_or_buf, path, False, plasma_properties)
+        model.to_hdf(path_or_buf, path, plasma_properties)
 
 
-def run_radial1d(radial1d_model, hdf_path_or_buf=None, hdf_mode='full'):
+def run_radial1d(radial1d_model, hdf_path_or_buf=None,
+                 hdf_mode='full', hdf_last_only=True):
     """
 
     Parameters
     ----------
     radial1d_model : tardis.model.Radial1DModel
-    hdf_path_or_buf : str or None
+    hdf_path_or_buf : str, optional
         A path to store the data of each simulation iteration
-    hdf_mode : {'full', 'input'}
+        (the default value is None, which means that nothing
+        will be stored).
+    hdf_mode : {'full', 'input'}, optional
         If 'full' all plasma properties will be stored to HDF,
         if 'input' only input plasma properties will be stored.
+    hdf_last_only: bool, optional
+        If True, only the last iteration of the simulation will
+        be stored to the HDFStore.
 
     Returns
     -------
@@ -435,7 +447,8 @@ def run_radial1d(radial1d_model, hdf_path_or_buf=None, hdf_mode='full'):
     """
 
     simulation = Simulation(radial1d_model.tardis_config)
-    simulation.legacy_run_simulation(radial1d_model, hdf_path_or_buf, hdf_mode)
+    simulation.legacy_run_simulation(radial1d_model, hdf_path_or_buf,
+                                     hdf_mode, hdf_last_only)
 
 
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import time
 import itertools
@@ -9,6 +10,7 @@ import numpy as np
 from astropy import units as u
 
 from tardis.montecarlo.base import MontecarloRunner
+from tardis.plasma.properties.base import Input
 
 # Adding logging support
 logger = logging.getLogger(__name__)
@@ -209,13 +211,37 @@ class Simulation(object):
                              'neither damped nor specific '
                              '- input is {0}'.format(convergence_strategy.type))
 
-    def legacy_run_simulation(self, model):
+    def legacy_run_simulation(self, model, hdf_path_or_buf=None, hdf_mode='full'):
+        """
+
+        Parameters
+        ----------
+        model : tardis.model.Radial1DModel
+        hdf_path_or_buf : str or None
+            A path to store the data of each simulation iteration
+        hdf_mode : {'full', 'input'}
+            If 'full' all plasma properties will be stored to HDF,
+            if 'input' only input plasma properties will be stored.
+
+        Returns
+        -------
+
+        """
         start_time = time.time()
 
         iterations_remaining = self.tardis_config.montecarlo.iterations
         iterations_max_requested = self.tardis_config.montecarlo.iterations
         iterations_executed = 0
         converged = False
+
+        if hdf_path_or_buf is not None:
+            if hdf_mode == 'full':
+                plasma_properties = None
+            elif hdf_mode == 'input':
+                plasma_properties = [Input]
+            else:
+                raise ValueError('hdf_mode must be "full" or "input"'
+                                 ', not "{}"'.format(type(hdf_mode)))
 
         while iterations_remaining > 1:
             logger.info('Remaining run %d', iterations_remaining)
@@ -249,6 +275,10 @@ class Simulation(object):
 
             model.calculate_j_blues(init_detailed_j_blues=False)
             model.update_plasmas(initialize_nlte=False)
+            if hdf_path_or_buf is not None:
+                self.to_hdf(model, hdf_path_or_buf,
+                            'simulation{}'.format(iterations_executed),
+                            plasma_properties)
 
 
             # if switching into the hold iterations mode or out back to the normal one
@@ -300,6 +330,11 @@ class Simulation(object):
 
         logger.info("Finished in {0:d} iterations and took {1:.2f} s".format(
             iterations_executed, time.time()-start_time))
+
+        if hdf_path_or_buf is not None:
+            self.to_hdf(model, hdf_path_or_buf,
+                        'simulation{}'.format(iterations_executed),
+                        plasma_properties)
 
 
     def legacy_update_spectrum(self, model, no_of_virtual_packets):
@@ -359,12 +394,48 @@ class Simulation(object):
         # required for gui
         model.current_no_of_packets = model.tardis_config.montecarlo.no_of_packets
 
-def run_radial1d(radial1d_model, history_fname=None):
-    if history_fname is not None:
-        raise ValueError('This functionality is currently not supported')
+    def to_hdf(self, model, path_or_buf, path='', plasma_properties=None):
+        """
+        Store the simulation to an HDF structure.
+
+        Parameters
+        ----------
+        model : tardis.model.Radial1DModel
+        path_or_buf
+            Path or buffer to the HDF store
+        path : str
+            Path inside the HDF store to store the simulation
+        plasma_properties
+            `None` or a `PlasmaPropertyCollection` which will
+            be passed as the collection argument to the
+            plasma.to_hdf method.
+        Returns
+        -------
+        None
+        """
+        self.runner.to_hdf(path_or_buf, path, False)
+        model.to_hdf(path_or_buf, path, False, plasma_properties)
+
+
+def run_radial1d(radial1d_model, hdf_path_or_buf=None, hdf_mode='full'):
+    """
+
+    Parameters
+    ----------
+    radial1d_model : tardis.model.Radial1DModel
+    hdf_path_or_buf : str or None
+        A path to store the data of each simulation iteration
+    hdf_mode : {'full', 'input'}
+        If 'full' all plasma properties will be stored to HDF,
+        if 'input' only input plasma properties will be stored.
+
+    Returns
+    -------
+
+    """
 
     simulation = Simulation(radial1d_model.tardis_config)
-    simulation.legacy_run_simulation(radial1d_model)
+    simulation.legacy_run_simulation(radial1d_model, hdf_path_or_buf, hdf_mode)
 
 
 


### PR DESCRIPTION
In this PR I introduce a `Simulation.to_hdf` method which in turn calls `plasma.to_hdf` and `runner.to_hdf`.

Also I have added the three following arguments to the `legacy_run_simulation`, essentially allowing to store each iteration of the simulation (along with the model and the runner) to the HDF file each under a `simulationX` path:

|     Argument    | Default value | Effect                                                                                                     |
|:---------------:|:-------------:|------------------------------------------------------------------------------------------------------------|
| hdf_path_or_buf | None          | A path to the HDF file that the simulation iterations will be written to. If None, nothing will be stored. |
| hdf_mode        | 'full'        | If 'input', only write Input plasma properties.                                                            |
| hdf_last_only   | False         | If True, only the last iteration of the simulation will be stored. Otherwise store every iteration.        |

These three arguments also apply to the `run_radial1d` function.

Currently with all the [TEP002] PRs applied, when running `run_radial1d(model, '/tmp/full.hdf', 'full')`, the output looks like:

```
/simulation1/model/arrays                                           frame        (shape->[20,4])    
/simulation1/model/metadata                                         series       (shape->[1])       
/simulation1/model/plasma/abundance                                 frame        (shape->[6,20])    
/simulation1/model/plasma/atomic_mass                               frame        (shape->[6,1])     
/simulation1/model/plasma/beta_electron                             frame        (shape->[20,1])    
/simulation1/model/plasma/beta_rad                                  frame        (shape->[20,1])    
/simulation1/model/plasma/delta                                     frame        (shape->[88,20])   
/simulation1/model/plasma/density                                   frame        (shape->[20,1])    
/simulation1/model/plasma/electron_densities                        frame        (shape->[20,1])    
/simulation1/model/plasma/excitation_energy                         frame        (shape->[4439,1])  
/simulation1/model/plasma/f_lu                                      frame        (shape->[29224,1]) 
/simulation1/model/plasma/g                                         frame        (shape->[4439,1])  
/simulation1/model/plasma/g_electron                                frame        (shape->[20,1])    
/simulation1/model/plasma/general_level_boltzmann_factor            frame        (shape->[4439,20]) 
/simulation1/model/plasma/ion_number_density                        frame        (shape->[94,20])   
/simulation1/model/plasma/ionization_data                           frame        (shape->[88,1])    
/simulation1/model/plasma/j_blues                                   frame        (shape->[29224,20])
/simulation1/model/plasma/level_boltzmann_factor                    frame        (shape->[4439,20]) 
/simulation1/model/plasma/level_number_density                      frame        (shape->[4439,20]) 
/simulation1/model/plasma/levels                                    frame        (shape->[1,1])     
/simulation1/model/plasma/lines                                     frame        (shape->[29224,12])
/simulation1/model/plasma/lines_lower_level_index                   frame        (shape->[29224,1]) 
/simulation1/model/plasma/lines_upper_level_index                   frame        (shape->[29224,1]) 
/simulation1/model/plasma/link_t_rad_t_electron                     frame        (shape->[1,1])     
/simulation1/model/plasma/metastability                             frame        (shape->[4439,1])  
/simulation1/model/plasma/nu                                        frame        (shape->[29224,1]) 
/simulation1/model/plasma/number_density                            frame        (shape->[6,20])    
/simulation1/model/plasma/partition_function                        frame        (shape->[94,20])   
/simulation1/model/plasma/phi                                       frame        (shape->[88,20])   
/simulation1/model/plasma/selected_atoms                            frame        (shape->[6,1])     
/simulation1/model/plasma/stimulated_emission_factor                frame        (shape->[29224,20])
/simulation1/model/plasma/t_electrons                               frame        (shape->[20,1])    
/simulation1/model/plasma/t_rad                                     frame        (shape->[20,1])    
/simulation1/model/plasma/tau_sobolevs                              frame        (shape->[29224,20])
/simulation1/model/plasma/time_explosion                            frame        (shape->[1,1])     
/simulation1/model/plasma/w                                         frame        (shape->[20,1])    
/simulation1/model/plasma/wavelength_cm                             frame        (shape->[29224,1]) 
/simulation1/model/plasma/zeta_data                                 frame        (shape->[94,20])   
/simulation1/model/scalars                                          series       (shape->[1])       
/simulation1/runner/j_estimator                                     frame        (shape->[20,1])    
/simulation1/runner/nu_bar_estimator                                frame        (shape->[20,1])    
/simulation1/runner/output_energy                                   frame        (shape->[200000,1])
/simulation1/runner/output_nu                                       frame        (shape->[200000,1])
/simulation2/model/arrays                                           frame        (shape->[20,4])    
[...]
```

**Things still in progress (but not in the scope of this PR):**

1. Properties under `model/plasma` and `runner` need to be stored like the properties in the rest of `model`. This means:
    1. 1D arrays (anything of shape [x,1]) as DataFrame columns under `model/plasma/arrays`
    1. scalars (anything of shape [1,1]) as Series items under `model/plasma/scalars`, and
    1. 2D arrays (rest of the shapes), as it currently is, i.e. a separate DataFrame
2. According to @wkerzendorf, plasma properties `w` and `t_rad` should not be stored by `plasma.to_hdf` if the latter was called by `model.to_hdf` because `model.to_hdf` will have already stored `model.ws` and `model.t_rads`.