### PR TITLE
Remove helper functions from atomic

### DIFF
--- a/tardis/io/atomic.py
+++ b/tardis/io/atomic.py
@@ -117,7 +117,7 @@ class AtomData(object):
                       ("collision_data", "collision_data_temperatures")]
 
     @classmethod
-    def from_hdf(cls, fname=None):
+    def from_hdf(cls, fname):
         """
         Function to read all the atom data from the special Carsus HDFStore file.
 
@@ -125,13 +125,9 @@ class AtomData(object):
         ----------
 
         fname: str, optional
-            The path to the HDFStore file. If set to `None` the default file with limited atomic_data
-            shipped with TARDIS will be used. For more complex atomic data please contact the authors.
+            Path to the HDFStore file. Please contact the authors to get the up-to-date file.
             (default: None)
         """
-
-        if fname is None:
-            fname = default_atom_h5_path
 
         if not os.path.exists(fname):
             raise ValueError("Supplied Atomic Model Database %s does not exists" % fname)

--- a/tardis/io/atomic.py
+++ b/tardis/io/atomic.py
@@ -2,7 +2,6 @@
 
 import os
 import logging
-import tardis
 import numpy as np
 import pandas as pd
 
@@ -16,31 +15,12 @@ from astropy.units import Quantity
 class AtomDataNotPreparedError(Exception):
     pass
 
+
 class AtomDataMissingError(Exception):
     pass
 
 
 logger = logging.getLogger(__name__)
-
-tardis_dir = os.path.dirname(os.path.realpath(tardis.__file__))
-
-
-def data_path(fname):
-    return os.path.join(tardis_dir, 'data', fname)
-
-
-def tests_data_path(fname):
-    return os.path.join(tardis_dir, 'tests', 'data', fname)
-
-
-default_atom_h5_path = data_path('atom_data.h5')
-
-atomic_symbols_data = np.recfromtxt(data_path('atomic_symbols.dat'),
-                                    names=['atomic_number', 'symbol'])
-
-symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'],
-                                       atomic_symbols_data['atomic_number']))
-atomic_number2symbol = OrderedDict(atomic_symbols_data)
 
 
 class AtomData(object):

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -6,9 +6,10 @@ import numpy as np
 import os
 import yaml
 import re
-
+import tardis
 import logging
-from tardis.io import atomic
+
+from collections import OrderedDict
 
 
 k_B_cgs = constants.k_B.cgs.value
@@ -47,10 +48,27 @@ class MalformedQuantityError(MalformedError):
         return 'Expecting a quantity string(e.g. "5 km/s") for keyword - supplied %s' % self.malformed_quantity_string
 
 
-
 logger = logging.getLogger(__name__)
 
-synpp_default_yaml_fname = os.path.join(os.path.dirname(__file__), 'data', 'synpp_default.yaml')
+tardis_dir = os.path.dirname(os.path.realpath(tardis.__path__[0]))
+
+
+def get_data_path(fname):
+    return os.path.join(tardis_dir, 'data', fname)
+
+
+def get_tests_data_path(fname):
+    return os.path.join(tardis_dir, 'tests', 'data', fname)
+
+
+atomic_symbols_data = np.recfromtxt(get_data_path('atomic_symbols.dat'),
+                                    names=['atomic_number', 'symbol'])
+symbol2atomic_number = OrderedDict(zip(atomic_symbols_data['symbol'],
+                                       atomic_symbols_data['atomic_number']))
+atomic_number2symbol = OrderedDict(atomic_symbols_data)
+
+
+synpp_default_yaml_fname = get_data_path('synpp_default.yaml')
 
 def int_to_roman(input):
    """
@@ -328,7 +346,7 @@ def savitzky_golay(y, window_size, order, deriv=0, rate=1):
 
 def species_tuple_to_string(species_tuple, roman_numerals=True):
     atomic_number, ion_number = species_tuple
-    element_symbol = atomic.atomic_number2symbol[atomic_number]
+    element_symbol = atomic_number2symbol[atomic_number]
     if roman_numerals:
         roman_ion_number = int_to_roman(ion_number+1)
         return '%s %s' % (element_symbol, roman_ion_number)
@@ -388,15 +406,15 @@ def parse_quantity(quantity_string):
 
 def element_symbol2atomic_number(element_string):
     reformatted_element_string = reformat_element_symbol(element_string)
-    if reformatted_element_string not in atomic.symbol2atomic_number:
+    if reformatted_element_string not in symbol2atomic_number:
         raise MalformedElementSymbolError(element_string)
-    return atomic.symbol2atomic_number[reformatted_element_string]
+    return symbol2atomic_number[reformatted_element_string]
 
 def atomic_number2element_symbol(atomic_number):
     """
     Convert atomic number to string symbol
     """
-    return atomic.atomic_number2symbol[atomic_number]
+    return atomic_number2symbol[atomic_number]
 
 def reformat_element_symbol(element_string):
     """


### PR DESCRIPTION
This PR moves the `atomic_number2symbol` and `symbol2atomic_number` functions to 
the `util` module from `atomic`. These functions
are helpers (that are also used in `util` and other modules) so they really
belong to the `util` module.

Also, the  PR moves `data_path` and `tests_data_path` to the `util` module and
renames them as `get_data_path` and `get_tests_data_path`. The rationale
for the renaming is that pytest confuses the `tests_data_path` with
a unit test.

Lastly, the PR removes completely `default_atom_h5_path` (there is not default HDFStore currently) and makes the `fname` argument from the `from_hdf` method a positional argument (no default value).