### PR TITLE
converted spectrum_frequency

### DIFF
--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -201,12 +201,12 @@ cdef initialize_storage_model(model, plasma, runner, storage_model_t *storage):
     storage.js = <double*> PyArray_DATA(runner.j_estimator)
     storage.nubars = <double*> PyArray_DATA(runner.nu_bar_estimator)
 
-    storage.spectrum_start_nu = runner.spectrum_frequency.value.min()
-    storage.spectrum_end_nu = runner.spectrum_frequency.value.max()
+    storage.spectrum_start_nu = runner.spectrum_frequency.to('Hz').value.min() 
+    storage.spectrum_end_nu = runner.spectrum_frequency.to('Hz').value.max()
     # TODO: Linspace handling for virtual_spectrum_range
     storage.spectrum_virt_start_nu = runner.virtual_spectrum_range.stop.to('Hz', units.spectral()).value
     storage.spectrum_virt_end_nu = runner.virtual_spectrum_range.start.to('Hz', units.spectral()).value
-    storage.spectrum_delta_nu = runner.spectrum_frequency.value[1] - runner.spectrum_frequency.value[0]
+    storage.spectrum_delta_nu = runner.spectrum_frequency.to('Hz').value[1] - runner.spectrum_frequency.to('Hz').value[0]
 
     storage.spectrum_virt_nu = <double*> PyArray_DATA(
         runner.legacy_montecarlo_virtual_luminosity)

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -201,7 +201,7 @@ cdef initialize_storage_model(model, plasma, runner, storage_model_t *storage):
     storage.js = <double*> PyArray_DATA(runner.j_estimator)
     storage.nubars = <double*> PyArray_DATA(runner.nu_bar_estimator)
 
-    storage.spectrum_start_nu = runner.spectrum_frequency.to('Hz').value.min() 
+    storage.spectrum_start_nu = runner.spectrum_frequency.to('Hz').value.min()
     storage.spectrum_end_nu = runner.spectrum_frequency.to('Hz').value.max()
     # TODO: Linspace handling for virtual_spectrum_range
     storage.spectrum_virt_start_nu = runner.virtual_spectrum_range.stop.to('Hz', units.spectral()).value


### PR DESCRIPTION
This PR is aimed to fix the issue #681 . 
This PR aims to solve the issue #681 , i.e. converting the quantities in montecarlo.pyx to astropy quantities as they are used throught the code, so that to ensure that no incompatibility occurs during the computations. Referred to the `astropy docs` for converting a quantity to astropy quantity with the given units. 

Following is the code I changed. 
``` storage.spectrum_start_nu = runner.spectrum_frequency.to('Hz').value.min() ```
    `storage.spectrum_end_nu = runner.spectrum_frequency.to('Hz').value.max()
    # TODO: Linspace handling for virtual_spectrum_range
    storage.spectrum_virt_start_nu = runner.virtual_spectrum_range.stop.to('Hz', units.spectral()).value
    storage.spectrum_virt_end_nu = runner.virtual_spectrum_range.start.to('Hz', units.spectral()).value
    storage.spectrum_delta_nu = runner.spectrum_frequency.to('Hz').value[1] - runner.spectrum_frequency.to('Hz').value[0] ` explicitly converted `spectrum_frequency` to Hz . 
