### PR TITLE
Merge 'generate_reference_path' and 'reference_path' in integration tests (bug #672)

### DIFF
--- a/docs/integration.yml
+++ b/docs/integration.yml
@@ -19,13 +19,11 @@ report:
   reportpath: "~/projects/tardis/integration"
 
 
-# Path to directory containing reference HDF files.
-reference: "~/projects/tardis/integration/"
-
 # Path to directory where reference HDF files will be generated and
 # saved during the test run. Use "--generate-reference" flag in command
-# line args for the purpose, for other cases this will be simply ignored.
-generate_reference: "~/projects/tardis/integration/"
+# line args for the purpose, for other cases this will denote path
+# to the directory containing reference HDF files.
+reference: "~/projects/tardis/integration/"
 
 
 # Speeds up test execution by reducing amount of packets per iteration,

--- a/tardis/tests/integration_tests/conftest.py
+++ b/tardis/tests/integration_tests/conftest.py
@@ -40,7 +40,7 @@ def pytest_terminal_summary(terminalreporter):
             terminalreporter.config.getvalue("integration-tests")):
         # TODO: Add a check whether generation was successful or not.
         terminalreporter.write_sep("-", "Generated reference data: {0}".format(os.path.join(
-            terminalreporter.config.integration_tests_config['generate_reference'],
+            terminalreporter.config.integration_tests_config['reference'],
             tardis_githash[:7]
         )))
 
@@ -77,15 +77,18 @@ def plot_object(request):
 def data_path(request):
     integration_tests_config = request.config.integration_tests_config
     hdf_filename = "{0}.h5".format(os.path.basename(request.param))
+    if (request.config.getoption("--generate-reference") ):
+        ref_path = os.path.join(os.path.expandvars(os.path.expanduser(
+            integration_tests_config['reference'])), tardis_githash[:7]
+        )
+    else:
+        ref_path = os.path.join(os.path.expandvars(
+            os.path.expanduser(integration_tests_config['reference'])), hdf_filename
+        )
 
     path = {
         'config_dirpath': request.param,
-        'reference_filepath': os.path.join(os.path.expandvars(
-            os.path.expanduser(integration_tests_config['reference'])), hdf_filename
-        ),
-        'gen_ref_path': os.path.join(os.path.expandvars(os.path.expanduser(
-            integration_tests_config['generate_reference'])), tardis_githash[:7]
-        ),
+        'reference_filepath': ref_path,
         'setup_name': hdf_filename[:-3],
         # Temporary hack for providing atom data per individual setup.
         # This url has all the atom data files hosted, for downloading.
@@ -99,8 +102,8 @@ def data_path(request):
     ))
 
     if (request.config.getoption("--generate-reference") and not
-            os.path.exists(path['gen_ref_path'])):
-        os.makedirs(path['gen_ref_path'])
+            os.path.exists(path['reference_filepath'])):
+        os.makedirs(path['reference_filepath'])
     return path
 
 

--- a/tardis/tests/integration_tests/conftest.py
+++ b/tardis/tests/integration_tests/conftest.py
@@ -88,7 +88,7 @@ def data_path(request):
 
     path = {
         'config_dirpath': request.param,
-        'reference_filepath': ref_path,
+        'reference_path': ref_path,
         'setup_name': hdf_filename[:-3],
         # Temporary hack for providing atom data per individual setup.
         # This url has all the atom data files hosted, for downloading.
@@ -102,8 +102,8 @@ def data_path(request):
     ))
 
     if (request.config.getoption("--generate-reference") and not
-            os.path.exists(path['reference_filepath'])):
-        os.makedirs(path['reference_filepath'])
+            os.path.exists(path['reference_path'])):
+        os.makedirs(path['reference_path'])
     return path
 
 
@@ -113,7 +113,7 @@ def reference(request, data_path):
     HDF file. All data is unpacked as a collection of ``pd.Series`` and
     ``pd.DataFrames`` in a ``pd.HDFStore`` object and returned away.
 
-    Assumed that ``data_path['reference_filepath']`` is a valid HDF file
+    Assumed that ``data_path['reference_path']`` is a valid HDF file
     containing the reference dath for a particular setup.
     """
     # Reference data need not be loaded and provided if current test run itself
@@ -122,10 +122,10 @@ def reference(request, data_path):
         return
     else:
         try:
-            reference = pd.HDFStore(data_path['reference_filepath'], 'r')
+            reference = pd.HDFStore(data_path['reference_path'], 'r')
         except IOError:
             raise IOError('Reference file {0} does not exist and is needed'
-                          ' for the tests'.format(data_path['reference_filepath']))
+                          ' for the tests'.format(data_path['reference_path']))
 
         else:
             return reference

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -129,7 +129,7 @@ class TestIntegration(object):
         self.result.run()
         if request.config.getoption("--generate-reference"):
             ref_data_path = os.path.join(
-                data_path['reference_filepath'], "{0}.h5".format(self.name)
+                data_path['reference_path'], "{0}.h5".format(self.name)
             )
             if os.path.exists(ref_data_path):
                 pytest.skip(
@@ -138,7 +138,7 @@ class TestIntegration(object):
             self.result.to_hdf(path_or_buf=ref_data_path,
                                suffix_count=False)
             pytest.skip("Reference data saved at {0}".format(
-                data_path['reference_filepath']
+                data_path['reference_path']
             ))
         capmanager.resumecapture()
 

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -129,7 +129,7 @@ class TestIntegration(object):
         self.result.run()
         if request.config.getoption("--generate-reference"):
             ref_data_path = os.path.join(
-                data_path['gen_ref_path'], "{0}.h5".format(self.name)
+                data_path['reference_filepath'], "{0}.h5".format(self.name)
             )
             if os.path.exists(ref_data_path):
                 pytest.skip(
@@ -138,7 +138,7 @@ class TestIntegration(object):
             self.result.to_hdf(path_or_buf=ref_data_path,
                                suffix_count=False)
             pytest.skip("Reference data saved at {0}".format(
-                data_path['gen_ref_path']
+                data_path['reference_filepath']
             ))
         capmanager.resumecapture()
 


### PR DESCRIPTION
When *--generate-references* argument is used then path specified in `generate_reference` is used to generate reference data otherwise path of directory already containing the reference data is specified in `reference`. So instead of two fields, they are merged into one.

- **tests/integration_tests/conftest.py**: merged `gen_ref_path` and `reference_filepath` to `reference_filepath`.  
- **tests/integration_tests/test_integration.py**: changes made in test file to comply with changes in conftest.py
- **docs/integration.yml**: updated doc as there is only one field required rather than `reference` and `generate_reference` 
