### PR TITLE
Automatically download and cache atomic data files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
         - ASTROPY_USE_SYSTEM_PYTEST=1
         - SETUP_CMD='test'
         - TEST_MODE='normal'
-        - ATOM_DATA_URL='http://www.mpa-garching.mpg.de/~michi/tardis/data/kurucz_cd23_chianti_H_He.zip'
         - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh'
 
 matrix:
@@ -28,20 +27,20 @@ matrix:
         - python: 2.7
           env:
             - COMPILER=gcc
-            - SETUP_CMD='test --args="--atomic-dataset=$HOME/kurucz_cd23_chianti_H_He.h5"'
+            - SETUP_CMD='test --args="--remote-data"'
             - TEST_MODE='spectrum'
 
         - python: 2.7
           env:
             - COMPILER=clang
-            - SETUP_CMD='test --args="--atomic-dataset=$HOME/kurucz_cd23_chianti_H_He.h5"'
+            - SETUP_CMD='test --args="--remote-data"'
             - TEST_MODE='spectrum'
 
         - os: osx
           language: generic
           env:
             - COMPILER=clang
-            - SETUP_CMD='test --args="--atomic-dataset=$HOME/kurucz_cd23_chianti_H_He.h5"'
+            - SETUP_CMD='test --args="--remote-data"'
             - TEST_MODE='spectrum'
             - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
 
@@ -66,9 +65,6 @@ before_install:
     - export PATH=$HOME/miniconda/bin:$PATH
     - hash -r
     - conda update --yes conda
-    - if [[ $TEST_MODE == 'spectrum' ]]; then wget $ATOM_DATA_URL; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then unzip kurucz_cd23_chianti_H_He.zip; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then mv kurucz_cd23_chianti_H_He.h5 $HOME/; fi
 
 install:
    - conda env create -f tardis_env27.yml

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -114,3 +114,11 @@ def included_he_atomic_data(test_data_path):
 def tardis_config_verysimple():
     return yaml_load_config_file(
         'tardis/io/tests/data/tardis_configv1_verysimple.yml')
+
+
+@pytest.fixture(scope="session")
+def atom_data_url():
+    return {
+        'kurucz_cd23_chianti_H_He.h5':
+            'http://www.mpa-garching.mpg.de/~michi/tardis/data/kurucz_cd23_chianti_H_He.zip'
+    }

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -98,7 +98,6 @@ def tardis_config_verysimple():
         'tardis/io/tests/data/tardis_configv1_verysimple.yml')
 
 
-@remote_data
 @pytest.fixture(scope="session")
 def _atom_data(request):
     atom_data_name = 'kurucz_cd23_chianti_H_He.h5'
@@ -124,7 +123,6 @@ def _atom_data(request):
     return atom_data
 
 
-@remote_data
 @pytest.fixture(scope="class")
 def atom_data(_atom_data):
     if _atom_data.md5 != '21095dd25faa1683f4c90c911a00c3f8':

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -15,7 +15,6 @@ from astropy.utils.data import download_file
 
 import tardis
 from tardis.atomic import AtomData
-from tardis.io.util import yaml_load_config_file
 
 ###
 # Astropy
@@ -94,8 +93,7 @@ def included_he_atomic_data(test_data_path):
 
 @pytest.fixture(scope="session")
 def tardis_config_verysimple():
-    return yaml_load_config_file(
-        'tardis/io/tests/data/tardis_configv1_verysimple.yml')
+    return 'tardis/io/tests/data/tardis_configv1_verysimple.yml'
 
 
 @pytest.fixture(scope="session")

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -83,26 +83,6 @@ def pytest_addoption(parser):
 # -------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="session")
