### PR TITLE
Replace LegacyPlasmaArray with a function

### DIFF
--- a/tardis/model.py
+++ b/tardis/model.py
@@ -11,7 +11,7 @@ from astropy.utils.decorators import deprecated
 from tardis.io.util import to_hdf
 from util import intensity_black_body
 
-from tardis.plasma.standard_plasmas import LegacyPlasmaArray
+from tardis.plasma.standard_plasmas import assemble_plasma
 
 logger = logging.getLogger(__name__)
 
@@ -108,19 +108,7 @@ class Radial1DModel(object):
         heating_rate_data_file = getattr(
             tardis_config.plasma, 'heating_rate_data_file', None)
 
-        self.plasma = LegacyPlasmaArray(
-            tardis_config.number_densities, tardis_config.atom_data,
-            tardis_config.supernova.time_explosion.to('s').value,
-            nlte_config=tardis_config.plasma.nlte,
-            delta_treatment=tardis_config.plasma.get('delta_treatment', None),
-            ionization_mode=tardis_config.plasma.ionization,
-            excitation_mode=tardis_config.plasma.excitation,
-            line_interaction_type=tardis_config.plasma.line_interaction_type,
-            link_t_rad_t_electron=0.9,
-            helium_treatment=tardis_config.plasma.helium_treatment,
-            heating_rate_data_file=heating_rate_data_file,
-            v_inner=self.v_inner,
-            v_outer=self.v_outer)
+        self.plasma = assemble_plasma(tardis_config, self)
 
         self.calculate_j_blues(init_detailed_j_blues=True)
         self.Edotlu = np.zeros(np.shape(self.j_blues.shape))

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -26,109 +26,76 @@ class LTEPlasma(BasePlasma):
         super(LTEPlasma, self).__init__(plasma_properties=plasma_modules,
             t_rad=t_rad, abundance=abundance, atomic_data=atomic_data,
             density=density, time_explosion=time_explosion, j_blues=j_blues,
-	        w=None, link_t_rad_t_electron=link_t_rad_t_electron,
+            w=None, link_t_rad_t_electron=link_t_rad_t_electron,
             delta_input=delta_treatment, nlte_species=None)
 
-class LegacyPlasmaArray(BasePlasma):
 
-    def from_number_densities(self, number_densities, atomic_data):
-        atomic_mass = atomic_data.atom_data.ix[number_densities.index].mass
-        elemental_density = number_densities.mul(atomic_mass,
-            axis='index')
-        density = elemental_density.sum()
-        abundance = pd.DataFrame(elemental_density/density,
-            index=number_densities.index, columns=number_densities.columns,
-            dtype=np.float64)
-        return abundance, density
+def assemble_plasma(config, model):
+    """
+    Create a BasePlasma instance from a Configuration object
+    and a Radial1DModel.
 
-    def initial_t_rad(self, number_densities):
-        return np.ones(len(number_densities.columns)) * 10000
+    Parameters
+    ----------
+    config: ~io.config_reader.Configuration
+    model: ~model.Radial1DModel
 
-    def initial_w(self, number_densities):
-        return np.ones(len(number_densities.columns)) * 0.5
+    Returns
+    -------
+    : ~plasma.BasePlasma
 
-    def update_radiationfield(self, t_rad, ws, j_blues, nlte_config,
-        t_electrons=None, n_e_convergence_threshold=0.05,
-        initialize_nlte=False):
-        if nlte_config is not None and nlte_config.species:
-            self.store_previous_properties()
-        self.update(t_rad=t_rad, w=ws, j_blues=j_blues)
+    """
 
-    def __init__(self, number_densities, atomic_data, time_explosion,
-        t_rad=None, delta_treatment=None, nlte_config=None,
-        ionization_mode='lte', excitation_mode='lte',
-        line_interaction_type='scatter', link_t_rad_t_electron=0.9,
-        helium_treatment='none', heating_rate_data_file=None,
-        v_inner=None, v_outer=None):
+    plasma_modules = basic_inputs + basic_properties
 
-        plasma_modules = basic_inputs + basic_properties
+    if config.plasma.excitation == 'lte':
+        plasma_modules += lte_excitation_properties
+    elif config.plasma.excitation == 'dilute-lte':
+        plasma_modules += dilute_lte_excitation_properties
 
-        if excitation_mode == 'lte':
-            plasma_modules += lte_excitation_properties
-        elif excitation_mode == 'dilute-lte':
-            plasma_modules += dilute_lte_excitation_properties
-        else:
-            raise NotImplementedError('Sorry {0} not implemented yet.'.format(
-            excitation_mode))
+    if config.plasma.ionization == 'lte':
+        plasma_modules += lte_ionization_properties
+    elif config.plasma.ionization == 'nebular':
+        plasma_modules += nebular_ionization_properties
 
