### PR TITLE
Fix unit tests

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -56,7 +56,7 @@ try:
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass
 
-DEFAULT_UUID = '06709f04d369f07c58e01a7d0f34bd10'
+DEFAULT_UUID = '94af35cb55d22ec5020914ea9409a1cb'
 
 # -------------------------------------------------------------------------
 # Initialization
@@ -90,7 +90,7 @@ def atomic_data_fname():
 @pytest.fixture
 def kurucz_atomic_data(atomic_data_fname):
     atomic_data = AtomData.from_hdf(atomic_data_fname)
-
+    
     if atomic_data.md5 != DEFAULT_UUID:
         pytest.skip('Need default Kurucz atomic dataset (md5="{}"'.format(DEFAULT_UUID))
     else:

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -87,7 +87,7 @@ def atomic_data_fname():
 
 @pytest.fixture
 def kurucz_atomic_data(atomic_data_fname):
-    atomic_data = AtomData.from_hdfstore(atomic_data_fname)
+    atomic_data = AtomData.from_hdf(atomic_data_fname)
 
     if atomic_data.md5 != '06709f04d369f07c58e01a7d0f34bd10':
         pytest.skip('Need default Kurucz atomic dataset '

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -56,6 +56,8 @@ try:
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass
 
+DEFAULT_UUID = '06709f04d369f07c58e01a7d0f34bd10'
+
 # -------------------------------------------------------------------------
 # Initialization
 # -------------------------------------------------------------------------
@@ -89,9 +91,8 @@ def atomic_data_fname():
 def kurucz_atomic_data(atomic_data_fname):
     atomic_data = AtomData.from_hdf(atomic_data_fname)
 
-    if atomic_data.md5 != '06709f04d369f07c58e01a7d0f34bd10':
-        pytest.skip('Need default Kurucz atomic dataset '
-                    '(md5="06709f04d369f07c58e01a7d0f34bd10"')
+    if atomic_data.md5 != DEFAULT_UUID:
+        pytest.skip('Need default Kurucz atomic dataset (md5="{}"'.format(DEFAULT_UUID))
     else:
         return atomic_data
 

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -98,17 +98,6 @@ def kurucz_atomic_data(atomic_data_fname):
 
 
 @pytest.fixture
-def test_data_path():
-    return os.path.join(tardis.__path__[0], 'tests', 'data')
-
-
-@pytest.fixture
-def included_he_atomic_data(test_data_path):
-    atomic_db_fname = os.path.join(test_data_path, 'chianti_he_db.h5')
-    return AtomData.from_hdf5(atomic_db_fname)
-
-
-@pytest.fixture
 def tardis_config_verysimple():
     return yaml_load_config_file(
         'tardis/io/tests/data/tardis_configv1_verysimple.yml')

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -7,10 +7,9 @@ from astropy.tests.pytest_plugins import (
         pytest_addoption as _pytest_add_option
     )
 
-import tardis
 import pytest
+
 from tardis.io.atomic import AtomData
-from tardis.io.config_reader import Configuration
 from tardis.io.util import yaml_load_config_file
 
 ###

--- a/tardis/io/tests/test_atomic.py
+++ b/tardis/io/tests/test_atomic.py
@@ -1,155 +1,65 @@
-import os
 import pytest
-from numpy import testing
-from tardis.io import atomic
+
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u
+from astropy import constants as const
 
 
-@pytest.fixture(scope="module")
-def default_atom_h5_path():
-    return atomic.data_path('atom_data.h5')
+@pytest.fixture
+def basic_atom_data(kurucz_atomic_data):
+    return kurucz_atomic_data.atom_data
 
 
-@pytest.fixture(scope="module")
-def chianti_he_db_h5_path():
-    return atomic.tests_data_path('chianti_he_db.h5')
+@pytest.fixture
+def ionization_data(kurucz_atomic_data):
+    return kurucz_atomic_data.ionization_data
 
 
-def test_data_path():
-    data_path = atomic.data_path('test')
-    assert data_path.split('/')[-3:] == ['tardis', 'data', 'test']
+@pytest.fixture
+def levels(kurucz_atomic_data):
+    return kurucz_atomic_data.levels
 
 
-def test_read_basic_atom_data(default_atom_h5_path):
-    data = atomic.read_basic_atom_data(default_atom_h5_path)
-    assert data['atomic_number'][13] == 14
-    assert data['symbol'][13] == "Si"
-    testing.assert_almost_equal(data['mass'][13], 28.085, decimal=4)
+@pytest.fixture
+def lines(kurucz_atomic_data):
+    return kurucz_atomic_data.lines
 
 
-def test_read_ionization_data(default_atom_h5_path):
-    data = atomic.read_ionization_data(default_atom_h5_path)
-    assert data['atomic_number'][0] == 1
-    assert data['ion_number'][0] == 1
-    testing.assert_almost_equal(data['ionization_energy'][0], 13.59844, decimal=4)
+def test_atom_data_basic_atom_data(basic_atom_data):
+    assert basic_atom_data.loc[2, 'symbol'] == 'He'
+    assert_quantity_allclose(
+        basic_atom_data.at[2, 'mass'] * u.Unit('g'),
+        4.002602 * const.u.cgs
+     )
 
 
-def test_read_levels_data(default_atom_h5_path):
-    data = atomic.read_levels_data(default_atom_h5_path)
-    assert data['atomic_number'][4] == 14
-    assert data['ion_number'][4] == 0
-    assert data['level_number'][4] == 4
-    testing.assert_almost_equal(data['energy'][4], 1.90865, decimal=4)
-    assert data['g'][4] == 1
-    assert data['metastable'][4] == False
+def test_atom_data_ionization_data(ionization_data):
+    assert_quantity_allclose(
+        ionization_data.at[(2, 1), 'ionization_energy'] * u.Unit('erg'),
+        24.587387936 * u.Unit('eV')
+    )
 
 
-def test_read_lines_data(default_atom_h5_path):
-    data = atomic.read_lines_data(default_atom_h5_path)
-    assert data['line_id'][0] == 8
-    assert data['atomic_number'][0] == 14
-    assert data['ion_number'][0] == 5
-    testing.assert_almost_equal(data['wavelength'][0], 66.772, decimal=4)
-    testing.assert_almost_equal(data['f_ul'][0], 0.02703, decimal=4)
-    testing.assert_almost_equal(data['f_lu'][0], 0.04054, decimal=4)
-    assert data['level_number_lower'][0] == 0.0
-    assert data['level_number_upper'][0] == 36.0
+def test_atom_data_levels(levels):
+    levels = levels.set_index(['atomic_number', 'ion_number', 'level_number'])
+    assert_quantity_allclose(
+        u.Quantity(levels.at[(2, 0, 2), 'energy'], u.Unit('erg')).to(u.Unit('cm-1'), equivalencies=u.spectral()),
+        166277.542 * u.Unit('cm-1')
+    )
 
 
-def test_read_synpp_refs(chianti_he_db_h5_path):
-    data = atomic.read_synpp_refs(chianti_he_db_h5_path)
-    assert data['atomic_number'][0] == 1
-    assert data['ion_number'][0] == 0
-    testing.assert_almost_equal(data['wavelength'][0], 6562.7973633, decimal=4)
-    assert data['line_id'][0] == 564995
+def test_atom_data_lines(lines):
+    lines = lines.set_index(['atomic_number', 'ion_number',
+                             'level_number_lower', 'level_number_upper'])
+    assert_quantity_allclose(
+        lines.at[(2, 0, 0, 6), 'wavelength_cm'] * u.Unit('cm'),
+        584.335 * u.Unit('Angstrom')
+    )
 
 
-def test_read_zeta_data(default_atom_h5_path, chianti_he_db_h5_path):
-    data = atomic.read_zeta_data(chianti_he_db_h5_path)
-    testing.assert_almost_equal(data[2000][1][1], 0.339, decimal=4)
-    testing.assert_almost_equal(data[2000][1][2], 0.000, decimal=4)
-
-    with pytest.raises(ValueError):
-        atomic.read_zeta_data(None)
-
-    with pytest.raises(IOError):
-        atomic.read_zeta_data('fakepath')
-
-    with pytest.raises(ValueError):
-        atomic.read_zeta_data(default_atom_h5_path)
-
-
-def test_read_collision_data(default_atom_h5_path, chianti_he_db_h5_path):
-    data = atomic.read_collision_data(chianti_he_db_h5_path)
-    assert data[0]['atomic_number'][0] == 2
-    assert data[0]['ion_number'][0] == 0
-    assert data[0]['level_number_upper'][0] == 18
-    assert data[0]['level_number_lower'][0] == 2
-    assert data[0]['g_ratio'][0] == 1.0
-    testing.assert_almost_equal(data[0]['delta_e'][0], 35484.251143, decimal=4)
-    assert data[1][0] == 2000.0
-    assert data[1][1] == 4000.0
-
-    with pytest.raises(ValueError):
-        atomic.read_zeta_data(None)
-
-    with pytest.raises(IOError):
-        atomic.read_zeta_data('fakepath')
-
-    with pytest.raises(ValueError):
-        atomic.read_zeta_data(default_atom_h5_path)
-
-
-def test_read_macro_atom_data(default_atom_h5_path, chianti_he_db_h5_path):
-    data = atomic.read_macro_atom_data(chianti_he_db_h5_path)
-    assert data[0]['atomic_number'][0] == 2
-    assert data[0]['ion_number'][0] == 0
-    assert data[0]['source_level_number'][0] == 0.0
-    assert data[0]['destination_level_number'][0] == 48.0
-    assert data[0]['transition_type'][0] == 1
-    assert data[0]['transition_probability'][0] == 0.0
-    assert data[0]['transition_line_id'][0] == 564957
-
-    assert data[1]['count_down'][0] == 0
-    assert data[1]['count_up'][0] == 7
-    assert data[1]['count_total'][0] == 7
-
-    with pytest.raises(ValueError):
-        atomic.read_macro_atom_data(None)
-
-    with pytest.raises(IOError):
-        atomic.read_macro_atom_data('fakepath')
-
-    with pytest.raises(ValueError):
-        atomic.read_macro_atom_data(default_atom_h5_path)
-
-
-def test_atom_levels():
-    atom_data = atomic.AtomData.from_hdf5(atomic.default_atom_h5_path)
-    with pytest.raises(Exception):
-        raise Exception('test the atom_data thoroughly')
-
-def test_atomic_symbol():
-    assert atomic.atomic_number2symbol[14] == 'Si'
-
-def test_atomic_symbol_reverse():
-    assert atomic.symbol2atomic_number['Si'] == 14
-
-@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
-                    reason='--atomic_database was not specified')
-def test_atomic_reprepare():
-    atom_data_filename = os.path.expanduser(os.path.expandvars(
-        pytest.config.getvalue('atomic-dataset')))
-    assert os.path.exists(atom_data_filename), ("{0} atomic datafiles "
-                                                         "does not seem to "
-                                                         "exist".format(
-        atom_data_filename))
-    atom_data = atomic.AtomData.from_hdf5(atom_data_filename)
-    atom_data.prepare_atom_data([14])
-    assert len(atom_data.lines) > 0
-    # Fix for new behavior of prepare_atom_data
-    # Consider doing only one prepare_atom_data and check
-    # len(atom_data.lines) == N where N is known
-    atom_data = atomic.AtomData.from_hdf5(atom_data_filename)
-    atom_data.prepare_atom_data([20])
-    assert len(atom_data.lines) > 0
-
+def test_atomic_reprepare(kurucz_atomic_data):
+    kurucz_atomic_data.prepare_atom_data([14, 20])
+    lines = kurucz_atomic_data.lines
+    assert lines['atomic_number'].isin([14, 20]).all()
+    assert len(lines.loc[lines['atomic_number'] == 14]) > 0
+    assert len(lines.loc[lines['atomic_number'] == 20]) > 0

