### PR TITLE
Set default value for nthreads in montecarlo schema to 0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,11 +60,11 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-add_command_option('install', 'with-openmp', 'compile TARDIS without OpenMP',
+add_command_option('install', 'with-openmp', 'compile TARDIS with OpenMP',
                    is_bool=True)
-add_command_option('build', 'with-openmp', 'compile TARDIS without OpenMP',
+add_command_option('build', 'with-openmp', 'compile TARDIS with OpenMP',
                    is_bool=True)
-add_command_option('develop', 'with-openmp', 'compile TARDIS without OpenMP',
+add_command_option('develop', 'with-openmp', 'compile TARDIS with OpenMP',
                    is_bool=True)
 add_command_option('install', 'with-vpacket-logging', 'compile TARDIS with virtual packet logging',
                    is_bool=True)
@@ -140,4 +140,3 @@ setup(name=PACKAGENAME + '-sn',
       entry_points=entry_points,
       **package_info
 )
-

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -4,7 +4,7 @@ properties:
   nthreads:
     type: number
     multipleOf: 1.0
-    default: 1
+    default: 0
     description: The number of OpenMP threads.
   seed:
     type: number


### PR DESCRIPTION
Addresses https://github.com/tardis-sn/tardis/issues/699.

This ensures to that, if `nthreads` isn't specified, the value of the `OMP_NUM_THREADS` environment variable is used by OpenMP instead of `1`.