-        if ionization_mode == 'lte':
-            plasma_modules += lte_ionization_properties
-        elif ionization_mode == 'nebular':
-            plasma_modules += nebular_ionization_properties
-        else:
-            raise NotImplementedError('Sorry ' + ionization_mode +
-                ' not implemented yet.')
+    nlte_conf = config.plasma.nlte
+    if nlte_conf.species:
+        plasma_modules += nlte_properties
+    else:
+        plasma_modules += non_nlte_properties
 
-        if nlte_config is not None and nlte_config.species:
-            plasma_modules += nlte_properties
-            if nlte_config.classical_nebular==True and \
-                nlte_config.coronal_approximation==False:
-                LevelBoltzmannFactorNLTE(self, classical_nebular=True)
-            elif nlte_config.coronal_approximation==True and \
-                nlte_config.classical_nebular==False:
-                LevelBoltzmannFactorNLTE(self, coronal_approximation=True)
-            elif nlte_config.coronal_approximation==True and \
-                nlte_config.classical_nebular==True:
-                raise PlasmaConfigError('Both coronal approximation and '
-                                        'classical nebular specified in the '
-                                        'config.')
-        else:
-            plasma_modules += non_nlte_properties
+    if config.plasma.line_interaction_type in ('downbranch', 'macroatom'):
+        plasma_modules += macro_atom_properties
 
-        if line_interaction_type in ('downbranch', 'macroatom'):
-            plasma_modules += macro_atom_properties
+    if config.plasma.helium_treatment == 'recomb-nlte':
+        plasma_modules += helium_nlte_properties
+    elif config.plasma.helium_treatment == 'numerical-nlte':
+        plasma_modules += helium_numerical_nlte_properties
+    else:
+        plasma_modules += helium_lte_properties
 
-        if t_rad is None:
-            t_rad = self.initial_t_rad(number_densities)
+    plasma = BasePlasma(plasma_properties=plasma_modules,
+                        t_rad=model.t_radiative, abundance=model.abundance,
+                        density=model.density, atomic_data=config.atom_data,
+                        time_explosion=model.time_explosion, j_blues=None,
+                        w=model.dilution_factor,
+                        link_t_rad_t_electron=0.9,
+                        heating_rate_data_file=config.plasma.heating_rate_data_file,
+                        helium_treatment=config.plasma.helium_treatment,
+                        v_inner=model.v_inner, v_outer=model.v_outer)
+    plasma.delta_treatment = config.plasma.get('delta_treatment', None)
 
-        w = self.initial_w(number_densities)
+    if nlte_conf.species:
+        plasma.nlte_species = nlte_conf.species
+        if nlte_conf.classical_nebular and not nlte_conf.coronal_approximation:
+            LevelBoltzmannFactorNLTE(plasma, classical_nebular=True)
+        elif nlte_conf.coronal_approximation and not nlte_conf.classical_nebular:
+            LevelBoltzmannFactorNLTE(plasma, coronal_approximation=True)
+        elif nlte_conf.coronal_approximation and nlte_conf.classical_nebular:
+            raise PlasmaConfigError('Both coronal approximation and '
+                                    'classical nebular specified in the '
+                                    'config.')
+    else:
+        plasma.nlte_species = None
 
-        abundance, density = self.from_number_densities(number_densities,
-            atomic_data)
-
-        if nlte_config is not None and nlte_config.species:
-            self.nlte_species = nlte_config.species
-        else:
-            self.nlte_species = None
-
-        if helium_treatment=='recomb-nlte':
-            plasma_modules += helium_nlte_properties
-        elif helium_treatment=='numerical-nlte':
-            plasma_modules += helium_numerical_nlte_properties
-            if heating_rate_data_file is None:
-                raise PlasmaConfigError('Heating rate data file not specified')
-            else:
-                self.heating_rate_data_file = heating_rate_data_file
-                self.v_inner = v_inner
-                self.v_outer = v_outer
-        else:
-            plasma_modules += helium_lte_properties
-
-        self.delta_treatment = delta_treatment
-
-        super(LegacyPlasmaArray, self).__init__(
-            plasma_properties=plasma_modules, t_rad=t_rad,
-            abundance=abundance, density=density,
-            atomic_data=atomic_data, time_explosion=time_explosion,
-            j_blues=None, w=w, link_t_rad_t_electron=link_t_rad_t_electron,
-            helium_treatment=helium_treatment)
+    return plasma


### PR DESCRIPTION
With this PR `LegacyPlasmaArray` is replaced with `assemble_plasma` which takes a `Configuration` object and a `Radial1DModel` (in the form it has in #632) and returns a `BasePlasma` instance.