### PR TITLE
Store emitted_luminosity as an attribute of the Simulation object

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -68,12 +68,8 @@ class Simulation(object):
 
     def estimate_t_inner(self, input_t_inner, luminosity_requested,
                          t_inner_update_exponent=-0.5):
-        emitted_luminosity = self.runner.calculate_emitted_luminosity(
-                                self.luminosity_nu_start,
-                                self.luminosity_nu_end)
-
         luminosity_ratios = (
-            (emitted_luminosity / luminosity_requested).to(1).value)
+            (self.emitted_luminosity / luminosity_requested).to(1).value)
 
         return input_t_inner * luminosity_ratios ** t_inner_update_exponent
 
@@ -198,11 +194,11 @@ class Simulation(object):
         if np.sum(output_energy < 0) == len(output_energy):
             logger.critical("No r-packet escaped through the outer boundary.")
 
-        emitted_luminosity = self.runner.calculate_emitted_luminosity(
+        self.emitted_luminosity = self.runner.calculate_emitted_luminosity(
             self.luminosity_nu_start, self.luminosity_nu_end)
         reabsorbed_luminosity = self.runner.calculate_reabsorbed_luminosity(
             self.luminosity_nu_start, self.luminosity_nu_end)
-        self.log_run_results(emitted_luminosity,
+        self.log_run_results(self.emitted_luminosity,
                              reabsorbed_luminosity)
         self.iterations_executed += 1
 


### PR DESCRIPTION
This also fixes calculating it twice per iteration.