### PR TITLE
Add a to_hdf method on TARDISSpectrum

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -303,3 +303,8 @@ class MontecarloRunner(object):
                       'j_estimator']
         to_hdf(path_or_buf, runner_path, {name: getattr(self, name) for name
                                           in properties})
+        self.spectrum.to_hdf(path_or_buf, runner_path)
+        self.spectrum_virtual.to_hdf(path_or_buf, runner_path,
+                                     'spectrum_virtual')
+        self.spectrum_reabsorbed.to_hdf(path_or_buf, runner_path,
+                                        'spectrum_reabsorbed')

--- a/tardis/montecarlo/spectrum.py
+++ b/tardis/montecarlo/spectrum.py
@@ -1,5 +1,9 @@
+import os
 import numpy as np
 from astropy import constants, units as u
+
+from tardis.io.util import to_hdf
+
 
 class TARDISSpectrum(object):
     """
@@ -67,3 +71,29 @@ class TARDISSpectrum(object):
             np.savetxt(fname, zip(self.wavelength.value, self.flux_lambda.value))
         else:
             raise NotImplementedError('only mode "luminosity_density" and "flux" are implemented')
+
+    def to_hdf(self, path_or_buf, path='', name=''):
+        """
+        Store the spectrum to an HDF structure.
+
+        Parameters
+        ----------
+        path_or_buf
+            Path or buffer to the HDF store
+        path : str
+            Path inside the HDF store to store the spectrum
+        name : str, optional
+            A different name than 'spectrum', if needed.
+
+        Returns
+        -------
+        None
+
+        """
+        if not name:
+            name = 'spectrum'
+        spectrum_path = os.path.join(path, name)
+        properties = ['luminosity_density_nu', 'delta_frequency', 'wavelength',
+                      'luminosity_density_lambda']
+        to_hdf(path_or_buf, spectrum_path, {name: getattr(self, name) for name
+                                            in properties})


### PR DESCRIPTION
This was missed in the original TEP002 PR, so adding it now.
All three spectra will be stored under montecarlo in the HDF Store.