### PR TITLE
Update link to tardis_example.yml in documentation - Fix #676

### DIFF
--- a/docs/configuration/configuration_old.rst
+++ b/docs/configuration/configuration_old.rst
@@ -6,9 +6,11 @@ Configuration File
 
 .. :currentmodule:: tardis.config_reader
 
-TARDIS uses the `YAML markup language <https://en.wikipedia.org/wiki/YAML>`_ for its configuration files. There are several sections which allow different
-settings for the different aspects of the TARDIS calculation. An example configuration file can be downloaded
-:download:`here <example_configs/full_configuration.yml>`.
+TARDIS uses the `YAML markup language <https://en.wikipedia.org/wiki/YAML>`_
+for its configuration files. There are several sections which allow different
+settings for the different aspects of the TARDIS calculation. An example
+configuration file can be downloaded :download:`here
+<../examples/tardis_example.yml>`.
 
 .. warning::
     One should note that currently floats in YAML need to be specified in a special format:

--- a/docs/examples/tardis_example.yml
+++ b/docs/examples/tardis_example.yml
@@ -1,46 +1,47 @@
 tardis_config_version: v1.0
 supernova:
-    luminosity_requested: 9.44 log_lsun
-    time_explosion: 13 day
+  luminosity_requested: 9.44 log_lsun
+  time_explosion: 13 day
 
 atom_data: kurucz_cd23_chianti_H_He.h5
 
 model:
-    structure:
-        type: specific
-        velocity:
-            start : 1.1e4 km/s
-            stop : 20000 km/s
-            num: 20
-        density:
-            type : branch85_w7
-    abundances:
-        type: uniform
-        O: 0.19
-        Mg: 0.03
-        Si: 0.52
-        S: 0.19
-        Ar: 0.04
-        Ca: 0.03
+  structure:
+    type: specific
+    velocity:
+      start: 1.1e4 km/s
+      stop: 20000 km/s
+      num: 20
+    density:
+      type: branch85_w7
+  abundances:
+    type: uniform
+    O: 0.19
+    Mg: 0.03
+    Si: 0.52
+    S: 0.19
+    Ar: 0.04
+    Ca: 0.03
+
 plasma:
-    disable_electron_scattering: no
-    ionization: lte
-    excitation: lte
-    radiative_rates_type: dilute-blackbody
-    line_interaction_type: macroatom
+  disable_electron_scattering: no
+  ionization: lte
+  excitation: lte
+  radiative_rates_type: dilute-blackbody
+  line_interaction_type: macroatom
 
 montecarlo:
-    seed: 23111963
-    no_of_packets : 4.0e+4
-    iterations: 20
-    black_body_sampling:
-        start: 1 angstrom
-        stop: 1000000 angstrom
-        num: 1.e+6
-    last_no_of_packets: 1.e+5
-    no_of_virtual_packets: 10
+  seed: 23111963
+  no_of_packets: 4.0e+4
+  iterations: 20
+  black_body_sampling:
+    start: 1 angstrom
+    stop: 1000000 angstrom
+    num: 1.e+6
+  last_no_of_packets: 1.e+5
+  no_of_virtual_packets: 10
 
 spectrum:
-    start : 500 angstrom
-    stop : 20000 angstrom
-    num: 10000
+  start: 500 angstrom
+  stop: 20000 angstrom
+  num: 10000


### PR DESCRIPTION
This PR fixes issue #676 by correcting the link the documentation.

In the future we have to consolidate the different locations where we store tardis configs.