### PR TITLE
Remove News from main TARDIS github page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,16 +28,3 @@ http://tardis.readthedocs.org.
 .. image:: https://badges.gitter.im/Join%20Chat.svg
   :target: https://gitter.im/tardis-sn/tardis
 
-News
-====
-
-16.04.2016
-----------
-
-.. image:: http://sophia.estec.esa.int/socis2015/sites/default/files/images/esalogo.png
-  :target: http://sophia.estec.esa.int/socis/
-
-TARDIS is part of ESA's Summer of Code in Space 2016 program! If you are
-interested in participating, please check our dedicated `webpage
-<http://opensupernova.org/socis2016/doku.php>`_
-


### PR DESCRIPTION
Mini PR to remove outdated SOCIS News from the main github page.