### PR TITLE
Facility to provide per-setup atom data as well as save report locally.

### DIFF
--- a/tardis/tests/integration_tests/conftest.py
+++ b/tardis/tests/integration_tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from tardis import __githash__ as tardis_githash
 from tardis.tests.integration_tests.report import DokuReport
-from tardis.tests.integration_tests.plot_helpers import PlotUploader
+from tardis.tests.integration_tests.plot_helpers import PlotUploader, LocalPlotSaver
 
 
 def pytest_configure(config):
@@ -59,7 +59,15 @@ def pytest_runtest_makereport(item, call):
 
 @pytest.fixture(scope="function")
 def plot_object(request):
-    return PlotUploader(request)
+    integration_tests_config = request.config.integration_tests_config
+    report_save_mode = integration_tests_config['report']['save_mode']
+
+    if report_save_mode == "remote":
+        return PlotUploader(request, request.config.dokureport.dokuwiki_url)
+    else:
+        return LocalPlotSaver(request, os.path.join(
+            request.config.dokureport.report_dirpath, "assets")
+        )
 
 
 @pytest.fixture(scope="class", params=[

--- a/tardis/tests/integration_tests/conftest.py
+++ b/tardis/tests/integration_tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 from tardis import __githash__ as tardis_githash
 from tardis.tests.integration_tests.report import DokuReport
-from tardis.tests.integration_tests.plot_helpers import PlotUploader, LocalPlotSaver
+from tardis.tests.integration_tests.plot_helpers import LocalPlotSaver, RemotePlotSaver
 
 
 def pytest_configure(config):
@@ -63,7 +63,7 @@ def plot_object(request):
     report_save_mode = integration_tests_config['report']['save_mode']
 
     if report_save_mode == "remote":
-        return PlotUploader(request, request.config.dokureport.dokuwiki_url)
+        return RemotePlotSaver(request, request.config.dokureport.dokuwiki_url)
     else:
         return LocalPlotSaver(request, os.path.join(
             request.config.dokureport.report_dirpath, "assets")

--- a/tardis/tests/integration_tests/conftest.py
+++ b/tardis/tests/integration_tests/conftest.py
@@ -24,7 +24,7 @@ def pytest_configure(config):
             # prevent opening dokupath on slave nodes (xdist)
             if not hasattr(config, 'slaveinput'):
                 config.dokureport = DokuReport(
-                    config.integration_tests_config['dokuwiki'])
+                    config.integration_tests_config['report'])
                 config.pluginmanager.register(config.dokureport)
 
 

--- a/tardis/tests/integration_tests/conftest.py
+++ b/tardis/tests/integration_tests/conftest.py
@@ -80,6 +80,16 @@ def data_path(request):
         ),
         'setup_name': hdf_filename[:-3]
     }
+
+    # For providing atom data per individual setup. Atom data can be fetched
+    # from a local directory or a remote url.
+    if integration_tests_config['atom_data']['fetch'] == "remote":
+        path['atom_data_url'] = integration_tests_config['atom_data']['url']
+    elif integration_tests_config['atom_data']['fetch'] == "local":
+        path['atom_data_dirpath'] = os.path.expandvars(os.path.expanduser(
+            integration_tests_config['atom_data']['dirpath']
+        ))
+
     if (request.config.getoption("--generate-reference") and not
             os.path.exists(path['gen_ref_dirpath'])):
         os.makedirs(path['gen_ref_dirpath'])

--- a/tardis/tests/integration_tests/plot_helpers.py
+++ b/tardis/tests/integration_tests/plot_helpers.py
@@ -1,10 +1,11 @@
+import os
 import tempfile
 
 from pytest_html import extras
-import tardis
+from tardis import __githash__ as tardis_githash
 
 
-thumbnail_html = """
+thumbnail_html_remote = """
 <div class="image" style="float: left">
     <a href="#">
         <img src= "{dokuwiki_url}lib/exe/fetch.php?media=reports:{githash}:{name}.png" />
