### PR TITLE
Fixed incorrect name in error message

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -80,7 +80,7 @@ def pytest_addoption(parser):
 def atomic_data_fname():
     atomic_data_fname = pytest.config.getvalue("atomic-dataset")
     if atomic_data_fname is None:
-        pytest.skip('--atomic_database was not specified')
+        pytest.skip('--atomic-dataset was not specified')
     else:
         return os.path.expandvars(os.path.expanduser(atomic_data_fname))
 


### PR DESCRIPTION
Some tests are skipped if `--atomic-dataset` is not given to `test`, but the diagnostic message suggests `--atomic_database` is missing. This PR changes the the message to give the correct argument name.