### PR TITLE
Fix detailed radiative rates

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -137,8 +137,10 @@ class MontecarloRunner(object):
         # Workaround so that j_blue_estimator is in the right ordering
         # They are written as an array of dimension (no_of_shells, no_of_lines)
         # but python expects (no_of_lines, no_of_shells)
-        self.j_blue_estimator = self.j_blue_estimator.flatten().reshape(
+        self.j_blue_estimator = np.ascontiguousarray(
+                self.j_blue_estimator.flatten().reshape(
                 self.j_blue_estimator.shape, order='F')
+                )
         self.Edotlu_estimator = self.Edotlu_estimator.flatten().reshape(
                 self.Edotlu_estimator.shape, order='F')
 


### PR DESCRIPTION
Because the j_blues_estimator array is expected to be in C ordering and
we are writing it in C ordering but with reversed axes we have to do
some 'magic' to make it work.

@mishinma I made a new PR because it's easier.