### PR TITLE
Fix bug in montecarlo.pyx

### DIFF
--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -297,9 +297,9 @@ def montecarlo_radial1d(model, runner, int_type_t virtual_packet_flag=0,
         postprocess(model,runner)
 
 def postprocess(model, runner):
-    Edotlu_norm_factor = (1 / 
+    Edotlu_norm_factor = (1 /
         (model.time_of_simulation * model.tardis_config.structure.volumes))
-    exptau = 1 - np.exp(- 
+    exptau = 1 - np.exp(-
                         runner.line_lists_tau_sobolevs.reshape(-1,
-                            model.tardis_config.structure["velocity"]["num"]) ) 
-    model.Edotlu = Edotlu_norm_factor*exptau*runner.Edotlu_estimator        
+                            runner.j_estimator.shape[0]) )
+    model.Edotlu = Edotlu_norm_factor*exptau*runner.Edotlu_estimator


### PR DESCRIPTION
The number of shells was extracted from tardis_config which fails if the
structure is given by a file. Now the no_of_shells is extracted from the
shape of the j_estimator.

Trailing spaces were removed.