### PR TITLE
Automatically conversion and store ranges as linspaces(solution for #679)

### DIFF
--- a/tardis/io/schemas/base.yml
+++ b/tardis/io/schemas/base.yml
@@ -17,15 +17,7 @@ properties:
   montecarlo:
     $ref: montecarlo.yml
   spectrum:
-    type: object
-    properties:
-      start:
-        type: quantity
-      stop:
-        type: quantity
-      num:
-        type: number
-        multipleOf: 1.0
+    type: quantity
     description: Final spectrum sampling
 required:
 - tardis_config_version

--- a/tardis/io/schemas/model.yml
+++ b/tardis/io/schemas/model.yml
@@ -124,15 +124,7 @@ definitions:
           enum:
           - specific
         velocity:
-          type: object
-          properties:
-            start:
-              type: quantity
-            stop:
-              type: quantity
-            num:
-              type: number
-              multipleOf: 1.0
+          type: quantity
           description: description of the boundaries of the shells
         density:
           oneOf:

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -20,19 +20,7 @@ properties:
     multipleOf: 1.0
     description: Number of maximum iterations
   black_body_sampling:
-    type: object
-    default: {}
-    properties:
-      start:
-        type: quantity
-        default: 50 angstrom
-      stop:
-        type: quantity
-        default: 200000 angstrom
-      num:
-        type: number
-        multipleOf: 1.0
-        default: 1000000
+    type: quantity
     description: Sampling of the black-body for energy packet creation (giving maximum
       and minimum packet frequency)
   last_no_of_packets:
@@ -47,19 +35,7 @@ properties:
     default: 0
     description: Setting the number of virtual packets for the last iteration.
   virtual_spectrum_range:
-    type: object
-    default: {}
-    properties:
-      start:
-        type: quantity
-        default: 50 angstrom
-      stop:
-        type: quantity
-        default: 250000 angstrom
-      num:
-        type: number
-        multipleOf: 1.0
-        default: 1000000
+    type: quantity
     description: Limits of virtual packet spectrum (giving maximum and minimum packet
       frequency)
   enable_reflective_inner_boundary:

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -38,12 +38,12 @@ def test_from_config_dict(tardis_config_verysimple):
                                           validate=True,
                                           config_dirname='test')
     assert conf.config_dirname == 'test'
-    assert_almost_equal(conf.spectrum.start.value,
-                        tardis_config_verysimple['spectrum']['start'].value)
-    assert_almost_equal(conf.spectrum.stop.value,
-                        tardis_config_verysimple['spectrum']['stop'].value)
+    assert_almost_equal(conf.spectrum[0].value,
+                        tardis_config_verysimple['spectrum'][0].value)
+    assert_almost_equal(conf.spectrum[-1].value,
+                        tardis_config_verysimple['spectrum'][-1].value)
 
-    tardis_config_verysimple['spectrum']['start'] = 'Invalid'
+    tardis_config_verysimple['spectrum'] = 'Invalid'
     with pytest.raises(ValidationError):
         conf = Configuration.from_config_dict(tardis_config_verysimple,
                                               validate=True,

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -92,10 +92,10 @@ class YAMLLoader(yaml.Loader):
         if set(mapping_dict.keys()) == {'start', 'stop', 'num'}:
             if hasattr(mapping_dict['start'], 'unit'):
                 return quantity_linspace(mapping_dict['start'], mapping_dict['stop'],
-                                         mapping_dict['num'])
+                                         mapping_dict['num']+1)
             else:
                 return np.linspace(mapping_dict['start'], mapping_dict['stop'],
-                                         mapping_dict['num'])
+                                         mapping_dict['num']+1)
         return OrderedDict(self.construct_pairs(node))
 
 YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 import yaml
 from astropy import constants, units as u
 from tardis.util import element_symbol2atomic_number
+from tardis.util import quantity_linspace
 
 import logging
 logger = logging.getLogger(__name__)
@@ -89,14 +90,12 @@ class YAMLLoader(yaml.Loader):
     def mapping_constructor(self, node):
         mapping_dict = self.construct_mapping(node)
         if set(mapping_dict.keys()) == {'start', 'stop', 'num'}:
