### PR TITLE
Update the tardis_example tar file provided in the documentation.

### DIFF
--- a/bootstrap_trusty64.sh
+++ b/bootstrap_trusty64.sh
@@ -12,5 +12,5 @@ conda create --yes -n tardis --file /vagrant/pip-requirements pip
 
 echo "export PATH=/home/vagrant/miniconda/bin:$PATH" >> .bashrc
 
-wget https://www.dropbox.com/s/svvyr5i7m8ouzdt/tardis_example.tar.gz
+wget http://opensupernova.org/~ftsamis/tardis_example.tar.gz
 tar zxvf tardis_example.tar.gz

--- a/docs/examples/tardis_example.rst
+++ b/docs/examples/tardis_example.rst
@@ -2,7 +2,7 @@ tardis_example
 --------------
 
 The simple and fast TARDIS setup is provided by tardis_example archive which
-may be obtained from `<https://www.dropbox.com/s/svvyr5i7m8ouzdt/tardis_example.tar.gz>`_
+may be obtained from `<http://opensupernova.org/~ftsamis/tardis_example.tar.gz>`
 and which we suggest every new user of TARDIS to run
 first.
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -10,7 +10,8 @@ configuration file (more info at :ref:`config-file`).
 Running TARDIS in the commandline
 =================================
 
-After installing TARDIS just download the example directory `<https://www.dropbox.com/s/svvyr5i7m8ouzdt/tardis_example.tar.gz>`_
+After installing TARDIS just download the `example directory
+<http://opensupernova.org/~ftsamis/tardis_example.tar.gz>`_
 and run TARDIS with:
 
 


### PR DESCRIPTION
This solves #577 by changing the invalid keywords `convergence_criteria` and `hold` in the YAML files of `tardis_example.tar.gz` to `convergence_strategy` and `hold_iterations` respectively.

I also made sure that the comments in the YAML files are up to date, and reformatted them.

I have double-checked that there was no other changes by mistake, by comparing the old YAML files with the new ones, after `yaml.load`ing them.