@@ -14,7 +15,7 @@ thumbnail_html = """
 
 
 class PlotUploader(object):
-    def __init__(self, request):
+    def __init__(self, request, dokuwiki_url):
         """A helper class to collect plots from integration tests and upload
         them to DokuWiki.
 
@@ -26,7 +27,7 @@ class PlotUploader(object):
         self.request = request
         self._plots = list()
         self.plot_html = list()
-        self.dokuwiki_url = self.request.config.dokureport.dokuwiki_url
+        self.dokuwiki_url = dokuwiki_url
 
     def add(self, plot, name):
         """Accept a plot figure and add it to ``self._plots``.
@@ -40,7 +41,7 @@ class PlotUploader(object):
         self._plots.append((plot, name))
 
     def upload(self, report):
-        """Upload the content in self._plots to dokuwiki.
+        """Upload the content of self._plots to dokuwiki.
 
         Parameters
         ----------
@@ -62,18 +63,89 @@ class PlotUploader(object):
             plot.savefig(plot_file.name)
 
             self.request.config.dokureport.doku_conn.medias.add(
-                "reports:{0}:{1}.png".format(tardis.__githash__[0:7], name),
+                "reports:{0}:{1}.png".format(tardis_githash[:7], name),
                 plot_file.name
             )
 
             self.plot_html.append(extras.html(
-                thumbnail_html.format(
+                thumbnail_html_remote.format(
                     dokuwiki_url=self.dokuwiki_url,
-                    githash=tardis.__githash__[0:7],
+                    githash=tardis_githash[:7],
                     name=name)
                 )
             )
             plot_file.close()
+
+    def get_extras(self):
+        """Return ``self.plot_html`` which is further added into html report.
+
+        Returns
+        -------
+        list
+             List of strings containing raw html snippet to embed images.
+        """
+        return self.plot_html
+
+
+thumbnail_html_local = """
+<div class="image" style="float: left">
+    <a href="#">
+        <img src= "assets/{name}.png" />
+    </a>
+</div>
+"""
+
+
+class LocalPlotSaver(object):
+    def __init__(self, request, assets_dirpath):
+        """A helper class to collect plots from integration tests and save
+        them in a particular directory locally.
+
+        Parameters
+        ----------
+        request : _pytest.python.RequestObject
+
+        """
+        self.request = request
+        self._plots = list()
+        self.plot_html = list()
+        self.assets_dirpath = assets_dirpath
+
+    def add(self, plot, name):
+        """Accept a plot figure and add it to ``self._plots``.
+
+        Parameters
+        ----------
+        plot : matplotlib.pyplot.figure
+        name : str
+
+        """
+        self._plots.append((plot, name))
+
+    def upload(self, report):
+        """Upload (save) content of ``self._plots`` to ``self.assets_dirpath``.
+
+        Parameters
+        ----------
+        report : _pytest.runner.TestReport
+
+        """
+
+        for plot, name in self._plots:
+            axes = plot.axes[0]
+
+            if report.passed:
+                axes.text(0.8, 0.8, 'passed', transform=axes.transAxes,
+                          bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
+            else:
+                axes.text(0.8, 0.8, 'failed', transform=axes.transAxes,
+                          bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
+
+            plot.savefig(os.path.join(self.assets_dirpath, "{0}.png".format(name)))
+
+            self.plot_html.append(extras.html(
+                thumbnail_html_local.format(name=name))
+            )
 
     def get_extras(self):
         """Return ``self.plot_html`` which is further added into html report.

--- a/tardis/tests/integration_tests/plot_helpers.py
+++ b/tardis/tests/integration_tests/plot_helpers.py
@@ -5,29 +5,23 @@ from pytest_html import extras
 from tardis import __githash__ as tardis_githash
 
 
