### PR TITLE
Implement #725

### DIFF
--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -4,7 +4,11 @@ import numpy as np
 import pandas as pd
 from astropy import constants, units as u
 
-from tardis.util import quantity_linspace, element_symbol2atomic_number
+from tardis.util import (
+        quantity_linspace,
+        element_symbol2atomic_number,
+        SimulationChild
+        )
 from tardis.io.model_reader import read_density_file, read_abundances_file
 from tardis.io.util import to_hdf
 from density import HomologousDensity
@@ -12,7 +16,7 @@ from density import HomologousDensity
 logger = logging.getLogger(__name__)
 
 
-class Radial1DModel(object):
+class Radial1DModel(SimulationChild):
     """An object that hold information about the individual shells.
 
     Parameters

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -141,8 +141,7 @@ class MontecarloRunner(SimulationChild):
         None
         """
         self.time_of_simulation = self.calculate_time_of_simulation(model)
-        self.volume = model.volume
-        self._initialize_estimator_arrays(self.volume.shape[0],
+        self._initialize_estimator_arrays(self.simulation.model.volume.shape[0],
                                           plasma.tau_sobolevs.shape)
         self._initialize_geometry_arrays(model)
 
@@ -295,7 +294,7 @@ class MontecarloRunner(SimulationChild):
                 / self.j_estimator)
         w = self.j_estimator / (4 * const.sigma_sb.cgs.value * t_rad ** 4
                                 * self.time_of_simulation.value
-                                * self.volume.value)
+                                * self.simulation.model.volume.value)
 
         return t_rad * u.K, w
 

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -7,7 +7,10 @@ from astropy import units as u, constants as const
 from scipy.special import zeta
 from spectrum import TARDISSpectrum
 
-from tardis.util import quantity_linspace
+from tardis.util import (
+        quantity_linspace,
+        SimulationChild,
+        )
 from tardis.montecarlo import montecarlo, packet_source
 from tardis.io.util import to_hdf
 
@@ -16,7 +19,7 @@ import pandas as pd
 
 logger = logging.getLogger(__name__)
 
-class MontecarloRunner(object):
+class MontecarloRunner(SimulationChild):
     """
     This class is designed as an interface between the Python part and the
     montecarlo C-part
@@ -173,7 +176,6 @@ class MontecarloRunner(object):
     def get_line_interaction_id(self, line_interaction_type):
         return ['scatter', 'downbranch', 'macroatom'].index(
             line_interaction_type)
-
 
     @property
     def output_nu(self):

--- a/tardis/plasma/base.py
+++ b/tardis/plasma/base.py
@@ -6,12 +6,13 @@ import fileinput
 import networkx as nx
 import pandas as pd
 
+from tardis.util import SimulationChild
 from tardis.plasma.exceptions import PlasmaMissingModule, NotInitializedModule
 from tardis.plasma.properties.base import *
 
 logger = logging.getLogger(__name__)
 
-class BasePlasma(object):
+class BasePlasma(SimulationChild):
 
     outputs_dict = {}
     def __init__(self, plasma_properties, property_kwargs=None, **kwargs):

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -46,8 +46,11 @@ class Simulation(object):
         self.iterations = iterations
         self.iterations_executed = 0
         self.model = model
+        self.model.simulation = self
         self.plasma = plasma
+        self.plasma.simulation = self
         self.runner = runner
+        self.runner.simulation = self
         self.no_of_packets = no_of_packets
         self.last_no_of_packets = last_no_of_packets
         self.no_of_virtual_packets = no_of_virtual_packets

--- a/tardis/util.py
+++ b/tardis/util.py
@@ -429,3 +429,28 @@ def quantity_linspace(start, stop, num, **kwargs):
                          'unit attribute')
 
     return np.linspace(start.value, stop.to(start.unit).value, num, **kwargs) * start.unit
+
+
+class SimulationChild(object):
+    '''
+    Mixing class to allow access to the simulation object from a child.
+    '''
+
+    @property
+    def simulation(self):
+        if getattr(self, '_simulation', None):
+            return self._simulation
+        else:
+            raise ValueError(
+                    str(self.__class__.__name__) +
+                    ' is not yet linked to a Simulation instance.')
+
+    @simulation.setter
+    def simulation(self, value):
+        from tardis.simulation import Simulation
+        if not isinstance(value, Simulation):
+            raise ValueError(
+                    'The setter of ' +
+                    str(self.__class__.__name__) +
+                    '.simulation expects an instance of Simulation')
+        self._simulation = value


### PR DESCRIPTION
A simple change that allows the three main dataholders (model, runner and plasma) access the parent (simulation) and therefore allow for less clutter in function calling.

It's just a small change which I think would benefit the overall code quality in the future.