-def atomic_data_fname():
-    atomic_data_fname = pytest.config.getvalue("atomic-dataset")
-    if atomic_data_fname is None:
-        pytest.skip('--atomic-dataset was not specified')
-    else:
-        return os.path.expandvars(os.path.expanduser(atomic_data_fname))
-
-
-@pytest.fixture
-def kurucz_atomic_data(atomic_data_fname):
-    atomic_data = AtomData.from_hdf5(atomic_data_fname)
-
-    if atomic_data.md5 != '21095dd25faa1683f4c90c911a00c3f8':
-        pytest.skip('Need default Kurucz atomic dataset '
-                    '(md5="21095dd25faa1683f4c90c911a00c3f8"')
-    else:
-        return atomic_data
-
-
 @pytest.fixture
 def test_data_path():
     return os.path.join(tardis.__path__[0], 'tests', 'data')
@@ -120,21 +100,14 @@ def tardis_config_verysimple():
         'tardis/io/tests/data/tardis_configv1_verysimple.yml')
 
 
-@pytest.fixture(scope="session")
-def atom_data_url():
-    return {
-        'kurucz_cd23_chianti_H_He.h5':
-            'http://www.mpa-garching.mpg.de/~michi/tardis/data/kurucz_cd23_chianti_H_He.zip'
-    }
-
-
 @remote_data
 @pytest.fixture(scope="session")
 def _atom_data(request):
     atom_data_name = 'kurucz_cd23_chianti_H_He.h5'
     # Download and cache the zip file of atomic data.
     atom_data_cache = download_file(
-        atom_data_url[atom_data_name], cache=True
+        'http://www.mpa-garching.mpg.de/~michi/tardis/data/kurucz_cd23_chianti_H_He.zip',
+        cache=True
     )
 
     # Obtained file is a zip file, hence unzipped inside a tempdir.
@@ -156,4 +129,7 @@ def _atom_data(request):
 @remote_data
 @pytest.fixture(scope="class")
 def atom_data(_atom_data):
+    if _atom_data.md5 != '21095dd25faa1683f4c90c911a00c3f8':
+        pytest.skip('Need default Kurucz atomic dataset '
+                    '(md5="21095dd25faa1683f4c90c911a00c3f8"')
     return copy.deepcopy(_atom_data)

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -68,8 +68,6 @@ except NameError:   # Needed to support Astropy <= 1.0.0
 
 def pytest_addoption(parser):
     _pytest_add_option(parser)
-    parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
-                     help="filename for atomic dataset")
     parser.addoption("--integration-tests", dest="integration-tests", default=None,
                      help="path to configuration file for integration tests")
     parser.addoption("--generate-reference", action="store_true", default=False,

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -114,7 +114,7 @@ def included_he_atomic_data(test_data_path):
     return AtomData.from_hdf5(atomic_db_fname)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def tardis_config_verysimple():
     return yaml_load_config_file(
         'tardis/io/tests/data/tardis_configv1_verysimple.yml')

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -99,7 +99,7 @@ def tardis_config_verysimple():
 
 
 @pytest.fixture(scope="session")
-def _atom_data(request):
+def atom_data(request):
     atom_data_name = 'kurucz_cd23_chianti_H_He.h5'
     # Download and cache the zip file of atomic data.
     atom_data_cache = download_file(
@@ -116,16 +116,13 @@ def _atom_data(request):
         os.path.join(atom_data_extract_tempdir, atom_data_name)
     )
 
+    if atom_data.md5 != '21095dd25faa1683f4c90c911a00c3f8':
+        pytest.skip('Need default Kurucz atomic dataset '
+                    '(md5="21095dd25faa1683f4c90c911a00c3f8"')
+
     def fin():
         # Delete the tempdir as no longer required.
         shutil.rmtree(atom_data_extract_tempdir)
     request.addfinalizer(fin)
+
     return atom_data
-
-
-@pytest.fixture(scope="class")
-def atom_data(_atom_data):
-    if _atom_data.md5 != '21095dd25faa1683f4c90c911a00c3f8':
-        pytest.skip('Need default Kurucz atomic dataset '
-                    '(md5="21095dd25faa1683f4c90c911a00c3f8"')
-    return copy.deepcopy(_atom_data)

--- a/tardis/plasma/tests/test_plasmas_full.py
+++ b/tardis/plasma/tests/test_plasmas_full.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import h5py
@@ -35,14 +36,14 @@ class TestPlasmas(object):
     def setup(self, atom_data):
         self.lte_config = Configuration.from_yaml(
             'tardis/plasma/tests/data/plasma_test_config_lte.yml',
-            atom_data=atom_data
+            atom_data=copy.deepcopy(atom_data)
         )
         self.lte_model = Radial1DModel(self.lte_config)
         run_radial1d(self.lte_model)
 
         self.nlte_config = Configuration.from_yaml(
             'tardis/plasma/tests/data/plasma_test_config_nlte.yml',
-            atom_data=atom_data
+            atom_data=copy.deepcopy(atom_data)
         )
         self.nlte_model = Radial1DModel(self.nlte_config)
         run_radial1d(self.nlte_model)

--- a/tardis/plasma/tests/test_plasmas_full.py
+++ b/tardis/plasma/tests/test_plasmas_full.py
@@ -1,46 +1,51 @@
-import pytest
-import numpy as np
-import tardis
-import numpy.testing as nptesting
-from astropy import units as u
 import os
-import h5py
 
-from tardis.base import run_tardis
-from tardis.io.util import yaml_load_config_file
+import h5py
+import numpy as np
+import numpy.testing as nptesting
+import pytest
+
+from astropy import units as u
+from astropy.tests.helper import remote_data
+
+import tardis
+from tardis.model import Radial1DModel
+from tardis.io.config_reader import Configuration
+from tardis.simulation.base import run_radial1d
 
 
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'plasma', 'tests', 'data', fname)
 
