### PR TITLE
Fix hold iterations

### DIFF
--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -164,6 +164,7 @@ definitions:
         hold_iterations:
           type: number
           multipleOf: 1.0
+          minimum: 1
           default: 3
           description: the number of iterations that the convergence criteria need
             to be fulfilled before TARDIS accepts the simulation as converged

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -17,9 +17,6 @@ logger = logging.getLogger(__name__)
 
 
 class Simulation(object):
-
-    converged = False
-
     def __init__(self, tardis_config):
         self.tardis_config = tardis_config
         self.runner = MontecarloRunner(self.tardis_config.montecarlo.seed,
@@ -31,6 +28,7 @@ class Simulation(object):
                                         lock_t_inner_cycles)
         t_inner_lock_cycle[0] = True
         self.t_inner_update = itertools.cycle(t_inner_lock_cycle)
+        self.converged = False
 
     def run_single_montecarlo(self, model, no_of_packets,
                               no_of_virtual_packets=0,last_run=False):

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -297,7 +297,6 @@ class Simulation(object):
                 self.iterations_remaining = (
                     convergence_section["hold_iterations"])
             elif not converged and self.holding:
-                # UMN Warning: the following two iterations attributes of the Simulation object don't exist
                 self.iterations_remaining = self.iterations_max_requested - self.iterations_executed
                 self.holding = False
             else:
@@ -305,10 +304,6 @@ class Simulation(object):
                 # converged OR it is not converged and the status of the
                 # simulation is not converged - Do nothing.
                 pass
-
-            if converged:
-                self.iterations_remaining = (
-                    convergence_section["hold_iterations"])
 
         #Finished second to last loop running one more time
         logger.info('Doing last run')

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -28,7 +28,7 @@ class Simulation(object):
                                         lock_t_inner_cycles)
         t_inner_lock_cycle[0] = True
         self.t_inner_update = itertools.cycle(t_inner_lock_cycle)
-        self.converged = False
+        self.holding = False
 
     def run_single_montecarlo(self, model, no_of_packets,
                               no_of_virtual_packets=0,last_run=False):
@@ -290,16 +290,16 @@ class Simulation(object):
 
             # if switching into the hold iterations mode or out back to the normal one
             # if it is in either of these modes already it will just stay there
-            if converged and not self.converged:
-                self.converged = True
+            if converged and not self.holding:
+                self.holding = True
                 # UMN - used to be 'hold_iterations_wrong' but this is
                 # currently not in the convergence_section namespace...
                 self.iterations_remaining = (
                     convergence_section["hold_iterations"])
-            elif not converged and self.converged:
+            elif not converged and self.holding:
                 # UMN Warning: the following two iterations attributes of the Simulation object don't exist
                 self.iterations_remaining = self.iterations_max_requested - self.iterations_executed
-                self.converged = False
+                self.holding = False
             else:
                 # either it is converged and the status of the simulation is
                 # converged OR it is not converged and the status of the

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -323,6 +323,8 @@ class Simulation(object):
             self.tardis_config.montecarlo.no_of_virtual_packets)
 
         self.run_single_montecarlo(model, no_of_packets, no_of_virtual_packets, last_run=True)
+        self.iterations_executed += 1
+        self.iterations_remaining -= 1
 
         self.runner.legacy_update_spectrum(no_of_virtual_packets)
         self.legacy_set_final_model_properties(model)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -244,14 +244,20 @@ class Simulation(object):
 
         self.iterations_remaining = self.tardis_config.montecarlo.iterations
         self.iterations_max_requested = self.tardis_config.montecarlo.iterations
+        convergence_strategy = self.tardis_config.montecarlo.convergence_strategy
         self.iterations_executed = 0
         converged = False
 
-        convergence_section = (
-                    self.tardis_config.montecarlo.convergence_strategy)
-
         while self.iterations_remaining > 1:
-            logger.info('Remaining run %d', self.iterations_remaining)
+            logger.info('Running iteration {}/{}'.format(
+                        self.iterations_executed + 1,
+                        self.iterations_max_requested))
+            if self.holding:
+                hold_n = (convergence_strategy.hold_iterations - 
+                         self.iterations_remaining + 1)
+                logger.info('Hold iteration {}/{}'.format(
+                    hold_n, convergence_strategy.hold_iterations))
+
             self.run_single_montecarlo(
                 model, self.tardis_config.montecarlo.no_of_packets)
             self.log_run_results(self.calculate_emitted_luminosity(),
@@ -287,26 +293,27 @@ class Simulation(object):
                             'simulation{}'.format(self.iterations_executed),
                             plasma_properties)
 
-
-            # if switching into the hold iterations mode or out back to the normal one
-            # if it is in either of these modes already it will just stay there
-            if converged and not self.holding:
+            # If the iteration has converged get in the hold iterations mode
+            if (converged and not self.holding and
+                            convergence_strategy.hold_iterations > 0):
                 self.holding = True
-                # UMN - used to be 'hold_iterations_wrong' but this is
-                # currently not in the convergence_section namespace...
-                self.iterations_remaining = (
-                    convergence_section["hold_iterations"])
+                self.iterations_remaining = convergence_strategy.hold_iterations
+            # If not all of the hold iterations converged switch back to
+            # the normal iterations
             elif not converged and self.holding:
-                self.iterations_remaining = self.iterations_max_requested - self.iterations_executed
+                self.iterations_remaining = (self.iterations_max_requested -
+                                             self.iterations_executed)
                 self.holding = False
-            else:
-                # either it is converged and the status of the simulation is
-                # converged OR it is not converged and the status of the
-                # simulation is not converged - Do nothing.
-                pass
 
         #Finished second to last loop running one more time
-        logger.info('Doing last run')
+        logger.info('Running iteration {}/{}'.format(
+            self.iterations_executed + 1,
+            self.iterations_max_requested))
+        if self.holding:
+            hold_n = (convergence_strategy.hold_iterations -
+                      self.iterations_remaining + 1)
+            logger.info('Hold iteration {}/{}'.format(
+                hold_n, convergence_strategy.hold_iterations))
         if self.tardis_config.montecarlo.last_no_of_packets is not None:
             no_of_packets = self.tardis_config.montecarlo.last_no_of_packets
         else:


### PR DESCRIPTION
Fix the following issues:

- There were cases where the hold_iterations mode was triggered by the convergence_strategy criteria, and the simulation would get in an infinite loop.
- Improve counting the simulation iterations in the log.
- Also count the last iteration in the final summary message.