### PR TITLE
Change matplotlib backend - fix test_integration remote plotting issue

### DIFF
--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -2,6 +2,8 @@ import os
 
 import yaml
 import pytest
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from numpy.testing import assert_allclose
 from astropy.tests.helper import assert_quantity_allclose


### PR DESCRIPTION
Currently, the integration tests fail on moria due to a plotting error (see below). This mini-PR fixes this issue by using a different backend ('Agg'). The associated problem is described in this tackoverflow post](http://stackoverflow.com/questions/4931376/generating-matplotlib-graphs-without-a-running-x-server).



## Error Log

```
self = <tardis.tests.integration_tests.test_integration.TestIntegration object at 0x7f1675cba690>, plot_object = <tardis.tests.integration_tests.plot_helpers.RemotePlotSaver object at 0x7f1675cba4d0>

    def test_spectrum(self, plot_object):
>       plot_object.add(self.plot_spectrum(), "{0}_spectrum".format(self.name))

tardis/tests/integration_tests/test_integration.py:196: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
_
tardis/tests/integration_tests/test_integration.py:217: in plot_spectrum
    spectrum_ax = plt.subplot(gs[0])
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/pyplot.py:1021: in subplot
    fig = gcf()
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/pyplot.py:578: in gcf
    return figure()
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/pyplot.py:527: in figure
    **kwargs)
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/backends/backend_qt4agg.py:46: in new_figure_manager
    return new_figure_manager_given_figure(num, thisFig)
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/backends/backend_qt4agg.py:53: in new_figure_manager_given_figure
    canvas = FigureCanvasQTAgg(figure)
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/backends/backend_qt4agg.py:76: in __init__
    FigureCanvasQT.__init__(self, figure)
/home/wkerzend/miniconda3/envs/tardis-integration/lib/python2.7/site-packages/matplotlib/backends/backend_qt4.py:68: in __init__
    _create_qApp()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
_

    def _create_qApp():
        """
        Only one qApp can exist at a time, so check before creating one.
        """
        global qApp
    
        if qApp is None:
            if DEBUG:
                print("Starting up QApplication")
            app = QtWidgets.QApplication.instance()
            if app is None:
                # check for DISPLAY env variable on X11 build of Qt
                if hasattr(QtGui, "QX11Info"):
                    display = os.environ.get('DISPLAY')
                    if display is None or not re.search(':\d', display):
>                       raise RuntimeError('Invalid DISPLAY variable')
E                       RuntimeError: Invalid DISPLAY variable
```