### PR TITLE
Remove exponent property from yaml files with exponential density

### DIFF
--- a/docs/examples/tardis_configv1_density_exponential_example.yml
+++ b/docs/examples/tardis_configv1_density_exponential_example.yml
@@ -14,4 +14,3 @@ model:
             time_0: 2. day
             rho_0: 6.e-10 g/cm^3
             v_0: 3000.  km/s
-            exponent: 1.0

--- a/tardis/io/tests/data/tardis_configv1_density_exponential_test.yml
+++ b/tardis/io/tests/data/tardis_configv1_density_exponential_test.yml
@@ -22,7 +22,6 @@ model:
             time_0: 2. day
             rho_0: 6.e-10 g/cm^3
             v_0: 3000.  km/s
-            exponent: 1.0
             
 
     abundances:


### PR DESCRIPTION
There were two YAML configuration files which had an `exponential` density type and were providing an `exponent` property. The `exponent` property is only used in `power_law` density type.

Because the old configuration validator didn't complain if it found additional properties, this had gone unnoticed.

This is relevant to #626.