### PR TITLE
Add missing diagnostics property to runner's to_hdf list

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -325,6 +325,7 @@ class MontecarloRunner(object):
         runner_path = os.path.join(path, 'runner')
         properties = ['output_nu', 'output_energy', 'nu_bar_estimator',
                       'j_estimator', 'montecarlo_virtual_luminosity',
+                      'last_interaction_in_nu',
                       'last_line_interaction_in_id',
                       'last_line_interaction_out_id',
                       'last_line_interaction_shell_id',


### PR DESCRIPTION
This mini PR adds the ``last_interaction_in_nu`` runner property to the list of properties which are written to hdf.

This property is very important for a detailed analysis of the output spectrum (e.g. for Kromer plots)