### PR TITLE
Replace LegacyPlasmaArray with a function

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -957,39 +957,6 @@ class Configuration(ConfigurationNameSpace):
 
 
 
-
-
-        ##### NLTE subsection of Plasma start
-        nlte_validated_config_dict = {}
-        nlte_species = []
-        nlte_section = plasma_section['nlte']
-
-        nlte_species_list = nlte_section.pop('species')
-        for species_string in nlte_species_list:
-            nlte_species.append(species_string_to_tuple(species_string))
-
-        nlte_validated_config_dict['species'] = nlte_species
-        nlte_validated_config_dict['species_string'] = nlte_species_list
-        nlte_validated_config_dict.update(nlte_section)
-
-        if 'coronal_approximation' not in nlte_section:
-            logger.debug('NLTE "coronal_approximation" not specified in NLTE section - defaulting to False')
-            nlte_validated_config_dict['coronal_approximation'] = False
-
-        if 'classical_nebular' not in nlte_section:
-            logger.debug('NLTE "classical_nebular" not specified in NLTE section - defaulting to False')
-            nlte_validated_config_dict['classical_nebular'] = False
-
-
-        elif nlte_section:  #checks that the dictionary is not empty
-            logger.warn('No "species" given - ignoring other NLTE options given:\n%s',
-                        pp.pformat(nlte_section))
-
-        if not nlte_validated_config_dict:
-            nlte_validated_config_dict['species'] = []
-
-        plasma_section['nlte'] = nlte_validated_config_dict
-
         #^^^^^^^^^^^^^^ End of Plasma Section
 
         ##### Monte Carlo Section

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -747,9 +747,7 @@ class Configuration(ConfigurationNameSpace):
             yaml_dict, *args, **kwargs)
 
     @classmethod
-    def from_config_dict(cls, config_dict, atom_data=None, test_parser=False,
-                         validate=True,
-                         config_dirname=''):
+    def from_config_dict(cls, config_dict, validate=True, config_dirname=''):
         """
         Validating and subsequently parsing a config file.
 
@@ -759,14 +757,6 @@ class Configuration(ConfigurationNameSpace):
 
         config_dict : ~dict
             dictionary of a raw unvalidated config file
-
-        atom_data: ~tardis.atomic.AtomData
-            atom data object. if `None` will be tried to be read from
-            atom data file path in the config_dict [default=None]
-
-        test_parser: ~bool
-            switch on to ignore a working atom_data, mainly useful for
-            testing this reader
 
         validate: ~bool
             Turn validation on or off.
@@ -783,26 +773,6 @@ class Configuration(ConfigurationNameSpace):
             validated_config_dict = config_validator.validate_dict(config_dict)
         else:
             validated_config_dict = config_dict
-
-        #First let's see if we can find an atom_db anywhere:
-        if test_parser:
-            atom_data = None
-        elif 'atom_data' in validated_config_dict.keys():
-            if os.path.isabs(validated_config_dict['atom_data']):
-                atom_data_fname = validated_config_dict['atom_data']
-            else:
-                atom_data_fname = os.path.join(config_dirname,
-                                               validated_config_dict['atom_data'])
-            validated_config_dict['atom_data_fname'] = atom_data_fname
-        else:
-            raise ConfigurationError('No atom_data key found in config or command line')
-
-        if atom_data is None and not test_parser:
-            logger.info('Reading Atomic Data from %s', atom_data_fname)
-            atom_data = atomic.AtomData.from_hdf5(atom_data_fname)
-        else:
-            atom_data = atom_data
-
 
 
         #Parsing supernova dictionary
@@ -997,23 +967,8 @@ class Configuration(ConfigurationNameSpace):
         validated_config_dict['spectrum'] = parse_spectrum_list2dict(
             validated_config_dict['spectrum'])
 
-        return cls(validated_config_dict, atom_data)
+        return cls(validated_config_dict)
 
 
-    def __init__(self, config_dict, atom_data):
+    def __init__(self, config_dict):
         super(Configuration, self).__init__(config_dict)
-        self.atom_data = atom_data
-        selected_atomic_numbers = self.abundances.index
-        if atom_data is not None:
-            self.number_densities = (self.abundances * self.structure.mean_densities.to('g/cm^3').value)
-            self.number_densities = self.number_densities.div(self.atom_data.atom_data.mass.ix[selected_atomic_numbers],
-                                                              axis=0)
-        else:
-            logger.critical('atom_data is None, only sensible for testing the parser')
-
-
-
-
-
-
-

--- a/tardis/plasma/properties/plasma_input.py
+++ b/tardis/plasma/properties/plasma_input.py
@@ -1,7 +1,7 @@
 from tardis.plasma.properties.base import (Input, ArrayInput, DataFrameInput)
 
 __all__ = ['TRadiative', 'DilutionFactor', 'AtomicData', 'Abundance', 'Density',
-           'TimeExplosion', 'JBlues', 'JBlueEstimator', 'LinkTRadTElectron',
+           'TimeExplosion', 'JBlueEstimator', 'LinkTRadTElectron',
            'HeliumTreatment']
 
 class TRadiative(ArrayInput):
@@ -71,16 +71,6 @@ class TimeExplosion(Input):
     """
     outputs = ('time_explosion',)
     latex_name = ('t_{\\textrm{exp}}',)
