### PR TITLE
from_hdf5 function (TEP014)

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -454,16 +454,16 @@ class Simulation(object):
         v_boundary_outer = sim_dict['model']['v_outer'][
             len(sim_dict['model']['v_outer']) - 1] * u.cm / u.s
         dilution_factor = np.array(sim_dict['model']['w'])
-        velocity = np.append(v_boundary_inner.value,
+        velocity = np.append(sim_dict['model']['v_inner'],
                              v_boundary_outer.value) * u.cm / u.s
 
-        #Presently homologous_density and luminosity_requested parameters are set to None
+        # Presently homologous_density and luminosity_requested parameters are
+        # set to None
         model = Radial1DModel(velocity, None, abundance, time_explosion,
                               t_inner, None, t_radiative,
                               dilution_factor, v_boundary_inner,
                               v_boundary_outer)
-        
-        #TODO Extend it to plasma and montecarlo objects and return Simulation object
+        # TODO : Extend it to plasma and montecarlo objects and return Simulation object
 
         return model
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -4,10 +4,11 @@ import numpy as np
 import pandas as pd
 from astropy import units as u
 from collections import OrderedDict
-
+import h5py
 from tardis.montecarlo import MontecarloRunner
 from tardis.model import Radial1DModel
 from tardis.plasma.standard_plasmas import assemble_plasma
+import os
 
 # Adding logging support
 logger = logging.getLogger(__name__)
@@ -409,4 +410,139 @@ class Simulation(object):
                    luminosity_requested=config.supernova.luminosity_requested.cgs,
                    convergence_strategy=config.montecarlo.convergence_strategy,
                    nthreads=config.montecarlo.nthreads)
+
+    @classmethod
+    def from_hdf5(cls, file_path):
+        """
+        This function converts a hdf5 file to a Radial1DModel Object.
+
+        Parameters
+        ----------
+
+        file_path : `str`
+            path to Simulation generated hdf file
+
+        Returns
+        -------
+
+        model : `~Radial1DModel`
+        """
+
+        if file_path is None:
+            raise ValueError("File Path can`t be None")
+        if not os.path.exists(file_path):
+            raise IOError("Supplied HDF5 File %s does not exists" % file_path)
+
+        h5_file = h5py.File(file_path)
+        sim_dict = {}  # It will store HDF Objects in a dict form
+        for simulation in h5_file.keys():
+            for key in h5_file[simulation]:
+                sim_dict[key] = {}
+                if 'model' in key:
+                    cls.read_model_data(
+                        h5_file, simulation + '/model/', sim_dict[key], file_path)
+                if 'plasma' in key:
+                    cls.read_plasma_data(
+                        h5_file, simulation + '/plasma/', sim_dict[key], file_path)
+        h5_file.close()
+        #Creates corresponding astropy.units.Quantity objects
+        abundance = sim_dict['plasma']['abundance']
+        time_explosion = sim_dict['plasma']['scalars']['time_explosion'] * u.s
+        t_inner = sim_dict['model']['scalars']['t_inner'] * u.K
+        t_radiative = sim_dict['plasma']['t_rad'] * u.K
+        v_boundary_inner = sim_dict['model']['v_inner'][0] * u.cm / u.s
+        v_boundary_outer = sim_dict['model']['v_outer'][
+            len(sim_dict['model']['v_outer']) - 1] * u.cm / u.s
+        dilution_factor = np.array(sim_dict['model']['w'])
+        velocity = np.append(v_boundary_inner.value,
+                             v_boundary_outer.value) * u.cm / u.s
+
+        #homologous_density and luminosity_requested parameters are None
+        model = Radial1DModel(velocity, None, abundance, time_explosion,
+                              t_inner, None, t_radiative,
+                              dilution_factor, v_boundary_inner,
+                              v_boundary_outer)
+
+        return model
+
+    @classmethod
+    def read_model_data(cls, h5_file, path, sim_dict, file_path):
+        """
+        This function reads model data from given HDF5 File.
+
+        Parameters
+        ----------
+
+        h5_file : `h5py.File`
+            Given HDF5 file
+        path : 'str'
+            Path to transverse in hdf file
+        sim_dict : 'dict'
+            Stores HDF Leaf objects
+        file_path : 'str'
+            Path of Simulation generated HDF file 
+            Required for pd.HDFStore function call
+
+
+        Returns
+        -------
+        None
+        """
+
+        if file_path is None:
+            raise ValueError("File Path can`t be None")
+        if not os.path.exists(file_path):
+            raise IOError("Supplied HDF5 File %s does not exists" % file_path)
+        if not h5_file:
+            raise ValueError("h5file Parameter can`t be None")
+        data = pd.HDFStore(file_path)
+        for key in h5_file[path].keys():
+            sim_dict[key] = {}
+            buff_path = path + '/' + key + '/'
+            sim_dict[key] = data[buff_path]
+
+        data.close()
+
+    @classmethod
+    def read_plasma_data(cls, h5_file, path, sim_dict, file_path):
+        """
+        This function reads plasma data from given HDF5 File.
+
+        Parameters
+        ----------
+
+        h5_file : `h5py.File`
+            Given HDF5 file
+        path : 'str'
+            Path to transverse in hdf file
+        sim_dict : 'dict'
+            Stores HDF Leaf objects
+        file_path : 'str' 
+            Path to Simulation generated hdf file
+            Required for pd.HDFStore function call
+
+
+        Returns
+        -------
+        None
+        """
+        if file_path is None:
+            raise ValueError("File Path can`t be None")
+        if not os.path.exists(file_path):
+            raise IOError("Supplied HDF5 File %s does not exists" % file_path)
+        if not h5_file:
+            raise ValueError("h5file Parameter can`t be None")
+
+        data = pd.HDFStore(file_path)
+        # For now , it reads only that keys , which are required for constructing
+        # Radial1DModel Object
+        plasma_keys = ['abundance', 't_rad', 'scalars']
+        for key in h5_file[path].keys():
+            if key in plasma_keys:
+                sim_dict[key] = {}
+                buff_path = path + '/' + key + '/'
+                sim_dict[key] = data[buff_path]
+
+        data.close()
+
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -449,7 +449,7 @@ class Simulation(object):
         abundance = sim_dict['plasma']['abundance']
         time_explosion = sim_dict['plasma']['scalars']['time_explosion'] * u.s
         t_inner = sim_dict['model']['scalars']['t_inner'] * u.K