-@pytest.fixture()
+
+@pytest.fixture
 def plasma_compare_data_fname():
     return data_path('plasma_test_data.h5')
 
-@pytest.fixture()
+
+@pytest.fixture
 def plasma_compare_data(plasma_compare_data_fname):
     return h5py.File(plasma_compare_data_fname, 'r')
 
-@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
-                    reason='--atomic_database was not specified')
-class TestPlasmas():
+
+@remote_data
+class TestPlasmas(object):
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self):
-        self.atom_data_filename = os.path.expanduser(os.path.expandvars(
-            pytest.config.getvalue('atomic-dataset')))
-        assert os.path.exists(self.atom_data_filename), ("{0} atomic datafiles"
-                                                         " does not seem to "
-                                                         "exist".format(
-            self.atom_data_filename))
-        self.config_yaml = yaml_load_config_file(
-            'tardis/plasma/tests/data/plasma_test_config_lte.yml')
-        self.config_yaml['atom_data'] = self.atom_data_filename
-        self.lte_model = run_tardis(self.config_yaml)
-        self.config_yaml = yaml_load_config_file(
-            'tardis/plasma/tests/data/plasma_test_config_nlte.yml')
-        self.config_yaml['atom_data'] = self.atom_data_filename
-        self.nlte_model = run_tardis(self.config_yaml)
+    def setup(self, atom_data):
+        self.lte_config = Configuration.from_yaml(
+            'tardis/plasma/tests/data/plasma_test_config_lte.yml',
+            atom_data=atom_data
+        )
+        self.lte_model = Radial1DModel(self.lte_config)
+        run_radial1d(self.lte_model)
+
+        self.nlte_config = Configuration.from_yaml(
+            'tardis/plasma/tests/data/plasma_test_config_nlte.yml',
+            atom_data=atom_data
+        )
+        self.nlte_model = Radial1DModel(self.nlte_config)
+        run_radial1d(self.nlte_model)
 
     def test_lte_plasma(self, plasma_compare_data):
         old_plasma_t_rads = plasma_compare_data['test_lte1/t_rad']

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -9,11 +9,10 @@ from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose, remote_data
 
 
-@remote_data
 @pytest.fixture
-def tardis_config(kurucz_atomic_data, tardis_config_verysimple):
+def tardis_config(atom_data, tardis_config_verysimple):
     return Configuration.from_config_dict(
-        tardis_config_verysimple, atom_data=kurucz_atomic_data
+        tardis_config_verysimple, atom_data=atom_data
     )
 
 