-
-class JBlues(DataFrameInput):
-    """
-    Attributes
-    ----------
-    j_blues : Pandas DataFrame
-              Mean intensity in the blue wing of each line.
-    """
-    outputs = ('j_blues',)
-    latex_name = ('J_{lu}^{b}',)
 
 
 class JBlueEstimator(ArrayInput):

--- a/tardis/plasma/properties/plasma_input.py
+++ b/tardis/plasma/properties/plasma_input.py
@@ -1,7 +1,8 @@
 from tardis.plasma.properties.base import (Input, ArrayInput, DataFrameInput)
 
 __all__ = ['TRadiative', 'DilutionFactor', 'AtomicData', 'Abundance', 'Density',
-           'TimeExplosion', 'JBlues', 'LinkTRadTElectron', 'HeliumTreatment']
+           'TimeExplosion', 'JBlues', 'JBlueEstimator', 'LinkTRadTElectron',
+           'HeliumTreatment']
 
 class TRadiative(ArrayInput):
     """
@@ -80,6 +81,16 @@ class JBlues(DataFrameInput):
     """
     outputs = ('j_blues',)
     latex_name = ('J_{lu}^{b}',)
+
+
+class JBlueEstimator(ArrayInput):
+    """
+    Attributes
+    ----------
+    j_blue_estimators : Numpy array
+    """
+    outputs = ('j_blue_estimators',)
+    latex_name = ('J_{\\textrm{blue-estimator}}',)
 
 class LinkTRadTElectron(Input):
     """

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -4,7 +4,7 @@ class PlasmaPropertyCollection(list):
     pass
 
 basic_inputs = PlasmaPropertyCollection([TRadiative, Abundance, Density,
-    TimeExplosion, AtomicData, JBlues, DilutionFactor, LinkTRadTElectron,
+    TimeExplosion, AtomicData, DilutionFactor, LinkTRadTElectron,
     HeliumTreatment])
 basic_properties = PlasmaPropertyCollection([BetaRadiation,
     Levels, Lines, AtomicMass, PartitionFunction,

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -21,7 +21,7 @@ dilute_lte_excitation_properties = PlasmaPropertyCollection([
     LevelBoltzmannFactorDiluteLTE])
 non_nlte_properties = PlasmaPropertyCollection([LevelBoltzmannFactorNoNLTE])
 nlte_properties = PlasmaPropertyCollection([
-    LevelBoltzmannFactorNLTE, NLTEData, JBluesBlackBody, PreviousElectronDensities,
+    LevelBoltzmannFactorNLTE, NLTEData, PreviousElectronDensities,
     PreviousBetaSobolev, BetaSobolev])
 helium_nlte_properties = PlasmaPropertyCollection([HeliumNLTE,
     RadiationFieldCorrection, ZetaData,

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -21,7 +21,7 @@ dilute_lte_excitation_properties = PlasmaPropertyCollection([
     LevelBoltzmannFactorDiluteLTE])
 non_nlte_properties = PlasmaPropertyCollection([LevelBoltzmannFactorNoNLTE])
 nlte_properties = PlasmaPropertyCollection([
-    LevelBoltzmannFactorNLTE, NLTEData, LTEJBlues, PreviousElectronDensities,
+    LevelBoltzmannFactorNLTE, NLTEData, JBluesBlackBody, PreviousElectronDensities,
     PreviousBetaSobolev, BetaSobolev])
 helium_nlte_properties = PlasmaPropertyCollection([HeliumNLTE,
     RadiationFieldCorrection, ZetaData,

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -239,7 +239,7 @@ class JBluesBlackBody(ProcessingPlasmaProperty):
     lte_j_blues : Pandas DataFrame, dtype float
                   J_blue values as calculated in LTE.
     '''
-    outputs = ('lte_j_blues',)
+    outputs = ('j_blues',)
     latex_name = ('J^{b}_{lu(LTE)}')
 
     @staticmethod

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -243,18 +243,11 @@ class JBluesBlackBody(ProcessingPlasmaProperty):
     latex_name = ('J^{b}_{lu(LTE)}')
 
     @staticmethod
-    def calculate(lines, nu, beta_rad):
-        beta_rad = pd.Series(beta_rad)
-        nu = pd.Series(nu)
-        h = const.h.cgs.value
-        c = const.c.cgs.value
-        df = pd.DataFrame(1, index=nu.index, columns=beta_rad.index)
-        df = df.mul(nu, axis='index') * beta_rad
-        exponential = (np.exp(h * df) - 1)**(-1)
-        remainder = (2 * (h * nu.values ** 3) /
-            (c ** 2))
-        j_blues = exponential.mul(remainder, axis=0)
-        return pd.DataFrame(j_blues, index=lines.index, columns=beta_rad.index)
+    def calculate(lines, nu, t_rad):
+        j_blues = intensity_black_body(nu.values[np.newaxis].T, t_rad)
+        j_blues = pd.DataFrame(j_blues, index=lines.index,
+                               columns=np.arange(len(t_rad)))
+        return np.array(j_blues, copy=False)
 
 
 class JBluesDiluteBlackBody(ProcessingPlasmaProperty):

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -11,7 +11,7 @@ from tardis.plasma.properties.util import macro_atom
 logger = logging.getLogger(__name__)
 
 __all__ = ['StimulatedEmissionFactor', 'TauSobolev', 'BetaSobolev',
-    'TransitionProbabilities', 'LTEJBlues']
+    'TransitionProbabilities', 'JBluesBlackBody']
 
 class StimulatedEmissionFactor(ProcessingPlasmaProperty):
     """