-        t_radiative = sim_dict['plasma']['t_rad'] * u.K
+        t_radiative = np.array(sim_dict['plasma']['t_rad']) * u.K
         v_boundary_inner = sim_dict['model']['v_inner'][0] * u.cm / u.s
         v_boundary_outer = sim_dict['model']['v_outer'][
             len(sim_dict['model']['v_outer']) - 1] * u.cm / u.s

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -497,13 +497,12 @@ class Simulation(object):
             raise IOError("Supplied HDF5 File %s does not exists" % file_path)
         if not h5_file:
             raise ValueError("h5file Parameter can`t be None")
-        data = pd.HDFStore(file_path)
-        for key in h5_file[path].keys():
-            sim_dict[key] = {}
-            buff_path = path + '/' + key + '/'
-            sim_dict[key] = data[buff_path]
+        with pd.HDFStore(file_path, 'r') as data:
+            for key in h5_file[path].keys():
+                sim_dict[key] = {}
+                buff_path = path + '/' + key + '/'
+                sim_dict[key] = data[buff_path]
 
-        data.close()
 
     @classmethod
     def read_plasma_data(cls, h5_file, path, sim_dict, file_path):
@@ -535,16 +534,15 @@ class Simulation(object):
         if not h5_file:
             raise ValueError("h5file Parameter can`t be None")
 
-        data = pd.HDFStore(file_path)
+        with pd.HDFStore(file_path, 'r') as data:
         # For now , it reads only that keys , which are required for constructing
         # Radial1DModel Object
-        plasma_keys = ['abundance', 't_rad', 'scalars']
-        for key in h5_file[path].keys():
-            if key in plasma_keys:
-                sim_dict[key] = {}
-                buff_path = path + '/' + key + '/'
-                sim_dict[key] = data[buff_path]
+            plasma_keys = ['abundance', 't_rad', 'scalars']
+            for key in h5_file[path].keys():
+                if key in plasma_keys:
+                    sim_dict[key] = {}
+                    buff_path = path + '/' + key + '/'
+                    sim_dict[key] = data[buff_path]
 
-        data.close()
 
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -433,18 +433,18 @@ class Simulation(object):
         if not os.path.exists(file_path):
             raise IOError("Supplied HDF5 File %s does not exists" % file_path)
 
-        h5_file = h5py.File(file_path)
-        sim_dict = {}  # It will store HDF Objects in a dict form
-        for simulation in h5_file.keys():
-            for key in h5_file[simulation]:
-                sim_dict[key] = {}
-                if 'model' in key:
-                    cls.read_model_data(
-                        h5_file, simulation + '/model/', sim_dict[key], file_path)
-                if 'plasma' in key:
-                    cls.read_plasma_data(
-                        h5_file, simulation + '/plasma/', sim_dict[key], file_path)
-        h5_file.close()
+        with h5py.File(file_path, 'r') as h5_file:
+            sim_dict = {}  # It will store HDF Objects in a dict form
+            for simulation in h5_file.keys():
+                for key in h5_file[simulation]:
+                    sim_dict[key] = {}
+                    if 'model' in key:
+                        cls.read_model_data(
+                            h5_file, simulation + '/model/', sim_dict[key], file_path)
+                    if 'plasma' in key:
+                        cls.read_plasma_data(
+                            h5_file, simulation + '/plasma/', sim_dict[key], file_path)
+
         #Creates corresponding astropy.units.Quantity objects
         abundance = sim_dict['plasma']['abundance']
         time_explosion = sim_dict['plasma']['scalars']['time_explosion'] * u.s

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -457,11 +457,13 @@ class Simulation(object):
         velocity = np.append(v_boundary_inner.value,
                              v_boundary_outer.value) * u.cm / u.s
 
-        #homologous_density and luminosity_requested parameters are None
+        #Presently homologous_density and luminosity_requested parameters are set to None
         model = Radial1DModel(velocity, None, abundance, time_explosion,
                               t_inner, None, t_radiative,
                               dilution_factor, v_boundary_inner,
                               v_boundary_outer)
+        
+        #TODO Extend it to plasma and montecarlo objects and return Simulation object
 
         return model
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -442,7 +442,3 @@ class Simulation(object):
         # As of now , it cannot return Simulation object , as convergence_strategy cannot
         # be set to None , at the time of initialization
         return model
-
-
-
-


### PR DESCRIPTION
@wkerzendorf  
This PR is related to first and bonus objective for [TEP014](http://opensupernova.org/gsoc2017/doku.php?id=ideas_page) (Reading Simulation from file).
I have implemented a from_hdf5 function in Simulation Base class, which returns Radial1DModel object.
Presently it is not extended for Plasma and MonteCarlo Runner objects.
homogeneous_density and luminosity_requested are set to None for now.

Example Usage :

```
from tardis.simulation import Simulation
model = Simulation.from_hdf5('/path/to/model_output.hdf')
print model.time_explosion
print model.v_boundary_inner
print model.v_boundary_outer
```

 