@@ -40,6 +39,7 @@ def simulation_compare_data(simulation_compare_data_fname):
     return h5py.File(simulation_compare_data_fname, mode='r')
 
 
+@remote_data
 def test_plasma_estimates(simulation_one_loop, simulation_compare_data):
     t_rad, w = simulation_one_loop.runner.calculate_radiationfield_properties()
 
@@ -55,6 +55,7 @@ def test_plasma_estimates(simulation_one_loop, simulation_compare_data):
     npt.assert_allclose(w, simulation_compare_data['test1/w'], atol=0.0)
 
 
+@remote_data
 def test_packet_output(simulation_one_loop, simulation_compare_data):
     assert_quantity_allclose(
             simulation_one_loop.runner.output_nu,

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -2,16 +2,19 @@ import numpy.testing as npt
 
 import h5py
 import pytest
-from tardis.io import config_reader
+from tardis.io.config_reader import Configuration
 from tardis.model import Radial1DModel
 from tardis.simulation import Simulation
 from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose, remote_data
 
+
+@remote_data
 @pytest.fixture
 def tardis_config(kurucz_atomic_data, tardis_config_verysimple):
-    return config_reader.Configuration.from_config_dict(
-        tardis_config_verysimple, atom_data=kurucz_atomic_data)
+    return Configuration.from_config_dict(
+        tardis_config_verysimple, atom_data=kurucz_atomic_data
+    )
 
 
 @pytest.fixture()

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -13,19 +13,11 @@ from tardis.simulation import Simulation
 
 
 @pytest.fixture
-def tardis_config(atom_data, tardis_config_verysimple):
-    return Configuration.from_config_dict(
+def simulation_one_loop(atom_data, tardis_config_verysimple):
+    tardis_config = Configuration.from_yaml(
         tardis_config_verysimple, atom_data=copy.deepcopy(atom_data)
     )
-
-
-@pytest.fixture()
-def raw_model(tardis_config):
-    return Radial1DModel(tardis_config)
-
-
-@pytest.fixture()
-def simulation_one_loop(raw_model, tardis_config):
+    raw_model = Radial1DModel(tardis_config)
     sim = Simulation(tardis_config)
     sim.run_single_montecarlo(raw_model, 40000)
 

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -1,18 +1,21 @@
-import numpy.testing as npt
+import copy
 
 import h5py
+import numpy.testing as npt
 import pytest
+
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose, remote_data
+
 from tardis.io.config_reader import Configuration
 from tardis.model import Radial1DModel
 from tardis.simulation import Simulation
-from astropy import units as u
-from astropy.tests.helper import assert_quantity_allclose, remote_data
 
 
 @pytest.fixture
 def tardis_config(atom_data, tardis_config_verysimple):
     return Configuration.from_config_dict(
-        tardis_config_verysimple, atom_data=atom_data
+        tardis_config_verysimple, atom_data=copy.deepcopy(atom_data)
     )
 
 

--- a/tardis/tests/coveragerc
+++ b/tardis/tests/coveragerc
@@ -20,5 +20,5 @@ exclude_lines =
    pragma: py{ignore_python_version}
 
 omit =
-   # Slow Tests should be run but need not appear in "html report"
-   tardis/tests/tests_slow/*
+   # Integration Tests should be run but need not appear in coveralls report
+   tardis/tests/integration_tests/*

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -1,19 +1,24 @@
 import os
-import yaml
+import shutil
+import tempfile
+import zipfile
 
 import pytest
 import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
-from astropy.tests.helper import assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose, remote_data
+from astropy.utils.data import download_file
 
 from tardis.atomic import AtomData
 from tardis.simulation.base import run_radial1d
 from tardis.model import Radial1DModel
 from tardis.io.config_reader import Configuration
+from tardis.io.util import yaml_load_config_file
 
 
 @pytest.mark.skipif(not pytest.config.getvalue("integration-tests"),
                     reason="integration tests are not included in this run")
+@remote_data
 class TestIntegration(object):
     """Slow integration test for various setups present in subdirectories of
     ``tardis/tests/integration_tests``.
@@ -21,7 +26,7 @@ class TestIntegration(object):
 
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self, request, reference, data_path, atomic_data_fname):
+    def setup(self, request, reference, data_path, atom_data_url):
         """
         This method does initial setup of creating configuration and performing
         a single run of integration test.
@@ -30,10 +35,27 @@ class TestIntegration(object):
         self.name = data_path['setup_name']
 
         self.config_file = os.path.join(data_path['config_dirpath'], "config.yml")
-        self.config_dict = yaml.load(self.config_file)
+        self.config_dict = yaml_load_config_file(self.config_file)
+
+        # Download and cache the zip file of atomic data. Name of atom data
+        # file is specified in config file, while url is provided by fixture.
+        atom_data_cache = download_file(
+            atom_data_url[self.config_dict['atom_data']], cache=True
+        )
+
+        # TODO: manipulate less packets in this dict itself after #620 merge
+
+        # Obtained file is a zip file, hence unzipped inside a tempdir.
+        atom_data_zipfile = zipfile.ZipFile(atom_data_cache)
+        atom_data_extract_tempdir = tempfile.mkdtemp()
+        atom_data_zipfile.extract(
+            self.config_dict['atom_data'], path=atom_data_extract_tempdir
+        )
 
         # Load atom data file separately, pass it for forming tardis config.
-        self.atom_data = AtomData.from_hdf5(atomic_data_fname)
+        self.atom_data = AtomData.from_hdf5(
+            os.path.join(atom_data_extract_tempdir, self.config_dict['atom_data'])
+        )
 
         # Check whether the atom data file in current run and the atom data
         # file used in obtaining the reference data are same.
@@ -43,7 +65,7 @@ class TestIntegration(object):
 
         # Create a Configuration through yaml file and atom data.
         tardis_config = Configuration.from_config_dict(
-            self.config_file, atom_data=self.atom_data,
+            self.config_dict, atom_data=self.atom_data,
             config_dirname=data_path['config_dirpath']
         )
 
@@ -76,6 +98,11 @@ class TestIntegration(object):
 
         # Get the reference data through the fixture.
         self.reference = reference
+
+        def fin():
+            # Delete the tempdir as no longer required.
+            shutil.rmtree(atom_data_extract_tempdir)
+        request.addfinalizer(fin)
 
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_j_estimators(self):

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -1,4 +1,6 @@
 import os
+import yaml
+
 import pytest
 import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
@@ -28,6 +30,7 @@ class TestIntegration(object):
         self.name = data_path['setup_name']
 
         self.config_file = os.path.join(data_path['config_dirpath'], "config.yml")
+        self.config_dict = yaml.load(self.config_file)
 
         # Load atom data file separately, pass it for forming tardis config.
         self.atom_data = AtomData.from_hdf5(atomic_data_fname)
@@ -39,8 +42,10 @@ class TestIntegration(object):
         assert self.atom_data.uuid1 == kurucz_data_file_uuid1
 
         # Create a Configuration through yaml file and atom data.
-        tardis_config = Configuration.from_yaml(
-            self.config_file, atom_data=self.atom_data)
+        tardis_config = Configuration.from_config_dict(
+            self.config_file, atom_data=self.atom_data,
+            config_dirname=data_path['config_dirpath']
+        )
 
         # Check whether current run is with less packets.
         if request.config.getoption("--less-packets"):

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -1,24 +1,18 @@
 import os
-import shutil
-import tempfile
-import zipfile
 
 import pytest
 import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose, remote_data
-from astropy.utils.data import download_file
 
-from tardis.atomic import AtomData
 from tardis.simulation.base import run_radial1d
 from tardis.model import Radial1DModel
 from tardis.io.config_reader import Configuration
-from tardis.io.util import yaml_load_config_file
 
 
+@remote_data
 @pytest.mark.skipif(not pytest.config.getvalue("integration-tests"),
                     reason="integration tests are not included in this run")
-@remote_data
 class TestIntegration(object):
     """Slow integration test for various setups present in subdirectories of
     ``tardis/tests/integration_tests``.
@@ -26,7 +20,7 @@ class TestIntegration(object):
 
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self, request, reference, data_path, atom_data_url):
+    def setup(self, request, reference, data_path, atom_data):
         """
         This method does initial setup of creating configuration and performing
         a single run of integration test.
@@ -34,39 +28,16 @@ class TestIntegration(object):
         # The last component in dirpath can be extracted as name of setup.
         self.name = data_path['setup_name']
 
-        self.config_file = os.path.join(data_path['config_dirpath'], "config.yml")
-        self.config_dict = yaml_load_config_file(self.config_file)
-
-        # Download and cache the zip file of atomic data. Name of atom data
-        # file is specified in config file, while url is provided by fixture.
-        atom_data_cache = download_file(
-            atom_data_url[self.config_dict['atom_data']], cache=True
-        )
-
-        # TODO: manipulate less packets in this dict itself after #620 merge
-
-        # Obtained file is a zip file, hence unzipped inside a tempdir.
-        atom_data_zipfile = zipfile.ZipFile(atom_data_cache)
-        atom_data_extract_tempdir = tempfile.mkdtemp()
-        atom_data_zipfile.extract(
-            self.config_dict['atom_data'], path=atom_data_extract_tempdir
-        )
-
-        # Load atom data file separately, pass it for forming tardis config.
-        self.atom_data = AtomData.from_hdf5(
-            os.path.join(atom_data_extract_tempdir, self.config_dict['atom_data'])
-        )
-
         # Check whether the atom data file in current run and the atom data
         # file used in obtaining the reference data are same.
         # TODO: hard coded UUID for kurucz atom data file, generalize it later.
         kurucz_data_file_uuid1 = "5ca3035ca8b311e3bb684437e69d75d7"
-        assert self.atom_data.uuid1 == kurucz_data_file_uuid1
+        assert atom_data.uuid1 == kurucz_data_file_uuid1
 
         # Create a Configuration through yaml file and atom data.
-        tardis_config = Configuration.from_config_dict(
-            self.config_dict, atom_data=self.atom_data,
-            config_dirname=data_path['config_dirpath']
+        tardis_config = Configuration.from_yaml(
+            os.path.join(data_path['config_dirpath'], 'config.yml'),
+            atom_data=atom_data
         )
 
         # Check whether current run is with less packets.
@@ -98,11 +69,6 @@ class TestIntegration(object):
 
         # Get the reference data through the fixture.
         self.reference = reference
-
-        def fin():
-            # Delete the tempdir as no longer required.
-            shutil.rmtree(atom_data_extract_tempdir)
-        request.addfinalizer(fin)
 
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_j_estimators(self):

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -1,3 +1,4 @@
+import copy
 import os
 
 import pytest
@@ -37,7 +38,7 @@ class TestIntegration(object):
         # Create a Configuration through yaml file and atom data.
         tardis_config = Configuration.from_yaml(
             os.path.join(data_path['config_dirpath'], 'config.yml'),
-            atom_data=atom_data
+            atom_data=copy.deepcopy(atom_data)
         )
 
         # Check whether current run is with less packets.

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from numpy import testing
+from astropy.tests.helper import remote_data
 from tardis import atomic
 
 
@@ -129,28 +130,20 @@ def test_atom_levels():
     with pytest.raises(Exception):
         raise Exception('test the atom_data thoroughly')
 
+
 def test_atomic_symbol():
     assert atomic.atomic_number2symbol[14] == 'Si'
+
 
 def test_atomic_symbol_reverse():
     assert atomic.symbol2atomic_number['Si'] == 14
 
-@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
-                    reason='--atomic_database was not specified')
-def test_atomic_reprepare():
-    atom_data_filename = os.path.expanduser(os.path.expandvars(
-        pytest.config.getvalue('atomic-dataset')))
-    assert os.path.exists(atom_data_filename), ("{0} atomic datafiles "
-                                                         "does not seem to "
-                                                         "exist".format(
-        atom_data_filename))
-    atom_data = atomic.AtomData.from_hdf5(atom_data_filename)
-    atom_data.prepare_atom_data([14])
+
+@remote_data
+@pytest.mark.parametrize(['selected_atomic_numbers'], [[14], [20]])
+def test_atomic_reprepare(atom_data, selected_atomic_numbers):
+    atom_data.prepare_atom_data(selected_atomic_numbers)
     assert len(atom_data.lines) > 0
-    # Fix for new behavior of prepare_atom_data
+    # FIXME: (new behavior of prepare_atom_data)
     # Consider doing only one prepare_atom_data and check
     # len(atom_data.lines) == N where N is known
-    atom_data = atomic.AtomData.from_hdf5(atom_data_filename)
-    atom_data.prepare_atom_data([20])
-    assert len(atom_data.lines) > 0
-

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -142,7 +142,7 @@ def test_atomic_symbol_reverse():
 @remote_data
 @pytest.mark.parametrize(['selected_atomic_numbers'], [[14], [20]])
 def test_atomic_reprepare(atom_data, selected_atomic_numbers):
-    atom_data.prepare_atom_data(selected_atomic_numbers)
+    atom_data.prepare_atom_data([selected_atomic_numbers])
     assert len(atom_data.lines) > 0
     # FIXME: (new behavior of prepare_atom_data)
     # Consider doing only one prepare_atom_data and check

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import pytest
 from numpy import testing
@@ -142,7 +143,8 @@ def test_atomic_symbol_reverse():
 @remote_data
 @pytest.mark.parametrize(['selected_atomic_numbers'], [[14], [20]])
 def test_atomic_reprepare(atom_data, selected_atomic_numbers):
-    atom_data.prepare_atom_data([selected_atomic_numbers])
+    atom_data_copy = copy.deepcopy(atom_data)
+    atom_data_copy.prepare_atom_data([selected_atomic_numbers])
     assert len(atom_data.lines) > 0
     # FIXME: (new behavior of prepare_atom_data)
     # Consider doing only one prepare_atom_data and check

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -26,7 +26,7 @@ class TestSimpleRun(object):
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, tardis_config_verysimple, atom_data):
-        tardis_config = Configuration.from_yaml(
+        tardis_config = Configuration.from_config_dict(
             tardis_config_verysimple, atom_data=atom_data
         )
         self.model = Radial1DModel(tardis_config)

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -27,7 +27,7 @@ class TestSimpleRun(object):
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, tardis_config_verysimple, atom_data):
-        tardis_config = Configuration.from_config_dict(
+        tardis_config = Configuration.from_yaml(
             tardis_config_verysimple, atom_data=copy.deepcopy(atom_data)
         )
         self.model = Radial1DModel(tardis_config)

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import pytest
 import numpy as np
@@ -27,7 +28,7 @@ class TestSimpleRun(object):
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, tardis_config_verysimple, atom_data):
         tardis_config = Configuration.from_config_dict(
-            tardis_config_verysimple, atom_data=atom_data
+            tardis_config_verysimple, atom_data=copy.deepcopy(atom_data)
         )
         self.model = Radial1DModel(tardis_config)
         run_radial1d(self.model)


### PR DESCRIPTION
This PR makes changes with mechanism of making use of atomic dataset. Initially an atomic dataset had to be kept separately and provided through command line, but with the merge of this PR, it will be automatically downloaded, cached and used. The command line argument `--atomic-dataset` has been replaced by a flag `--remote-data`.

- [X] A session scoped fixture named `_atom_data` is made in top level **conftest.py**, which will download and cache atom data (currently only `kurucz_cd23_chianti_H_He.h5.zip`).
- [X] A fixture named `atom_data` is made alongwith it, to return a copy of this `AtomData` object returned by `_atom_data` fixture, to avoid re prepare.
- [X] Old fixtures in **conftest.py** have been removed and other tests have been modified to use this structure henceforth.
- [X] Suitable changes have been made in **.travis.yml** as well. Manually `wget` and `unzip` commands of atomic dataset file have been removed.

[Latest Report](http://opensupernova.org/~karandesai96/integration/doku.php?id=reports:c0cf29d)