### PR TITLE
Require pyyaml 3.12

### DIFF
--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -6,7 +6,6 @@ import numpy as np
 import collections
 from collections import OrderedDict
 import yaml
-import copy
 from astropy import constants, units as u
 from tardis.util import element_symbol2atomic_number
 
@@ -66,38 +65,6 @@ class YAMLLoader(yaml.Loader):
     A custom YAML loader containing all the constructors required
     to properly parse the tardis configuration.
     """
-    @classmethod
-    def add_implicit_resolver(cls, tag, regexp, first=None):
-        """
-        Parameters
-        ----------
-
-        tag:
-            The YAML tag to implicitly apply to any YAML scalar that matches `regexp`
-
-        regexp:
-            The regular expression to match YAML scalars against `tag`
-
-
-        Notes
-        -----
-
-        This classmethod is a monkey-patch for a copy() related bug
-        in the original class method which affects this yaml.Loader subclass.
-
-        This class method is to be removed when this bug gets fixed upstream.
-
-        https://bitbucket.org/xi/pyyaml/issues/57/add_implicit_resolver-on-a-subclass-may
-        """
-        if 'yaml_implicit_resolvers' not in cls.__dict__:
-            yaml_implicit_resolvers = {}
-            for k, v in cls.yaml_implicit_resolvers.items():
-                yaml_implicit_resolvers[k] = copy.copy(v)
-            cls.yaml_implicit_resolvers = yaml_implicit_resolvers
-        if first is None:
-            first = [None]
-        for ch in first:
-            cls.yaml_implicit_resolvers.setdefault(ch, []).append((tag, regexp))
 
     def construct_quantity(self, node):
         """
@@ -124,9 +91,9 @@ class YAMLLoader(yaml.Loader):
 
 YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)
 YAMLLoader.add_implicit_resolver(u'!quantity',
-                                 MockRegexPattern(quantity_from_str))
+                                 MockRegexPattern(quantity_from_str), None)
 YAMLLoader.add_implicit_resolver(u'tag:yaml.org,2002:float',
-                                 MockRegexPattern(float))
+                                 MockRegexPattern(float), None)
 YAMLLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
                            YAMLLoader.mapping_constructor)
 

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -12,6 +12,7 @@ dependencies:
 - Cython=0.21
 - networkx=1.10
 - pytest=2.9.1
+- pyyaml=3.12
 - jsonschema=2.5.1
 
 
@@ -35,4 +36,3 @@ dependencies:
   - sphinxcontrib-tikz
   - coveralls
   - pytest-html==1.10.0
-  - pyyaml==3.12

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -8,7 +8,6 @@ dependencies:
 - h5py=2.5
 - matplotlib=1.4.3
 - astropy=1.1.2
-- PyYAML=3.11
 - numexpr=2.4.4
 - Cython=0.21
 - networkx=1.10
@@ -28,6 +27,7 @@ dependencies:
 - requests=2.9.1
 - docopt=0.6.2
 - pytest-cov=2.2.1
+
 - pip:
   - nbsphinx
   - sphinx_bootstrap_theme
@@ -35,3 +35,4 @@ dependencies:
   - sphinxcontrib-tikz
   - coveralls
   - pytest-html==1.10.0
+  - pyyaml==3.12


### PR DESCRIPTION
A monkeypatch for fixing the upstream [pyyaml bug #57](https://bitbucket.org/xi/pyyaml/issues/57/add_implicit_resolver-on-a-subclass-may) which was affecting TARDIS was put in the TARDIS codebase when `YAMLLoader` was introduced.

As of pyyaml version 3.12 the bug has been fixed [upstream](https://bitbucket.org/xi/pyyaml/commits/823acfc7b4ff0ece9e6026ef0c0d98ade981c317) and therefore the monkeypatch is no longer necessary as long as we require pyyaml=3.12.

Therefore, in this PR I'm requiring pyyaml=3.12, and removing the aforementioned monkeypatch.