### PR TITLE
Mark tardis full test as slow and adds commandline option for the same

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -75,7 +75,7 @@ def pytest_addoption(parser):
     parser.addoption("--less-packets",
                      action="store_true", default=False,
                      help="Run integration tests with less packets.")
-    parser.addoption("--py.test",dest='py.test',
+    parser.addoption("--full-test",dest='full-test',
                      action="store_true", default=False,
                      help="Run Tardis full test.")
 

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -75,6 +75,9 @@ def pytest_addoption(parser):
     parser.addoption("--less-packets",
                      action="store_true", default=False,
                      help="Run integration tests with less packets.")
+    parser.addoption("--py.test",dest='py.test',
+                     action="store_true", default=False,
+                     help="Run Tardis full test.")
 
 
 # -------------------------------------------------------------------------

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -10,7 +10,7 @@ from tardis.simulation.base import Simulation
 from tardis.io.config_reader import Configuration
 
 slow = pytest.mark.skipif(
-       not pytest.config.getoption("--py.test"),
+       not pytest.config.getoption("--full-test"),
        reason = "Need py.test commandline option to run the test")
 
 def data_path(fname):

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -9,11 +9,14 @@ from tardis.io.util import yaml_load_config_file
 from tardis.simulation.base import Simulation
 from tardis.io.config_reader import Configuration
 
-
+slow = pytest.mark.skipif(
+       not pytest.config.getoption("--py.test"),
+       reason = "Need py.test commandline option to run the test")
 
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'tests', 'data', fname)
 
+@slow
 @pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
                     reason='--atomic_database was not specified')
 class TestSimpleRun():


### PR DESCRIPTION
As mentioned on the ideas page for the project `Expanding the Integration-Testing Framework`, *Tardis full test* is marked as slow and commandline option `py.test` is added for it's execution.

- **tardis/conftest.py**: commandline option `py.test` added with boolean flag `store_true`. When `py.test` option is mentioned in the run test command *TARDIS full test* will run.

- **tardis/tests/test_tardis_full.py**: marker `slow` added to class `TestSimpleRun`. 

