### PR TITLE
Create an overview page on Dokuwiki.

### DIFF
--- a/tardis/tests/integration_tests/report.py
+++ b/tardis/tests/integration_tests/report.py
@@ -71,7 +71,7 @@ class DokuReport(HTMLReport):
             self.dokuwiki_url = dokuwiki_details["url"]
 
     def pytest_sessionstart(self, session):
-        self.suite_start_datetime = datetime.datetime.now().strftime('%d %b %H:%M:%S')
+        self.suite_start_datetime = datetime.datetime.utcnow().strftime('%d %b %H:%M:%S')
         super(DokuReport, self).pytest_sessionstart(session)
 
     def _generate_report(self, session):
@@ -79,7 +79,7 @@ class DokuReport(HTMLReport):
         suite_stop_time = time.time()
         self.suite_time_delta = suite_stop_time - self.suite_start_time
         numtests = self.passed + self.failed + self.xpassed + self.xfailed
-        generated = datetime.datetime.now()
+        generated = datetime.datetime.utcnow()
 
         style_css = pkg_resources.resource_string(
             pytest_html_path, os.path.join('resources', 'style.css'))
@@ -189,21 +189,21 @@ class DokuReport(HTMLReport):
         gh_commit_message = gh_commit_data['message'].split('\n')[0]
 
         # Truncate long commit messages
-        if len(gh_commit_message) > 40:
-            gh_commit_message = "{0}...".format(gh_commit_message[:37])
-        row = "| "
+        if len(gh_commit_message) > 60:
+            gh_commit_message = "{0}...".format(gh_commit_message[:57])
+        row = "|  "
         # Append hash
-        row += "[[reports:{0}|{0}]] | ".format(tardis.__githash__[:7])
+        row += "[[reports:{0}|{0}]]  | ".format(tardis.__githash__[:7])
         # Append commit message
-        row += "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{1}]] | ".format(
+        row += "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{1}]] |  ".format(
             tardis.__githash__, gh_commit_message
         )
         # Append start time
-        row += "{0} | ".format(self.suite_start_datetime)
+        row += "{0}  |  ".format(self.suite_start_datetime)
         # Append time elapsed
-        row += "{0:.2f} sec | ".format(self.suite_time_delta)
+        row += "{0:.2f} sec  |  ".format(self.suite_time_delta)
         # Append status
-        row += "{0} |".format(status)
+        row += "{0}  |\n".format(status)
         try:
             self.doku_conn.pages.append('/', row)
         except (gaierror, TypeError):

--- a/tardis/tests/integration_tests/report.py
+++ b/tardis/tests/integration_tests/report.py
@@ -70,10 +70,6 @@ class DokuReport(HTMLReport):
         else:
             self.dokuwiki_url = dokuwiki_details["url"]
 
-    def pytest_sessionstart(self, session):
-        self.suite_start_datetime = datetime.datetime.utcnow().strftime('%d %b %H:%M:%S')
-        super(DokuReport, self).pytest_sessionstart(session)
-
     def _generate_report(self, session):
         """Writes HTML report to a temporary logfile."""
         suite_stop_time = time.time()
@@ -178,6 +174,8 @@ class DokuReport(HTMLReport):
         else:
             status = "Errored"
 
+        suite_start_datetime = datetime.datetime.utcfromtimestamp(self.suite_start_time)
+
         # Fetch commit message from github.
         gh_request = requests.get(
             "https://api.github.com/repos/tardis-sn/tardis/git/commits/{0}".format(
@@ -199,7 +197,7 @@ class DokuReport(HTMLReport):
             tardis.__githash__, gh_commit_message
         )
         # Append start time
-        row += "{0}  |  ".format(self.suite_start_datetime)
+        row += "{0}  |  ".format(suite_start_datetime.strftime('%d %b %H:%M:%S'))
         # Append time elapsed
         row += "{0:.2f} sec  |  ".format(self.suite_time_delta)
         # Append status


### PR DESCRIPTION
This PR introduces maintenance of an overview page on our Integration Tests Dokuwiki. It is selected as the [landing page](http://opensupernova.org/~karandesai96/integration/doku.php?id=start) of the wiki.
Each time a report it uploaded n Wiki, its information in appended on this page.
Information includes commit hash, commit message description, start time in UTC, time elapsed, and status of test run (pass / fail / error).