-            if type(mapping_dict['start']) == int:
-                return np.linspace(mapping_dict['start'],
-                                                mapping_dict['stop'],
-                                                mapping_dict['num']),
+            if hasattr(mapping_dict['start'], 'unit'):
+                return quantity_linspace(mapping_dict['start'], mapping_dict['stop'],
+                                         mapping_dict['num'])
             else:
-                return u.Quantity(np.linspace(mapping_dict['start'].value,
-                                                mapping_dict['stop'].value,
-                                                mapping_dict['num']), mapping_dict['start'].unit)
+                return np.linspace(mapping_dict['start'], mapping_dict['stop'],
+                                         mapping_dict['num'])
         return OrderedDict(self.construct_pairs(node))
 
 YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -94,9 +94,9 @@ class YAMLLoader(yaml.Loader):
                                                 mapping_dict['stop'],
                                                 mapping_dict['num']),
             else:
-                return np.linspace(mapping_dict['start'].value,
+                return u.Quantity(np.linspace(mapping_dict['start'].value,
                                                 mapping_dict['stop'].value,
-                                                mapping_dict['num']), mapping_dict['start'].unit,
+                                                mapping_dict['num']), mapping_dict['start'].unit)
         return OrderedDict(self.construct_pairs(node))
 
 YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -87,6 +87,16 @@ class YAMLLoader(yaml.Loader):
         return quantity_from_str(data)
 
     def mapping_constructor(self, node):
+        mapping_dict = self.construct_mapping(node)
+        if set(mapping_dict.keys()) == {'start', 'stop', 'num'}:
+            if type(mapping_dict['start']) == int:
+                return np.linspace(mapping_dict['start'],
+                                                mapping_dict['stop'],
+                                                mapping_dict['num']),
+            else:
+                return np.linspace(mapping_dict['start'].value,
+                                                mapping_dict['stop'].value,
+                                                mapping_dict['num']), mapping_dict['start'].unit,
         return OrderedDict(self.construct_pairs(node))
 
 YAMLLoader.add_constructor(u'!quantity', YAMLLoader.construct_quantity)

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -301,9 +301,7 @@ class Radial1DModel(object):
 
         structure = config.model.structure
         if structure.type == 'specific':
-            velocity = quantity_linspace(structure.velocity.start,
-                                         structure.velocity.stop,
-                                         structure.velocity.num + 1).cgs
+            velocity = config.model.structure.velocity
             homologous_density = HomologousDensity.from_config(config)
         elif structure.type == 'file':
             if os.path.isabs(structure.filename):

--- a/tardis/model/density.py
+++ b/tardis/model/density.py
@@ -46,9 +46,7 @@ class HomologousDensity(object):
 
         """
         d_conf = config.model.structure.density
-        velocity = quantity_linspace(config.model.structure.velocity.start,
-                                     config.model.structure.velocity.stop,
-                                     config.model.structure.velocity.num + 1).cgs
+        velocity = config.model.structure.velocity
 
         adjusted_velocity = velocity.insert(0, 0)
         v_middle = (adjusted_velocity[1:] * 0.5 +

--- a/tardis/model/tests/test_base.py
+++ b/tardis/model/tests/test_base.py
@@ -23,11 +23,11 @@ class TestModelFromPaper1Config:
 
     def test_velocities(self):
         velocity = self.config.model.structure.velocity
-        assert_almost_equal(velocity.start.cgs.value,
+        assert_almost_equal(velocity[0].cgs.value,
                             self.model.v_inner[0].cgs.value)
-        assert_almost_equal(velocity.stop.cgs.value,
+        assert_almost_equal(velocity[-1].cgs.value,
                             self.model.v_outer[-1].cgs.value)
-        assert len(self.model.v_outer) == velocity.num
+        assert len(self.model.v_outer) == len(velocity)-1
 
     def test_densities(self):
         assert_almost_equal(self.model.density[0].cgs.value,


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/15082729/23578745/d33ec6da-0103-11e7-9ffd-dca3bae33e62.png)

In the **"black_body_sampling"**, since it's quantity having a unit, so it returns its unit as well whereas the **'spectrum'** is a unitless quantity so its unit is not returning.

@ftsamis please review it once.