### PR TITLE
Minor updates to documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,10 @@ simple TARDIS calculations.
 
 .. _requirements_label:
 
+.. note::
+    We strongly recommond to install TARDIS within an Anaconda environment and
+    to always use the lastest github development version.
+
 Requirements
 ============
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,3 +1,16 @@
+GSOC 2017
+---------
+
+.. image:: https://developers.google.com/open-source/gsoc/resources/downloads/GSoC-logo-horizontal.svg
+  :target: http://python-gsoc.org/
+  :width: 458 px
+
+TARDIS participates in the Google Summer of Code 2017 program under the
+umbrella of the `Python Software Foundation <http://python-gsoc.org/>`_! If you
+are interested in contributing to TARDIS check out our dedicated `information
+page <http://opensupernova.org/gsoc2017/doku.php>`_, get in contact with us on
+`gitter <https://gitter.im/tardis-sn/gsoc2017>`_ and apply!
+
 SOCIS 2016
 ----------
 


### PR DESCRIPTION
This PR makes minor modifications in the documentation:

- a note on the installation page is added; it recommends using anaconda and the latest github development version of tardis
- the news page is updated; it now contains a small news item about GSOC 2017