### PR TITLE
Small update of to_hdf5 for runner: Necessary for Kromer Plots

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -325,6 +325,7 @@ class MontecarloRunner(object):
         runner_path = os.path.join(path, 'runner')
         properties = ['output_nu', 'output_energy', 'nu_bar_estimator',
                       'j_estimator', 'montecarlo_virtual_luminosity',
+                      'last_interaction_type',
                       'last_interaction_in_nu',
                       'last_line_interaction_in_id',
                       'last_line_interaction_out_id',


### PR DESCRIPTION
This small PR adds ``last_interaction_type`` to ``to_hdf`` of the runner class. This is needed for making Kromer plots.