-thumbnail_html_remote = """
-<div class="image" style="float: left">
-    <a href="#">
-        <img src= "{dokuwiki_url}lib/exe/fetch.php?media=reports:{githash}:{name}.png" />
-    </a>
-</div>
-"""
-
-
-class PlotUploader(object):
-    def __init__(self, request, dokuwiki_url):
-        """A helper class to collect plots from integration tests and upload
-        them to DokuWiki.
+class BasePlotSaver(object):
+    def __init__(self, request, dokuwiki_url=None, assets_dirpath=None):
+        """Base Class for RemotePlotSaver and LocalPlotSaver classes.
+        These help in uploading plots to DokuWiki instance or saving them
+        locally in a directory.
 
         Parameters
         ----------
         request : _pytest.python.RequestObject
-
+        dokuwiki_url : str
+        assets_dirpath : str
         """
         self.request = request
         self._plots = list()
         self.plot_html = list()
         self.dokuwiki_url = dokuwiki_url
+        self.assets_dirpath = assets_dirpath
 
     def add(self, plot, name):
         """Accept a plot figure and add it to ``self._plots``.
@@ -40,8 +34,52 @@ class PlotUploader(object):
         """
         self._plots.append((plot, name))
 
+    def save(self, plot, filepath, report):
+        """Mark pass / fail and save a plot with ``name`` to ``filepath``.
+
+        Parameters
+        ----------
+        plot : matplotlib.pyplot.figure
+        filepath : str
+        report : _pytest.runner.TestReport
+        """
+        axes = plot.axes[0]
+
+        if report.passed:
+            axes.text(0.8, 0.8, 'passed', transform=axes.transAxes,
+                        bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
+        else:
+            axes.text(0.8, 0.8, 'failed', transform=axes.transAxes,
+                        bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
+
+        plot.savefig(filepath)
+
+    def get_extras(self):
+        """Return ``self.plot_html`` which is further added into html report.
+
+        Returns
+        -------
+        list
+             List of strings containing raw html snippet to embed images.
+        """
+        return self.plot_html
+
+
+thumbnail_html_remote = """
+<div class="image" style="float: left">
+    <a href="#">
+        <img src= "{dokuwiki_url}lib/exe/fetch.php?media=reports:{githash}:{name}.png" />
+    </a>
+</div>
+"""
+
+
+class RemotePlotSaver(BasePlotSaver):
+    def __init__(self, request, dokuwiki_url):
+        super(RemotePlotSaver, self).__init__(request, dokuwiki_url=dokuwiki_url)
+
     def upload(self, report):
-        """Upload the content of self._plots to dokuwiki.
+        """Upload content of ``self._plots`` to ``self.dokuwiki_url``.
 
         Parameters
         ----------
@@ -51,16 +89,7 @@ class PlotUploader(object):
 
         for plot, name in self._plots:
             plot_file = tempfile.NamedTemporaryFile(suffix=".png")
-            axes = plot.axes[0]
-
-            if report.passed:
-                axes.text(0.8, 0.8, 'passed', transform=axes.transAxes,
-                            bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
-            else:
-                axes.text(0.8, 0.8, 'failed', transform=axes.transAxes,
-                            bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
-
-            plot.savefig(plot_file.name)
+            self.save(plot, plot_file.name, report)
 
             self.request.config.dokureport.doku_conn.medias.add(
                 "reports:{0}:{1}.png".format(tardis_githash[:7], name),
@@ -76,16 +105,6 @@ class PlotUploader(object):
             )
             plot_file.close()
 
-    def get_extras(self):
-        """Return ``self.plot_html`` which is further added into html report.
-
-        Returns
-        -------
-        list
-             List of strings containing raw html snippet to embed images.
-        """
-        return self.plot_html
-
 
 thumbnail_html_local = """
 <div class="image" style="float: left">
@@ -96,34 +115,12 @@ thumbnail_html_local = """
 """
 
 
-class LocalPlotSaver(object):
+class LocalPlotSaver(BasePlotSaver):
     def __init__(self, request, assets_dirpath):