@@ -231,7 +231,7 @@ class TransitionProbabilities(ProcessingPlasmaProperty):
 
 
 
-class LTEJBlues(ProcessingPlasmaProperty):
+class JBluesBlackBody(ProcessingPlasmaProperty):
     '''
     Attributes
     ----------

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -7,6 +7,7 @@ from astropy import units as u, constants as const
 
 from tardis.plasma.properties.base import ProcessingPlasmaProperty
 from tardis.plasma.properties.util import macro_atom
+from tardis.util import intensity_black_body
 
 logger = logging.getLogger(__name__)
 
@@ -261,15 +262,8 @@ class JBluesDiluteBlackBody(ProcessingPlasmaProperty):
     latex_name = ('J_{\\textrm{blue}}')
 
     @staticmethod
-    def calculate(lines, nu, beta_rad, w):
-        beta_rad = pd.Series(beta_rad)
-        nu = pd.Series(nu)
-        h = const.h.cgs.value
-        c = const.c.cgs.value
-        df = pd.DataFrame(1, index=nu.index, columns=beta_rad.index)
-        df = df.mul(nu, axis='index') * beta_rad
-        exponential = (np.exp(h * df) - 1)**(-1)
-        remainder = (2 * (h * nu.values ** 3) /
-            (c ** 2))
-        j_blues = w * exponential.mul(remainder, axis=0)
-        return pd.DataFrame(j_blues, index=lines.index, columns=beta_rad.index)
+    def calculate(lines, nu, t_rad, w):
+        j_blues = w * intensity_black_body(nu.values[np.newaxis].T, t_rad)
+        j_blues = pd.DataFrame(j_blues, index=lines.index,
+                               columns=np.arange(len(t_rad)))
+        return np.array(j_blues, copy=False)

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -11,7 +11,7 @@ from tardis.plasma.properties.util import macro_atom
 logger = logging.getLogger(__name__)
 
 __all__ = ['StimulatedEmissionFactor', 'TauSobolev', 'BetaSobolev',
-    'TransitionProbabilities', 'JBluesBlackBody']
+    'TransitionProbabilities', 'JBluesBlackBody', 'JBluesDiluteBlackBody']
 
 class StimulatedEmissionFactor(ProcessingPlasmaProperty):
     """
@@ -253,4 +253,23 @@ class JBluesBlackBody(ProcessingPlasmaProperty):
         remainder = (2 * (h * nu.values ** 3) /
             (c ** 2))
         j_blues = exponential.mul(remainder, axis=0)
+        return pd.DataFrame(j_blues, index=lines.index, columns=beta_rad.index)
+
+
+class JBluesDiluteBlackBody(ProcessingPlasmaProperty):
+    outputs = ('j_blues',)
+    latex_name = ('J_{\\textrm{blue}}')
+
+    @staticmethod
+    def calculate(lines, nu, beta_rad, w):
+        beta_rad = pd.Series(beta_rad)
+        nu = pd.Series(nu)
+        h = const.h.cgs.value
+        c = const.c.cgs.value
+        df = pd.DataFrame(1, index=nu.index, columns=beta_rad.index)
+        df = df.mul(nu, axis='index') * beta_rad
+        exponential = (np.exp(h * df) - 1)**(-1)
+        remainder = (2 * (h * nu.values ** 3) /
+            (c ** 2))
+        j_blues = w * exponential.mul(remainder, axis=0)
         return pd.DataFrame(j_blues, index=lines.index, columns=beta_rad.index)

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -11,7 +11,8 @@ from tardis.plasma.properties.property_collections import (basic_inputs,
     nlte_properties, helium_nlte_properties, helium_numerical_nlte_properties,
     helium_lte_properties)
 from tardis.plasma.exceptions import PlasmaConfigError
-from tardis.plasma.properties import LevelBoltzmannFactorNLTE
+from tardis.plasma.properties import (LevelBoltzmannFactorNLTE, JBluesBlackBody,
+                                      JBluesDiluteBlackBody)
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +53,19 @@ def assemble_plasma(config, model):
         nlte_species=config.plasma.nlte.species)
     kwargs = dict(t_rad=model.t_radiative, abundance=model.abundance,
                   density=model.density, atomic_data=config.atom_data,
-                  time_explosion=model.time_explosion, j_blues=None,
+                  time_explosion=model.time_explosion,
                   w=model.dilution_factor, link_t_rad_t_electron=0.9)
 
     plasma_modules = basic_inputs + basic_properties
+    if config.plasma.radiative_rates_type == 'blackbody':
+        plasma_modules.append(JBluesBlackBody)
+    elif config.plasma.radiative_rates_type == 'dilute-blackbody':
+        plasma_modules.append(JBluesDiluteBlackBody)
+    elif config.plasma.radiative_rates_type == 'detailed':
+        raise NotImplementedError("Detailed mode not implemented yet.")
+    else:
+        raise ValueError('radiative_rates_type type unknown - %s',
+                         config.plasma.radiative_rates_type)
 
     if config.plasma.excitation == 'lte':
         plasma_modules += lte_excitation_properties

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -51,9 +51,8 @@ def assemble_plasma(config, model):
     nlte_species = [species_string_to_tuple(s) for s in
                     config.plasma.nlte.species]
 
-    selected_atomic_numbers = config.abundances.index
     config.atom_data.prepare_atom_data(
-        selected_atomic_numbers,
+        model.abundance.index,
         line_interaction_type=config.plasma.line_interaction_type,
         nlte_species=nlte_species)
     kwargs = dict(t_rad=model.t_radiative, abundance=model.abundance,

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -45,6 +45,11 @@ def assemble_plasma(config, model):
     : ~plasma.BasePlasma
 
     """
+    selected_atomic_numbers = config.abundances.index
+    config.atom_data.prepare_atom_data(
+        selected_atomic_numbers,
+        line_interaction_type=config.plasma.line_interaction_type,
+        nlte_species=config.plasma.nlte.species)
     kwargs = dict(t_rad=model.t_radiative, abundance=model.abundance,
                   density=model.density, atomic_data=config.atom_data,
                   time_explosion=model.time_explosion, j_blues=None,

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -26,109 +26,81 @@ class LTEPlasma(BasePlasma):
         super(LTEPlasma, self).__init__(plasma_properties=plasma_modules,
             t_rad=t_rad, abundance=abundance, atomic_data=atomic_data,
             density=density, time_explosion=time_explosion, j_blues=j_blues,
-	        w=None, link_t_rad_t_electron=link_t_rad_t_electron,
+            w=None, link_t_rad_t_electron=link_t_rad_t_electron,
             delta_input=delta_treatment, nlte_species=None)
 
-class LegacyPlasmaArray(BasePlasma):
 
-    def from_number_densities(self, number_densities, atomic_data):
-        atomic_mass = atomic_data.atom_data.ix[number_densities.index].mass
-        elemental_density = number_densities.mul(atomic_mass,
-            axis='index')
-        density = elemental_density.sum()
-        abundance = pd.DataFrame(elemental_density/density,
-            index=number_densities.index, columns=number_densities.columns,
-            dtype=np.float64)
-        return abundance, density
+def assemble_plasma(config, model):
+    """
+    Create a BasePlasma instance from a Configuration object
+    and a Radial1DModel.
 
-    def initial_t_rad(self, number_densities):
-        return np.ones(len(number_densities.columns)) * 10000
+    Parameters
+    ----------
+    config: ~io.config_reader.Configuration
+    model: ~model.Radial1DModel
 
-    def initial_w(self, number_densities):
-        return np.ones(len(number_densities.columns)) * 0.5
+    Returns
+    -------
+    : ~plasma.BasePlasma
 
-    def update_radiationfield(self, t_rad, ws, j_blues, nlte_config,
-        t_electrons=None, n_e_convergence_threshold=0.05,
-        initialize_nlte=False):
-        if nlte_config is not None and nlte_config.species:
-            self.store_previous_properties()
-        self.update(t_rad=t_rad, w=ws, j_blues=j_blues)
+    """
+    kwargs = dict(t_rad=model.t_radiative, abundance=model.abundance,
+                  density=model.density, atomic_data=config.atom_data,
+                  time_explosion=model.time_explosion, j_blues=None,
+                  w=model.dilution_factor, link_t_rad_t_electron=0.9)
 
-    def __init__(self, number_densities, atomic_data, time_explosion,
-        t_rad=None, delta_treatment=None, nlte_config=None,
-        ionization_mode='lte', excitation_mode='lte',
-        line_interaction_type='scatter', link_t_rad_t_electron=0.9,
-        helium_treatment='none', heating_rate_data_file=None,
-        v_inner=None, v_outer=None):
+    plasma_modules = basic_inputs + basic_properties
 
-        plasma_modules = basic_inputs + basic_properties
+    if config.plasma.excitation == 'lte':
+        plasma_modules += lte_excitation_properties
+    elif config.plasma.excitation == 'dilute-lte':
+        plasma_modules += dilute_lte_excitation_properties
 
-        if excitation_mode == 'lte':
-            plasma_modules += lte_excitation_properties
-        elif excitation_mode == 'dilute-lte':
-            plasma_modules += dilute_lte_excitation_properties
+    if config.plasma.ionization == 'lte':
+        plasma_modules += lte_ionization_properties
+    elif config.plasma.ionization == 'nebular':
+        plasma_modules += nebular_ionization_properties
+
+    nlte_conf = config.plasma.nlte
+    if nlte_conf.species:
+        plasma_modules += nlte_properties
+        kwargs['nlte_species'] = nlte_conf.species
+        if nlte_conf.classical_nebular and not nlte_conf.coronal_approximation:
+            plasma_modules.append(LevelBoltzmannFactorNLTE)
+            kwargs['classical_nebular'] = True
+        elif nlte_conf.coronal_approximation and not nlte_conf.classical_nebular:
+            plasma_modules.append(LevelBoltzmannFactorNLTE)
+            kwargs['coronal_approximation'] = True
+        elif nlte_conf.coronal_approximation and nlte_conf.classical_nebular:
+            raise PlasmaConfigError('Both coronal approximation and '
+                                    'classical nebular specified in the '
+                                    'config.')
+    else:
+        plasma_modules += non_nlte_properties
+
+    if config.plasma.line_interaction_type in ('downbranch', 'macroatom'):
+        plasma_modules += macro_atom_properties
+
+    if config.plasma.helium_treatment == 'recomb-nlte':
+        plasma_modules += helium_nlte_properties
+    elif config.plasma.helium_treatment == 'numerical-nlte':
+        plasma_modules += helium_numerical_nlte_properties
+        # TODO: See issue #633
+        if config.plasma.heating_rate_data_file in ['none', None]:
+            raise PlasmaConfigError('Heating rate data file not specified')
         else:
-            raise NotImplementedError('Sorry {0} not implemented yet.'.format(
-            excitation_mode))
+            kwargs['heating_rate_data_file'] = \
+                config.plasma.heating_rate_data_file
+            kwargs['v_inner'] = model.v_inner
+            kwargs['v_outer'] = model.v_outer
+    else:
+        plasma_modules += helium_lte_properties
+    kwargs['helium_treatment'] = config.plasma.helium_treatment
 
-        if ionization_mode == 'lte':
-            plasma_modules += lte_ionization_properties
-        elif ionization_mode == 'nebular':
-            plasma_modules += nebular_ionization_properties
-        else:
-            raise NotImplementedError('Sorry ' + ionization_mode +
-                ' not implemented yet.')
+    if 'delta_treatment' in config.plasma:
+        kwargs['delta_treatment'] = config.plasma.delta_treatment
 
-        if nlte_config is not None and nlte_config.species:
-            plasma_modules += nlte_properties
-            if nlte_config.classical_nebular==True and \
-                nlte_config.coronal_approximation==False:
-                LevelBoltzmannFactorNLTE(self, classical_nebular=True)
-            elif nlte_config.coronal_approximation==True and \
-                nlte_config.classical_nebular==False:
-                LevelBoltzmannFactorNLTE(self, coronal_approximation=True)
-            elif nlte_config.coronal_approximation==True and \
-                nlte_config.classical_nebular==True:
-                raise PlasmaConfigError('Both coronal approximation and '
-                                        'classical nebular specified in the '
-                                        'config.')
-        else:
-            plasma_modules += non_nlte_properties
+    plasma = BasePlasma(plasma_properties=plasma_modules, **kwargs)
 
-        if line_interaction_type in ('downbranch', 'macroatom'):
-            plasma_modules += macro_atom_properties
-
-        if t_rad is None:
-            t_rad = self.initial_t_rad(number_densities)
-
-        w = self.initial_w(number_densities)
-
-        abundance, density = self.from_number_densities(number_densities,
-            atomic_data)
-
-        if nlte_config is not None and nlte_config.species:
-            self.nlte_species = nlte_config.species
-        else:
-            self.nlte_species = None
-
-        if helium_treatment=='recomb-nlte':
-            plasma_modules += helium_nlte_properties
-        elif helium_treatment=='numerical-nlte':
-            plasma_modules += helium_numerical_nlte_properties
-            if heating_rate_data_file is None:
-                raise PlasmaConfigError('Heating rate data file not specified')
-            else:
-                self.heating_rate_data_file = heating_rate_data_file
-                self.v_inner = v_inner
-                self.v_outer = v_outer
-        else:
-            plasma_modules += helium_lte_properties
-
-        self.delta_treatment = delta_treatment
-
-        super(LegacyPlasmaArray, self).__init__(
-            plasma_properties=plasma_modules, t_rad=t_rad,
-            abundance=abundance, density=density,
-            atomic_data=atomic_data, time_explosion=time_explosion,
-            j_blues=None, w=w, link_t_rad_t_electron=link_t_rad_t_electron,
-            helium_treatment=helium_treatment)
+    return plasma

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -62,6 +62,9 @@ def assemble_plasma(config, model):
     elif config.plasma.radiative_rates_type == 'dilute-blackbody':
         plasma_modules.append(JBluesDiluteBlackBody)
     elif config.plasma.radiative_rates_type == 'detailed':
+        # FIXME: Support initializing arguments of Plasma properties
+        # we need to pass w_epsilon value in the __init__ method of
+        # JBluesDiluteDetailed
         raise NotImplementedError("Detailed mode not implemented yet.")
     else:
         raise ValueError('radiative_rates_type type unknown - %s',
@@ -82,11 +85,11 @@ def assemble_plasma(config, model):
         plasma_modules += nlte_properties
         kwargs['nlte_species'] = nlte_conf.species
         if nlte_conf.classical_nebular and not nlte_conf.coronal_approximation:
-            plasma_modules.append(LevelBoltzmannFactorNLTE)
-            kwargs['classical_nebular'] = True
+            # FIXME: Support initializing arguments of Plasma properties
+            plasma_modules.append(LevelBoltzmannFactorNLTE) # (classical_nebular = True)
         elif nlte_conf.coronal_approximation and not nlte_conf.classical_nebular:
-            plasma_modules.append(LevelBoltzmannFactorNLTE)
-            kwargs['coronal_approximation'] = True
+            # FIXME: Support initializing arguments of Plasma properties
+            plasma_modules.append(LevelBoltzmannFactorNLTE) # (coronal_approximation = True)
         elif nlte_conf.coronal_approximation and nlte_conf.classical_nebular:
             raise PlasmaConfigError('Both coronal approximation and '
                                     'classical nebular specified in the '


### PR DESCRIPTION
With this PR `LegacyPlasmaArray` is replaced with `assemble_plasma` which takes a `Configuration` object and a `Radial1DModel` (in the form it has in #632) and returns a `BasePlasma` instance.