### PR TITLE
Addition of new assertion methods in TestIntegration class.

### DIFF
--- a/tardis/model.py
+++ b/tardis/model.py
@@ -276,7 +276,7 @@ class Radial1DModel(object):
         model_path = os.path.join(path, 'model')
         properties = [
             'last_line_interaction_in_id', 'last_line_interaction_out_id',
-            'last_line_interaction_shell_id', 'line_line_interaction_angstrom',
+            'last_line_interaction_shell_id', 'last_line_interaction_angstrom',
             't_inner', 'ws', 't_rads', 'v_inner', 'v_outer', 'luminosity_inner',
             'j_blues', 'j_blue_estimators', 'j_blues_norm_factor',
             'montecarlo_luminosity', 'montecarlo_nu'

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -274,8 +274,12 @@ class Radial1DModel(object):
 
         """
         model_path = os.path.join(path, 'model')
-        properties = ['t_inner', 'ws', 't_rads', 'v_inner', 'v_outer',
-                      'montecarlo_luminosity', 'montecarlo_nu']
+        properties = [
+            'last_line_interaction_in_id', 'last_line_interaction_out_id',
+            'last_line_interaction_shell_id', 'line_line_interaction_angstrom',
+            't_inner', 'ws', 't_rads', 'v_inner', 'v_outer',
+            'montecarlo_luminosity', 'montecarlo_nu'
+        ]
         to_hdf(path_or_buf, model_path, {name: getattr(self, name) for name
                                          in properties})
 

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -278,6 +278,7 @@ class Radial1DModel(object):
             'last_line_interaction_in_id', 'last_line_interaction_out_id',
             'last_line_interaction_shell_id', 'line_line_interaction_angstrom',
             't_inner', 'ws', 't_rads', 'v_inner', 'v_outer',
+            'j_blues', 'j_blue_estimators', 'j_blues_norm_factor',
             'montecarlo_luminosity', 'montecarlo_nu'
         ]
         to_hdf(path_or_buf, model_path, {name: getattr(self, name) for name

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -274,7 +274,8 @@ class Radial1DModel(object):
 
         """
         model_path = os.path.join(path, 'model')
-        properties = ['t_inner', 'ws', 't_rads', 'v_inner', 'v_outer']
+        properties = ['t_inner', 'ws', 't_rads', 'v_inner', 'v_outer',
+                      'montecarlo_luminosity', 'montecarlo_nu']
         to_hdf(path_or_buf, model_path, {name: getattr(self, name) for name
                                          in properties})
 

--- a/tardis/model.py
+++ b/tardis/model.py
@@ -277,7 +277,7 @@ class Radial1DModel(object):
         properties = [
             'last_line_interaction_in_id', 'last_line_interaction_out_id',
             'last_line_interaction_shell_id', 'line_line_interaction_angstrom',
-            't_inner', 'ws', 't_rads', 'v_inner', 'v_outer',
+            't_inner', 'ws', 't_rads', 'v_inner', 'v_outer', 'luminosity_inner',
             'j_blues', 'j_blue_estimators', 'j_blues_norm_factor',
             'montecarlo_luminosity', 'montecarlo_nu'
         ]

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -300,7 +300,7 @@ class MontecarloRunner(object):
         """
         runner_path = os.path.join(path, 'runner')
         properties = ['output_nu', 'output_energy', 'nu_bar_estimator',
-                      'j_estimator']
+                      'j_estimator', 'montecarlo_virtual_luminosity']
         to_hdf(path_or_buf, runner_path, {name: getattr(self, name) for name
                                           in properties})
         self.spectrum.to_hdf(path_or_buf, runner_path)

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -102,11 +102,60 @@ class TestIntegration(object):
             self.result.plasma.transition_probabilities
         )
 
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_j_estimators(self):
+    def test_t_rads(self, plot_object):
+        plot_object.add(self.plot_t_rads(), "{0}_t_rads".format(self.name))
+
         assert_allclose(
-                self.reference['j_estimators'],
-                self.result.j_estimators)
+            self.reference['/simulation/model/t_rads'],
+            self.result.t_rads.cgs.value
+        )
+
+    def plot_t_rads(self):
+        plt.suptitle("Shell temperature for packets", fontweight="bold")
+        figure = plt.figure()
+
+        ax = figure.add_subplot(111)
+        ax.set_xlabel("Shell id")
+        ax.set_ylabel("t_rads")
+
+        result_line = ax.plot(
+            self.result.t_rads.cgs, color="blue", marker=".", label="Result"
+        )
+        reference_line = ax.plot(
+            self.reference['/simulation/model/t_rads'],
+            color="green", marker=".", label="Reference"
+        )
+
+        error_ax = ax.twinx()
+        error_line = error_ax.plot(
+            (1 - self.result.t_rads.cgs.value / self.reference['/simulation/model/t_rads']),
+            color="red", marker=".", label="Rel. Error"
+        )
+        error_ax.set_ylabel("Relative error (1 - result / reference)")
+
+        lines = result_line + reference_line + error_line
+        labels = [l.get_label() for l in lines]
+
+        ax.legend(lines, labels, loc="lower left")
+        return figure
+
+    def test_ws(self):
+        assert_allclose(
+            self.reference['simulation/model/ws'],
+            self.result.ws
+        )
+
+    def test_j_estimator(self):
+        assert_allclose(
+            self.reference['/simulation/runner/j_estimator'],
+            self.result.runner.j_estimator
+        )
+
+    def test_nu_bar_estimator(self):
+        assert_allclose(
+            self.reference['/simulation/runner/nu_bar_estimator'],
+            self.result.runner.nu_bar_estimator
+        )
 
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_j_blue_estimators(self):
@@ -135,18 +184,6 @@ class TestIntegration(object):
         assert_quantity_allclose(
                 self.reference['last_line_interaction_angstrom'],
                 self.result.last_line_interaction_angstrom)
-
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_nubar_estimators(self):
-        assert_allclose(
-                self.reference['nubar_estimators'],
-                self.result.nubar_estimators)
-
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_ws(self):
-        assert_allclose(
-                self.reference['ws'],
-                self.result.ws)
 
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_luminosity_inner(self):
@@ -203,39 +240,3 @@ class TestIntegration(object):
         assert_quantity_allclose(
                 self.reference['montecarlo_nu'],
                 self.result.montecarlo_nu)
-
-    def test_shell_temperature(self, plot_object):
-        plot_object.add(self.plot_t_rads(), "{0}_t_rads".format(self.name))
-
-        assert_allclose(
-            self.reference['/simulation/model/t_rads'],
-            self.result.t_rads.cgs.value)
-
-    def plot_t_rads(self):
-        plt.suptitle("Shell temperature for packets", fontweight="bold")
-        figure = plt.figure()
-
-        ax = figure.add_subplot(111)
-        ax.set_xlabel("Shell id")
-        ax.set_ylabel("t_rads")
-
-        result_line = ax.plot(
-            self.result.t_rads.cgs, color="blue", marker=".", label="Result"
-        )
-        reference_line = ax.plot(
-            self.reference['/simulation/model/t_rads'],
-            color="green", marker=".", label="Reference"
-        )
-
-        error_ax = ax.twinx()
-        error_line = error_ax.plot(
-            (1 - self.result.t_rads.cgs.value / self.reference['/simulation/model/t_rads']),
-            color="red", marker=".", label="Rel. Error"
-        )
-        error_ax.set_ylabel("Relative error (1 - result / reference)")
-
-        lines = result_line + reference_line + error_line
-        labels = [l.get_label() for l in lines]
-
-        ax.legend(lines, labels, loc="lower left")
-        return figure

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -114,6 +114,12 @@ class TestIntegration(object):
             self.result.j_blues_norm_factor
         )
 
+    def test_luminosity_inner(self):
+        assert_quantity_allclose(
+            self.reference['/simulation/model/luminosity_inner'],
+            self.result.luminosity_inner.cgs.value
+        )
+
     def test_montecarlo_luminosity(self):
         assert_allclose(
             self.reference['/simulation/model/montecarlo_luminosity'],
@@ -216,12 +222,6 @@ class TestIntegration(object):
             self.reference['/simulation/runner/nu_bar_estimator'],
             self.result.runner.nu_bar_estimator
         )
-
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_luminosity_inner(self):
-        assert_quantity_allclose(
-                self.reference['luminosity_inner'],
-                self.result.luminosity_inner)
 
     def test_spectrum(self, plot_object):
         plot_object.add(self.plot_spectrum(), "{0}_spectrum".format(self.name))

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -116,7 +116,7 @@ class TestIntegration(object):
 
     def test_luminosity_inner(self):
         assert_quantity_allclose(
-            self.reference['/simulation/model/luminosity_inner'],
+            self.reference['/simulation/model/scalars']['luminosity_inner'],
             self.result.luminosity_inner.cgs.value
         )
 

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -72,6 +72,36 @@ class TestIntegration(object):
         # Get the reference data through the fixture.
         self.reference = reference
 
+    def test_plasma_ion_number_density(self):
+        assert_allclose(
+            self.reference['/simulation/model/plasma/ion_number_density'],
+            self.result.plasma.ion_number_density
+        )
+
+    def test_plasma_level_number_density(self):
+        assert_allclose(
+            self.reference['/simulation/model/plasma/level_number_density'],
+            self.result.plasma.level_number_density
+        )
+
+    def test_plasma_electron_densities(self):
+        assert_allclose(
+            self.reference['/simulation/model/plasma/electron_densities'],
+            self.result.plasma.electron_densities
+        )
+
+    def test_plasma_tau_sobolevs(self):
+        assert_allclose(
+            self.reference['/simulation/model/plasma/tau_sobolevs'],
+            self.result.plasma.tau_sobolevs
+        )
+
+    def test_plasma_transition_probabilities(self):
+        assert_allclose(
+            self.reference['/simulation/model/plasma/transition_probabilities'],
+            self.result.plasma.transition_probabilities
+        )
+
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_j_estimators(self):
         assert_allclose(

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -72,6 +72,30 @@ class TestIntegration(object):
         # Get the reference data through the fixture.
         self.reference = reference
 
+    def test_last_line_interaction_in_id(self):
+        assert_allclose(
+            self.reference['/simulation/model/last_line_interaction_in_id'],
+            self.result.last_line_interaction_in_id
+        )
+
+    def test_last_line_interaction_out_id(self):
+        assert_allclose(
+            self.reference['/simulation/model/last_line_interaction_out_id'],
+            self.result.last_line_interaction_out_id
+        )
+
+    def test_last_line_interaction_shell_id(self):
+        assert_allclose(
+            self.reference['/simulation/model/last_line_interaction_shell_id'],
+            self.result.last_line_interaction_shell_id
+        )
+
+    def test_last_line_interaction_angstrom(self):
+        assert_allclose(
+            self.reference['/simulation/model/last_line_interaction_angstrom'],
+            self.result.last_line_interaction_angstrom.cgs.value
+        )
+
     def test_plasma_ion_number_density(self):
         assert_allclose(
             self.reference['/simulation/model/plasma/ion_number_density'],
@@ -168,24 +192,6 @@ class TestIntegration(object):
                 self.result.j_blues_norm_factor)
 
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_last_line_interactions(self):
-        assert_allclose(
-                self.reference['last_line_interaction_in_id'],
-                self.result.last_line_interaction_in_id)
-
-        assert_allclose(
-                self.reference['last_line_interaction_out_id'],
-                self.result.last_line_interaction_out_id)
-
-        assert_allclose(
-                self.reference['last_line_interaction_shell_id'],
-                self.result.last_line_interaction_shell_id)
-
-        assert_quantity_allclose(
-                self.reference['last_line_interaction_angstrom'],
-                self.result.last_line_interaction_angstrom)
-
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_luminosity_inner(self):
         assert_quantity_allclose(
                 self.reference['luminosity_inner'],
@@ -242,5 +248,5 @@ class TestIntegration(object):
     def test_montecarlo_nu(self):
         assert_allclose(
             self.reference['/simulation/model/montecarlo_nu'],
-            self.result.montecarlo_nu
+            self.result.montecarlo_nu.cgs.value
         )

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -96,6 +96,42 @@ class TestIntegration(object):
             self.result.last_line_interaction_angstrom.cgs.value
         )
 
+    def test_j_blues(self):
+        assert_allclose(
+            self.reference['/simulation/model/j_blues'],
+            self.result.j_blues
+        )
+
+    def test_j_blue_estimators(self):
+        assert_allclose(
+            self.reference['/simulation/model/j_blue_estimators'],
+            self.result.j_blue_estimators
+        )
+
+    def j_blues_norm_factor(self):
+        assert_quantity_allclose(
+            self.reference['/simulation/model/j_blues_norm_factor'],
+            self.result.j_blues_norm_factor
+        )
+
+    def test_montecarlo_luminosity(self):
+        assert_allclose(
+            self.reference['/simulation/model/montecarlo_luminosity'],
+            self.result.montecarlo_luminosity.cgs.value
+        )
+
+    def test_montecarlo_virtual_luminosity(self):
+        assert_allclose(
+            self.reference['/simulation/runner/montecarlo_virtual_luminosity'],
+            self.result.runner.montecarlo_virtual_luminosity.cgs.value
+        )
+
+    def test_montecarlo_nu(self):
+        assert_allclose(
+            self.reference['/simulation/model/montecarlo_nu'],
+            self.result.montecarlo_nu.cgs.value
+        )
+
     def test_plasma_ion_number_density(self):
         assert_allclose(
             self.reference['/simulation/model/plasma/ion_number_density'],
@@ -182,16 +218,6 @@ class TestIntegration(object):
         )
 
     @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_j_blue_estimators(self):
-        assert_allclose(
-                self.reference['j_blue_estimators'],
-                self.result.j_blue_estimators)
-
-        assert_quantity_allclose(
-                self.reference['j_blues_norm_factor'],
-                self.result.j_blues_norm_factor)
-
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
     def test_luminosity_inner(self):
         assert_quantity_allclose(
                 self.reference['luminosity_inner'],
@@ -232,21 +258,3 @@ class TestIntegration(object):
             color="blue", marker="."
         )
         return figure
-
-    def test_montecarlo_luminosity(self):
-        assert_allclose(
-            self.reference['/simulation/model/montecarlo_luminosity'],
-            self.result.montecarlo_luminosity.cgs.value
-        )
-
-    def test_montecarlo_virtual_luminosity(self):
-        assert_allclose(
-            self.reference['/simulation/runner/montecarlo_virtual_luminosity'],
-            self.result.runner.montecarlo_virtual_luminosity.cgs.value
-        )
-
-    def test_montecarlo_nu(self):
-        assert_allclose(
-            self.reference['/simulation/model/montecarlo_nu'],
-            self.result.montecarlo_nu.cgs.value
-        )

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -141,7 +141,7 @@ class TestIntegration(object):
 
     def test_ws(self):
         assert_allclose(
-            self.reference['simulation/model/ws'],
+            self.reference['/simulation/model/ws'],
             self.result.ws
         )
 
@@ -227,16 +227,20 @@ class TestIntegration(object):
         )
         return figure
 
-    @pytest.mark.skipif(True, reason="Introduction of HDF mechanism.")
-    def test_montecarlo_properties(self):
-        assert_quantity_allclose(
-                self.reference['montecarlo_luminosity'],
-                self.result.montecarlo_luminosity)
+    def test_montecarlo_luminosity(self):
+        assert_allclose(
+            self.reference['/simulation/model/montecarlo_luminosity'],
+            self.result.montecarlo_luminosity.cgs.value
+        )
 
-        assert_quantity_allclose(
-                self.reference['montecarlo_virtual_luminosity'],
-                self.result.runner.montecarlo_virtual_luminosity)
+    def test_montecarlo_virtual_luminosity(self):
+        assert_allclose(
+            self.reference['/simulation/runner/montecarlo_virtual_luminosity'],
+            self.result.runner.montecarlo_virtual_luminosity.cgs.value
+        )
 
-        assert_quantity_allclose(
-                self.reference['montecarlo_nu'],
-                self.result.montecarlo_nu)
+    def test_montecarlo_nu(self):
+        assert_allclose(
+            self.reference['/simulation/model/montecarlo_nu'],
+            self.result.montecarlo_nu
+        )


### PR DESCRIPTION
This PR tests certain properties from the model:
- /simulation/model/plasma/ion_number_density
- /simulation/model/plasma/level_number_density
- /simulation/model/plasma/electron_densities
- /simulation/model/plasma/tau_sobolevs
- /simulation/model/plasma/transition_probabilities
- /simulation/model/t_rads
- /simulation/model/ws
- /simulation/runner/j_estimator
- /simulation/runner/nu_bar_estimator

Assertions were not added / skipped earlier due to ongoing restructure as well as prototyping small scale implementation.

[Latest Report](http://opensupernova.org/~karandesai96/integration/doku.php?id=reports:a2fda76)