-        """A helper class to collect plots from integration tests and save
-        them in a particular directory locally.
-
-        Parameters
-        ----------
-        request : _pytest.python.RequestObject
-
-        """
-        self.request = request
-        self._plots = list()
-        self.plot_html = list()
-        self.assets_dirpath = assets_dirpath
-
-    def add(self, plot, name):
-        """Accept a plot figure and add it to ``self._plots``.
-
-        Parameters
-        ----------
-        plot : matplotlib.pyplot.figure
-        name : str
-
-        """
-        self._plots.append((plot, name))
+        super(LocalPlotSaver, self).__init__(request, assets_dirpath=assets_dirpath)
 
     def upload(self, report):
-        """Upload (save) content of ``self._plots`` to ``self.assets_dirpath``.
+        """Save content of ``self._plots`` to ``self.assets_dirpath``.
 
         Parameters
         ----------
@@ -132,27 +129,10 @@ class LocalPlotSaver(object):
         """
 
         for plot, name in self._plots:
-            axes = plot.axes[0]
-
-            if report.passed:
-                axes.text(0.8, 0.8, 'passed', transform=axes.transAxes,
-                          bbox={'facecolor': 'green', 'alpha': 0.5, 'pad': 10})
-            else:
-                axes.text(0.8, 0.8, 'failed', transform=axes.transAxes,
-                          bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})
-
-            plot.savefig(os.path.join(self.assets_dirpath, "{0}.png".format(name)))
+            self.save(plot, os.path.join(
+                self.assets_dirpath, "{0}.png".format(name)), report
+            )
 
             self.plot_html.append(extras.html(
                 thumbnail_html_local.format(name=name))
             )
-
-    def get_extras(self):
-        """Return ``self.plot_html`` which is further added into html report.
-
-        Returns
-        -------
-        list
-             List of strings containing raw html snippet to embed images.
-        """
-        return self.plot_html

--- a/tardis/tests/integration_tests/report.py
+++ b/tardis/tests/integration_tests/report.py
@@ -78,14 +78,19 @@ class DokuReport(HTMLReport):
                 self.dokuwiki_url = dokuwiki_details['url']
         else:
             # Save the html report file locally.
-            self.report_dirpath = os.path.join(report_config['dirpath'], tardis_githash[:7])
+            self.report_dirpath = os.path.join(
+                os.path.expandvars(os.path.expanduser(report_config['dirpath'])),
+                tardis_githash[:7]
+            )
+
             if os.path.exists(self.report_dirpath):
                 shutil.rmtree(self.report_dirpath)
             os.makedirs(self.report_dirpath)
+            os.makedirs(os.path.join(self.report_dirpath, 'assets'))
 
             super(DokuReport, self).__init__(
                 logfile=os.path.join(self.report_dirpath, "report.html"),
-                self_contained=True, has_rerun=False
+                self_contained=False, has_rerun=False
             )
 
     def _generate_report(self, session):
@@ -126,7 +131,11 @@ class DokuReport(HTMLReport):
                 pass
         else:
             # Save the file locally at "self.logfile" path
-            super(DokuReport, self)._save_report(report_content)
+            with open(self.logfile, 'w') as f:
+                f.write(report_content)
+
+            with open(os.path.join(self.report_dirpath, 'assets', 'style.css'), 'w') as f:
+                f.write(self.style_css)
 
     def _wiki_overview_entry(self):
         """Makes an entry of current test run on overview page of dokuwiki."""

--- a/tardis/tests/integration_tests/report.py
+++ b/tardis/tests/integration_tests/report.py
@@ -26,12 +26,14 @@ References
 """
 import datetime
 import json
+import os
+import shutil
 import time
 
 # For specifying error while exception handling
 from socket import gaierror
 
-import tardis
+from tardis import __githash__ as tardis_githash
 
 try:
     from pytest_html import __name__ as pytest_html_path
@@ -46,28 +48,45 @@ except ImportError:
 
 class DokuReport(HTMLReport):
 
-    def __init__(self, dokuwiki_details):
+    def __init__(self, report_config):
         """
         Initialization of a DokuReport object and registration as a plugin
         occurs in `pytest_configure`, where a dict containing url, username and
         password of dokuwiki is passed through `dokuwiki_details`.
         """
