### PR TITLE
Fix tardis_dir in util

### DIFF
--- a/tardis/util.py
+++ b/tardis/util.py
@@ -50,7 +50,7 @@ class MalformedQuantityError(MalformedError):
 
 logger = logging.getLogger(__name__)
 
-tardis_dir = os.path.dirname(os.path.realpath(tardis.__path__[0]))
+tardis_dir = os.path.realpath(tardis.__path__[0])
 
 
 def get_data_path(fname):


### PR DESCRIPTION
This PR removes `os.path.dirname` because the correct directory is already being returned from `__path__`.
