### PR TITLE
Revert "Add exponent as a property for exponential density"

### DIFF
--- a/tardis/io/schemas/model.yml
+++ b/tardis/io/schemas/model.yml
@@ -47,14 +47,10 @@ definitions:
         v_0:
           type: quantity
           description: at what velocity the density rho_0 applies
-        exponent:
-          type: number
-          description: exponent for exponential density profile
       required:
       - time_0
       - rho_0
       - v_0
-      - exponent
     power_law:
       type: object
       additionalProperties: false


### PR DESCRIPTION
This reverts commit https://github.com/tardis-sn/tardis/pull/549/commits/58c92586638bae5e2af8191703a491d9a469b3df and the merge of https://github.com/tardis-sn/tardis/pull/571, in which `exponent` was mistakenly added as a (mandatory) property of the exponential density schema.

In the code, it turns out that the `exponent` value is never used in `calculate_exponential_density`, so I'm reverting this change with this PR.