-        # Base class accepts a file path to save the report, but we pass an
-        # empty string and then delete it anyhow.
-        super(DokuReport, self).__init__(
-            logfile=" ", self_contained=True, has_rerun=False
-        )
+        # This will be either "remote" or "local".
+        self.save_mode = report_config['save_mode']
 
-        try:
-            self.doku_conn = dokuwiki.DokuWiki(
-                url=dokuwiki_details["url"],
-                user=dokuwiki_details["username"],
-                password=dokuwiki_details["password"])
-        except (TypeError, gaierror, dokuwiki.DokuWikiError):
-            self.doku_conn = None
-            self.dokuwiki_url = ""
+        if self.save_mode == "remote":
+            # Base class accepts a file path to save the report, but we pass an
+            # empty string as it is redundant for this use case.
+            super(DokuReport, self).__init__(
+                logfile=" ", self_contained=True, has_rerun=False
+            )
+
+            # Upload the report on a dokuwiki instance.
+            dokuwiki_details = report_config['dokuwiki']
+            try:
+                self.doku_conn = dokuwiki.DokuWiki(
+                    url=dokuwiki_details['url'],
+                    user=dokuwiki_details['username'],
+                    password=dokuwiki_details['password'])
+            except (TypeError, gaierror, dokuwiki.DokuWikiError):
+                self.doku_conn = None
+                self.dokuwiki_url = ""
+            else:
+                self.dokuwiki_url = dokuwiki_details['url']
         else:
-            self.dokuwiki_url = dokuwiki_details["url"]
+            # Save the html report file locally.
+            self.report_dirpath = os.path.join(report_config['dirpath'], tardis_githash[:7])
+            if os.path.exists(self.report_dirpath):
+                shutil.rmtree(self.report_dirpath)
+            os.makedirs(self.report_dirpath)
+
+            super(DokuReport, self).__init__(
+                logfile=os.path.join(self.report_dirpath, "report.html"),
+                self_contained=True, has_rerun=False
+            )
 
     def _generate_report(self, session):
         """Writes HTML report to a temporary logfile."""
@@ -81,7 +100,7 @@ class DokuReport(HTMLReport):
         report_content = (
             "Test executed on commit "
             "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{0}]]\n\n".format(
-                tardis.__githash__
+                tardis_githash
             )
         ) + report_content
 
@@ -98,11 +117,16 @@ class DokuReport(HTMLReport):
         Uploads the report and closes the temporary file. Temporary file is
         made using `tempfile` built-in module, it gets deleted upon closing.
         """
-        try:
-            self.doku_conn.pages.set("reports:{0}".format(
-                tardis.__githash__[:7]), report_content)
-        except (gaierror, TypeError):
-            pass
+        if self.save_mode == "remote":
+            # Upload the report content to wiki
+            try:
+                self.doku_conn.pages.set("reports:{0}".format(
+                    tardis_githash[:7]), report_content)
+            except (gaierror, TypeError):
+                pass
+        else:
+            # Save the file locally at "self.logfile" path
+            super(DokuReport, self)._save_report(report_content)
 
     def _wiki_overview_entry(self):
         """Makes an entry of current test run on overview page of dokuwiki."""
@@ -119,7 +143,7 @@ class DokuReport(HTMLReport):
         # Fetch commit message from github.
         gh_request = requests.get(
             "https://api.github.com/repos/tardis-sn/tardis/git/commits/{0}".format(
-                tardis.__githash__
+                tardis_githash
             )
         )
         gh_commit_data = json.loads(gh_request.content)
@@ -131,10 +155,10 @@ class DokuReport(HTMLReport):
             gh_commit_message = "{0}...".format(gh_commit_message[:57])
         row = "|  "
         # Append hash
-        row += "[[reports:{0}|{0}]]  | ".format(tardis.__githash__[:7])
+        row += "[[reports:{0}|{0}]]  | ".format(tardis_githash[:7])
         # Append commit message
         row += "[[https://www.github.com/tardis-sn/tardis/commit/{0}|{1}]] |  ".format(
-            tardis.__githash__, gh_commit_message
+            tardis_githash, gh_commit_message
         )
         # Append start time
         row += "{0}  |  ".format(suite_start_datetime.strftime('%d %b %H:%M:%S'))
@@ -154,7 +178,10 @@ class DokuReport(HTMLReport):
         """
         report_content = self._generate_report(session)
         self._save_report(report_content)
