### PR TITLE
Fix all imports and paths

### DIFF
--- a/docs/atomic/atomic_data_description.rst
+++ b/docs/atomic/atomic_data_description.rst
@@ -3,7 +3,7 @@
 ******************************
 Atomic Data Format Description
 ******************************
-.. currentmodule:: tardis.atomic
+.. currentmodule:: tardis.io.atomic
 
 
 The atomic data for tardis is stored in `hdf5 files <http://www.h5py.org/>`_. TARDIS ships with a
@@ -225,4 +225,4 @@ TO BE BETTER DOCUMENTED ...
 
 
 
-.. automodapi:: tardis.atomic
+.. automodapi:: tardis.io.atomic

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -19,8 +19,8 @@ def run_tardis(config, atom_data=None):
         atomic data will be loaded according to keywords set in the configuration
         [default=None]
     """
-    from tardis.io import config_reader
-    from tardis import model, simulation, atomic
+    from tardis.io import config_reader, atomic
+    from tardis import model, simulation
 
     if atom_data is not None:
         try:

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -9,7 +9,7 @@ from astropy.tests.pytest_plugins import (
 
 import tardis
 import pytest
-from tardis.atomic import AtomData
+from tardis.io.atomic import AtomData
 from tardis.io.config_reader import Configuration
 from tardis.io.util import yaml_load_config_file
 

--- a/tardis/io/atomic.py
+++ b/tardis/io/atomic.py
@@ -20,10 +20,13 @@ class AtomDataNotPreparedError(Exception):
 
 logger = logging.getLogger(__name__)
 
+tardis_dir = os.path.dirname(os.path.realpath(tardis.__file__))
 
 def data_path(fname):
-    tardis_dir = os.path.dirname(os.path.realpath(tardis.__file__))
     return os.path.join(tardis_dir, 'data', fname)
+
+def tests_data_path(fname):
+    return os.path.join(tardis_dir, 'tests', 'data', fname)
 
 
 default_atom_h5_path = data_path('atom_data.h5')

--- a/tardis/io/tests/test_atomic.py
+++ b/tardis/io/tests/test_atomic.py
@@ -11,7 +11,7 @@ def default_atom_h5_path():
 
 @pytest.fixture(scope="module")
 def chianti_he_db_h5_path():
-    return atomic.data_path('chianti_he_db.h5')
+    return atomic.tests_data_path('chianti_he_db.h5')
 
 
 def test_data_path():

--- a/tardis/io/tests/test_atomic.py
+++ b/tardis/io/tests/test_atomic.py
@@ -6,13 +6,12 @@ from tardis.io import atomic
 
 @pytest.fixture(scope="module")
 def default_atom_h5_path():
-    return atomic.default_atom_h5_path
+    return atomic.data_path('atom_data.h5')
 
 
 @pytest.fixture(scope="module")
 def chianti_he_db_h5_path():
-    return os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), 'data', 'chianti_he_db.h5')
+    return atomic.data_path('chianti_he_db.h5')
 
 
 def test_data_path():

--- a/tardis/plasma/tests/conftest.py
+++ b/tardis/plasma/tests/conftest.py
@@ -6,7 +6,7 @@ from astropy import units as u
 import pytest
 
 import tardis
-from tardis.atomic import AtomData
+from tardis.io.atomic import AtomData
 from tardis.plasma.standard_plasmas import LegacyPlasmaArray
 from tardis.plasma.properties import *
 

--- a/tardis/tests/tests_slow/test_w7.py
+++ b/tardis/tests/tests_slow/test_w7.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose
 
-from tardis.atomic import AtomData
+from tardis.io.atomic import AtomData
 from tardis.io.util import yaml_load_config_file
 from tardis.simulation.base import Simulation
 from tardis.model import Radial1DModel


### PR DESCRIPTION
The `atomic.py` module has been moved to the `tardis.io` package. 
In this PR I fixed all imports of `atomic.py` and also corrected some data paths. 