--- a/tardis/tests/test_plasma_simple.py
+++ b/tardis/tests/test_plasma_simple.py
@@ -1,20 +1,27 @@
-from astropy import constants as const, units as u
 import os
-import pandas as pd
-import tardis
-from tardis.io import atomic
+import pytest
 import warnings
+import pandas as pd
+
+from astropy import constants as const, units as u
 from tardis.plasma.standard_plasmas import LegacyPlasmaArray
+from tardis.io.atomic import AtomData
 from tardis.io.util import parse_abundance_dict_to_dataframe
-# from numpy.testing import assert_allclose
-data_path = os.path.join(tardis.__path__[0], 'tests', 'data')
-helium_test_db = os.path.join(data_path, 'chianti_he_db.h5')
 
 
+@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
+                    reason='--atomic_database was not specified')
 class TestNebularPlasma(object):
 
+    @classmethod
+    @pytest.fixture(scope="class", autouse=True)
     def setup(self):
-        atom_data = atomic.AtomData.from_hdf5(helium_test_db)
+        atom_data_filename = os.path.expanduser(os.path.expandvars(
+            pytest.config.getvalue('atomic-dataset')))
+        assert os.path.exists(atom_data_filename), \
+            "{0} atomic datafiles does not seem to exist".format(atom_data_filename)
+
+        atom_data = AtomData.from_hdf(atom_data_filename)
         density = 1e-15 * u.Unit('g/cm3')
         abundance = parse_abundance_dict_to_dataframe({'He': 1.0})
         abundance = pd.DataFrame({0: abundance})


### PR DESCRIPTION
This PR fixes unit tests after the restructuring of the `atomic` module:
- reimplements unit tests in `test_atomic.py`
- uses the HDFStore provided with the `--atomic-dataset` option for *all* unit tests. This is the default atomic dataset for testing.
- ditches `chianti_he_db.h5` and removes it from tests (see the previous point).