-        self._wiki_overview_entry()
+
+        # This method need not be called if saving locally
+        if self.save_mode == "remote":
+            self._wiki_overview_entry()
 
     def pytest_terminal_summary(self, terminalreporter):
         """
@@ -162,20 +189,24 @@ class DokuReport(HTMLReport):
         summary at the end. Here, the success / failure of upload of report
         to dokuwiki is logged.
         """
-        try:
-            uploaded_report = self.doku_conn.pages.get(
-                "reports:{0}".format(tardis.__githash__[0:7]))
-        except (gaierror, TypeError):
-            uploaded_report = ""
+        if self.save_mode == "remote":
+            try:
+                uploaded_report = self.doku_conn.pages.get(
+                    "reports:{0}".format(tardis_githash[:7]))
+            except (gaierror, TypeError):
+                uploaded_report = ""
 
-        if len(uploaded_report) > 0:
-            terminalreporter.write_sep(
-                "-", "Successfully uploaded report to Dokuwiki")
-            terminalreporter.write_sep(
-                "-", "URL: {0}doku.php?id=reports:{1}".format(
-                    self.dokuwiki_url, tardis.__githash__[0:7]
+            if len(uploaded_report) > 0:
+                terminalreporter.write_sep(
+                    "-", "Successfully uploaded report to Dokuwiki"
                 )
-            )
+                terminalreporter.write_sep(
+                    "-", "URL: {0}doku.php?id=reports:{1}".format(
+                        self.dokuwiki_url, tardis_githash[:7])
+                )
+            else:
+                terminalreporter.write_sep(
+                    "-", "Connection not established, upload failed.")
         else:
-            terminalreporter.write_sep(
-                "-", "Connection not established, upload failed.")
+            if os.path.exists(self.logfile):
+                super(DokuReport, self).pytest_terminal_summary(terminalreporter)


### PR DESCRIPTION
This PR focuses on adding flexibility to current integration testing infrastructure.

### Facility for Atom Data files;
* Till now only one atom data file ( generally `kurucz_cd23_chianti_H_He.h5` ) could be provided using the `--atomic-dataset` flag. Instead of this, the integration tests can now use the atom data file specified in the YAML config of a particular setup used for integration tests (in the sub directories of `tardis/tests/integration_tests` ).

* The user has to put all the atom data files specified in config files of various setups in one directory and provide the directory path in integration tests YAML config file. Alternatively, these files can be served at a URL and that URL can also be provided.

* The block schema in integration tests YAML config file looks like this:
```yml
atom_data:
    fetch: "local" # has two choices: "local" or "remote"
    url: "http://urlservingfiles.com"
    dirpath: "/path/to/directory"
```
* If `fetch` is set to local, then files will be taken from `dirpath` and `url` field will be ignored. Even writing it in isn't necessary in those cases. It will be the opposite case if `fetch: "remote"`.
* Example of URL serving atom data files: http://opensupernova.org/~karandesai96/atom_data

### Local saving of report:
* The _HTML_ report of integration tests was uploaded on a dokuwiki instance before now. This PR lets the user generate a report locally and view it in the browser.

* The block schema in integration tests YAML config file looks like this:
```yml
report:
    save_mode: "local" # has two choices: "local" or "remote"
    dokuwiki:
        url: "http://dokuwikiurl.com"
        username: "your_username"
        password: "your_password"
    dirpath: "/path/to/directory"
```

* If `save_mode` is set to local, then files will be taken from `dirpath` and `dokuwiki` section will be ignored. Even writing it in isn't necessary in those cases. It will be the opposite case if `save_mode: "remote"`.

### NOTE:
* Do add astropy's `--remote-data` flag as argument.
