### PR TITLE
Refactor spectrum

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -108,10 +108,11 @@ class MontecarloRunner(object):
 
     @property
     def spectrum_virtual(self):
-        # if no_of_virtual_packets > 0:
-        #     montecarlo_virtual_luminosity = (
-        #             self.montecarlo_virtual_luminosity *
-        #             1 * u.erg / self.time_of_simulation)[:-1]
+        if np.all(self.montecarlo_virtual_luminosity == 0):
+            warnings.warn(
+                    "MontecarloRunner.spectrum_virtual"
+                    "is zero. Please run the montecarlo simulation with"
+                    "no_of_virtual_packets > 0", UserWarning)
 
         return TARDISSpectrum(
                 self.spectrum_frequency,

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -31,13 +31,12 @@ class MontecarloRunner(object):
 
     def __init__(self, seed, spectrum_frequency, virtual_spectrum_range,
                  sigma_thomson, enable_reflective_inner_boundary,
-                 inner_boundary_albedo, line_interaction_type, distance=None):
+                 inner_boundary_albedo, line_interaction_type):
 
         self.seed = seed
         self.packet_source = packet_source.BlackBodySimpleSource(seed)
         self.spectrum_frequency = spectrum_frequency
         self.virtual_spectrum_range = virtual_spectrum_range
-        self.distance = distance
         self.sigma_thomson = sigma_thomson
         self.enable_reflective_inner_boundary = enable_reflective_inner_boundary
         self.inner_boundary_albedo = inner_boundary_albedo
@@ -99,15 +98,13 @@ class MontecarloRunner(object):
     def spectrum(self):
         return TARDISSpectrum(
                 self.spectrum_frequency,
-                self.montecarlo_emitted_luminosity,
-                self.distance)
+                self.montecarlo_emitted_luminosity)
 
     @property
     def spectrum_reabsorbed(self):
         return TARDISSpectrum(
                 self.spectrum_frequency,
-                self.montecarlo_reabsorbed_luminosity,
-                self.distance)
+                self.montecarlo_reabsorbed_luminosity)
 
     @property
     def spectrum_virtual(self):
@@ -118,8 +115,7 @@ class MontecarloRunner(object):
 
         return TARDISSpectrum(
                 self.spectrum_frequency,
-                self.montecarlo_virtual_luminosity,
-                self.distance)
+                self.montecarlo_virtual_luminosity)
 
     def run(self, model, plasma, no_of_packets, no_of_virtual_packets=0, nthreads=1,last_run=False):
         """
@@ -394,5 +390,5 @@ class MontecarloRunner(object):
                    sigma_thomson=sigma_thomson,
                    enable_reflective_inner_boundary=config.montecarlo.enable_reflective_inner_boundary,
                    inner_boundary_albedo=config.montecarlo.inner_boundary_albedo,
-                   line_interaction_type=config.plasma.line_interaction_type,
-                   distance=config.supernova.get('distance', None))
+                   line_interaction_type=config.plasma.line_interaction_type
+                   )

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -12,9 +12,9 @@ from tardis.montecarlo import montecarlo, packet_source
 from tardis.io.util import to_hdf
 
 import numpy as np
-import pandas as pd
 
 logger = logging.getLogger(__name__)
+
 
 class MontecarloRunner(object):
     """
@@ -53,12 +53,11 @@ class MontecarloRunner(object):
         model: ~Radial1DModel
         """
 
-        #Estimators
+        # Estimators
         self.j_estimator = np.zeros(no_of_shells, dtype=np.float64)
         self.nu_bar_estimator = np.zeros(no_of_shells, dtype=np.float64)
         self.j_blue_estimator = np.zeros(tau_sobolev_shape)
         self.Edotlu_estimator = np.zeros(tau_sobolev_shape)
-
 
     def _initialize_geometry_arrays(self, model):
         """

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -229,7 +229,7 @@ cdef initialize_storage_model(model, plasma, runner, storage_model_t *storage):
     storage.spectrum_delta_nu = runner.spectrum_frequency.to('Hz').value[1] - runner.spectrum_frequency.to('Hz').value[0]
 
     storage.spectrum_virt_nu = <double*> PyArray_DATA(
-        runner.legacy_montecarlo_virtual_luminosity)
+        runner._montecarlo_virtual_luminosity.value)
 
     storage.sigma_thomson = runner.sigma_thomson.cgs.value
     storage.inverse_sigma_thomson = 1.0 / storage.sigma_thomson

--- a/tardis/montecarlo/spectrum.py
+++ b/tardis/montecarlo/spectrum.py
@@ -92,11 +92,11 @@ class TARDISSpectrum(object):
 
     def plot(self, ax, mode='wavelength'):
         if mode == 'wavelength':
-            ax.plot(self.wavelength.value, self.flux_lambda.value)
+            ax.plot(self.wavelength.value, self.luminosity_density_lambda.value)
             ax.set_xlabel('Wavelength [{}]'.format(
                 self.wavelength.unit._repr_latex_())
                 )
-            ax.set_ylabel('Flux [%s]' % self.flux_lambda.unit._repr_latex_())
+            ax.set_ylabel('Flux [%s]' % self.luminosity_density_lambda.unit._repr_latex_())
 
     def to_ascii(self, fname, mode='luminosity_density'):
         if mode == 'luminosity_density':

--- a/tardis/montecarlo/spectrum.py
+++ b/tardis/montecarlo/spectrum.py
@@ -93,18 +93,25 @@ class TARDISSpectrum(object):
     def plot(self, ax, mode='wavelength'):
         if mode == 'wavelength':
             ax.plot(self.wavelength.value, self.flux_lambda.value)
-            ax.set_xlabel('Wavelength [%s]' % self.wavelength.unit._repr_latex_())
+            ax.set_xlabel('Wavelength [{}]'.format(
+                self.wavelength.unit._repr_latex_())
+                )
             ax.set_ylabel('Flux [%s]' % self.flux_lambda.unit._repr_latex_())
 
     def to_ascii(self, fname, mode='luminosity_density'):
         if mode == 'luminosity_density':
-            np.savetxt(fname, zip(self.wavelength.value, self.luminosity_density_lambda.value))
+            np.savetxt(
+                    fname, zip(
+                        self.wavelength.value,
+                        self.luminosity_density_lambda.value))
         elif mode == 'flux':
             np.savetxt(
                     fname,
                     zip(self.wavelength.value, self.flux_lambda.value))
         else:
-            raise NotImplementedError('only mode "luminosity_density" and "flux" are implemented')
+            raise NotImplementedError(
+                    'only mode "luminosity_density"'
+                    'and "flux" are implemented')
 
     def to_hdf(self, path_or_buf, path):
         pass

--- a/tardis/montecarlo/spectrum.py
+++ b/tardis/montecarlo/spectrum.py
@@ -5,58 +5,70 @@ from astropy import constants, units as u
 from tardis.io.util import to_hdf
 
 
+def require_field(name):
+    def _require_field(f):
+        def wrapper(self, *args, **kwargs):
+            if not getattr(self, name, None):
+                raise AttributeError(
+                        '{} is required as attribute of {} to calculate {}'.format(
+                            name,
+                            self.__class__.__name__,
+                            f.__name__
+                            )
+                        )
+            else:
+                return f(self, *args, **kwargs)
+        return wrapper
+    return _require_field
+
+
 class TARDISSpectrum(object):
     """
     TARDIS Spectrum object
     """
 
-    def __init__(self, frequency, distance=None):
-        self._frequency = frequency
-        self.wavelength = self.frequency.to('angstrom', u.spectral())
-
+    def __init__(self, frequency, luminosity, distance=None):
         self.distance = distance
 
-
-
+        self._frequency = frequency
         self.delta_frequency = frequency[1] - frequency[0]
+        self.wavelength = self.frequency.to('angstrom', u.spectral())
 
-        self._flux_nu = np.zeros_like(frequency.value) * u.Unit('erg / (s Hz cm^2)')
-        self._flux_lambda = np.zeros_like(frequency.value) * u.Unit('erg / (s Angstrom cm^2)')
+        self._luminosity = luminosity
 
-        self.luminosity_density_nu = np.zeros_like(self.frequency) * u.Unit('erg / (s Hz)')
-        self.luminosity_density_lambda = np.zeros_like(self.frequency) * u.Unit('erg / (s Angstrom)')
+        self.luminosity_density_nu = (
+                luminosity / self.delta_frequency).to('erg / (s Hz)')
+        self.luminosity_density_lambda = u.Quantity(
+                self.f_nu_to_f_lambda(self.luminosity_density_nu.value),
+                'erg / (s Angstrom)'
+                )
+
+        if self.distance is not None:
+            self._flux_nu = (
+                    self.luminosity_density_nu /
+                    (4 * np.pi * self.distance.to('cm')**2))
+
+            self._flux_lambda = u.Quantity(
+                    self.f_nu_to_f_lambda(self.flux_nu.value),
+                    'erg / (s Angstrom cm^2)'
+                    )
 
     @property
     def frequency(self):
         return self._frequency[:-1]
 
-
     @property
+    @require_field('distance')
     def flux_nu(self):
-        if self.distance is None:
-            raise AttributeError('supernova distance not supplied - flux calculation impossible')
-        else:
-            return self._flux_nu
+        return self._flux_nu
 
     @property
+    @require_field('distance')
     def flux_lambda(self):
-        if self.distance is None:
-            raise AttributeError('supernova distance not supplied - flux calculation impossible')
         return self._flux_lambda
-
-    def update_luminosity(self, spectrum_luminosity):
-        self.luminosity_density_nu = (spectrum_luminosity / self.delta_frequency).to('erg / (s Hz)')
-        self.luminosity_density_lambda = self.f_nu_to_f_lambda(self.luminosity_density_nu.value) \
-                                         * u.Unit('erg / (s Angstrom)')
-
-        if self.distance is not None:
-            self._flux_nu = (self.luminosity_density_nu / (4 * np.pi * self.distance.to('cm')**2))
-
-            self._flux_lambda = self.f_nu_to_f_lambda(self.flux_nu.value) * u.Unit('erg / (s Angstrom cm^2)')
 
     def f_nu_to_f_lambda(self, f_nu):
         return f_nu * self.frequency.value**2 / constants.c.cgs.value / 1e8
-
 
     def plot(self, ax, mode='wavelength'):
         if mode == 'wavelength':

--- a/tardis/montecarlo/spectrum.py
+++ b/tardis/montecarlo/spectrum.py
@@ -37,6 +37,8 @@ class TARDISSpectrum(object):
     """
 
     def __init__(self, _frequency, luminosity):
+
+        # Check for correct inputs
         if not _frequency.shape[0] == luminosity.shape[0] + 1:
             raise ValueError(
                     "shape of '_frequency' and 'luminosity' are not compatible"
@@ -47,25 +49,13 @@ class TARDISSpectrum(object):
         self._frequency = _frequency.to('Hz', u.spectral())
         self.luminosity = luminosity.to('erg / s')
 
-    @property
-    def frequency(self):
-        return self._frequency[:-1]
+        self.frequency = self._frequency[:-1]
+        self.delta_frequency = self._frequency[1] - self._frequency[0]
+        self.wavelength = self.frequency.to('angstrom', u.spectral())
 
-    @property
-    def delta_frequency(self):
-        return self.frequency[1] - self.frequency[0]
-
-    @property
-    def wavelength(self):
-        return self.frequency.to('angstrom', u.spectral())
-
-    @property
-    def luminosity_density_nu(self):
-        return (self.luminosity / self.delta_frequency).to('erg / (s Hz)')
-
-    @property
-    def luminosity_density_lambda(self):
-        return self.f_nu_to_f_lambda(
+        self.luminosity_density_nu = (
+                self.luminosity / self.delta_frequency).to('erg / (s Hz)')
+        self.luminosity_density_lambda = self.f_nu_to_f_lambda(
                 self.luminosity_density_nu,
                 )
 

--- a/tardis/montecarlo/spectrum.py
+++ b/tardis/montecarlo/spectrum.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 from astropy import units as u
@@ -71,6 +72,13 @@ class TARDISSpectrum(object):
     @property
     @require_field('distance')
     def flux_nu(self):
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(
+                "TARDISSpectrum.flux_nu is deprecated, "
+                "please use TARDISSpectrum.luminosity_to_flux() in the "
+                "future.",
+                category=DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)
         return self.luminosity_to_flux(
                 self.luminosity_density_nu,
                 self.distance)
@@ -78,6 +86,13 @@ class TARDISSpectrum(object):
     @property
     @require_field('distance')
     def flux_lambda(self):
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(
+                "TARDISSpectrum.flux_lambda is deprecated, "
+                "please use TARDISSpectrum.luminosity_to_flux() in the "
+                "future.",
+                category=DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)
         return self.luminosity_to_flux(
                 self.luminosity_density_lambda,
                 self.distance

--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 import numpy as np
 import pandas as pd
@@ -188,6 +187,7 @@ def test_to_from_hdf_buffer(tmpdir, spectrum):
     compare_spectra(
             spectrum,
             spec_from)
+
 
 def test_creat_from_wl(spectrum):
     actual = TARDISSpectrum(

--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -1,0 +1,198 @@
+import os
+import pytest
+import numpy as np
+import pandas as pd
+
+from astropy import (
+        units as u,
+        constants as c
+        )
+import astropy.tests.helper as test_helper
+from tardis.montecarlo.spectrum import TARDISSpectrum
+
+BIN = 5
+
+TESTDATA = [
+        {
+            'nu': u.Quantity(np.linspace(1, 50, BIN + 1), 'Hz'),
+            'lum':  u.Quantity(np.linspace(1e27, 1e28, BIN), 'erg / s'),
+            'distance': None
+            },
+        {
+            'nu': u.Quantity(np.linspace(1, 50, BIN + 1), 'Hz'),
+            'lum':  u.Quantity(np.linspace(1e27, 1e28, BIN), 'erg / s'),
+            'distance': u.Quantity(1, 'Mpc')
+            },
+        {
+            'nu': u.Quantity([1, 2, 3, 4], 'Hz'),
+            'lum': u.Quantity([1, 2, 3], 'erg / s') * np.pi,
+            'distance': u.Quantity(.5, 'cm'),
+            }
+        ]
+
+
+@pytest.fixture(
+        scope='module',
+        params=TESTDATA
+        )
+def spectrum(request):
+    data = TARDISSpectrum(
+            request.param['nu'],
+            request.param['lum'],
+            )
+    distance = request.param['distance']
+    if distance:
+        data.distance = distance
+    return data
+
+
+###
+# Testing properties
+###
+def test_frequency(spectrum):
+    assert np.all(
+            spectrum.frequency == spectrum._frequency[:-1]
+            )
+
+
+def test_luminosity_density_nu(spectrum):
+    expected = spectrum.luminosity / np.diff(spectrum._frequency)
+    test_helper.assert_quantity_allclose(
+            spectrum.luminosity_density_nu,
+            expected
+            )
+
+
+def test_luminosity_density_lambda(spectrum):
+    expected = spectrum.f_nu_to_f_lambda(
+            spectrum.luminosity / np.diff(spectrum._frequency)
+            )
+    test_helper.assert_quantity_allclose(
+            spectrum.luminosity_density_lambda,
+            expected
+            )
+
+
+def test_flux_nu(spectrum):
+    if getattr(spectrum, 'distance', None):
+        test_helper.assert_quantity_allclose(
+                spectrum.flux_nu,
+                spectrum.luminosity_to_flux(
+                    spectrum.luminosity_density_nu,
+                    spectrum.distance)
+                )
+    else:
+        with pytest.raises(AttributeError):
+            spectrum.flux_nu
+
+
+def test_flux_lambda(spectrum):
+    if getattr(spectrum, 'distance', None):
+        test_helper.assert_quantity_allclose(
+                spectrum.flux_lambda,
+                spectrum.luminosity_to_flux(
+                    spectrum.luminosity_density_lambda,
+                    spectrum.distance)
+                )
+    else:
+        with pytest.raises(AttributeError):
+            spectrum.flux_nu
+
+
+###
+# Testing methods
+###
+
+def test_luminosity_to_flux():
+    lum = u.Quantity(np.arange(1, 4, 1) * np.pi, 'erg / s')
+    distance = u.Quantity(.5, 'cm')
+    flux = TARDISSpectrum.luminosity_to_flux(lum, distance)
+    test_helper.assert_quantity_allclose(
+            flux,
+            u.Quantity(lum.value / np.pi, 'erg/s/cm^2')
+            )
+
+
+def test_f_nu_to_f_lambda(spectrum):
+    expected = (
+            spectrum.luminosity_density_nu *
+            spectrum.frequency**2 / c.c.to('angstrom/s')
+            ).to('erg / (s angstrom)')
+    print(expected)
+    test_helper.assert_quantity_allclose(
+            spectrum.luminosity_density_lambda,
+            expected
+            )
+    expected = (
+            spectrum.luminosity_density_nu *
+            spectrum.frequency**2 / c.c.to('angstrom/s')
+            ).to('erg / (s angstrom)')
+    np.testing.assert_allclose(
+            spectrum.luminosity_density_lambda.value,
+            expected.value
+            )
+
+
+###
+# Save and Load
+###
+
+def compare_spectra(actual, desired):
+    test_helper.assert_quantity_allclose(
+            actual.frequency,
+            desired.frequency
+            )
+    test_helper.assert_quantity_allclose(
+            actual.luminosity,
+            desired.luminosity
+            )
+    if getattr(actual, 'distance', None):
+        test_helper.assert_quantity_allclose(
+                actual.distance,
+                desired.distance
+                )
+
+
+@pytest.mark.xfail
+def test_to_from_hdf(tmpdir, spectrum):
+    path = str(tmpdir.join('spectrum.hdf'))
+    spectrum.to_hdf(
+            str(path),
+            'spectrum'
+            )
+
+    spec_from = TARDISSpectrum.from_hdf(
+            path,
+            'spectrum'
+            )
+
+    compare_spectra(
+            spectrum,
+            spec_from)
+
+
+@pytest.mark.xfail
+def test_to_from_hdf_buffer(tmpdir, spectrum):
+    path = str(tmpdir.join('spectrum.hdf'))
+    spectrum.to_hdf(
+            str(path),
+            'spectrum'
+            )
+
+    with pd.HDFStore(path, mode='r') as buffer:
+        spec_from = TARDISSpectrum.from_hdf(
+                buffer,
+                'spectrum'
+                )
+
+    compare_spectra(
+            spectrum,
+            spec_from)
+
+def test_creat_from_wl(spectrum):
+    actual = TARDISSpectrum(
+            spectrum._frequency.to('angstrom', u.spectral()),
+            spectrum.luminosity
+            )
+
+    compare_spectra(actual, spectrum)

--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -74,12 +74,13 @@ def test_luminosity_density_lambda(spectrum):
 
 def test_flux_nu(spectrum):
     if getattr(spectrum, 'distance', None):
-        test_helper.assert_quantity_allclose(
-                spectrum.flux_nu,
-                spectrum.luminosity_to_flux(
-                    spectrum.luminosity_density_nu,
-                    spectrum.distance)
-                )
+        with pytest.warns(DeprecationWarning):
+            test_helper.assert_quantity_allclose(
+                    spectrum.flux_nu,
+                    spectrum.luminosity_to_flux(
+                        spectrum.luminosity_density_nu,
+                        spectrum.distance)
+                    )
     else:
         with pytest.raises(AttributeError):
             spectrum.flux_nu
@@ -87,12 +88,13 @@ def test_flux_nu(spectrum):
 
 def test_flux_lambda(spectrum):
     if getattr(spectrum, 'distance', None):
-        test_helper.assert_quantity_allclose(
-                spectrum.flux_lambda,
-                spectrum.luminosity_to_flux(
-                    spectrum.luminosity_density_lambda,
-                    spectrum.distance)
-                )
+        with pytest.warns(DeprecationWarning):
+            test_helper.assert_quantity_allclose(
+                    spectrum.flux_lambda,
+                    spectrum.luminosity_to_flux(
+                        spectrum.luminosity_density_lambda,
+                        spectrum.distance)
+                    )
     else:
         with pytest.raises(AttributeError):
             spectrum.flux_nu

--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -189,10 +189,24 @@ def test_to_from_hdf_buffer(tmpdir, spectrum):
             spec_from)
 
 
+###
+# Test creation from nonstandard units
+###
+
+
 def test_creat_from_wl(spectrum):
     actual = TARDISSpectrum(
             spectrum._frequency.to('angstrom', u.spectral()),
             spectrum.luminosity
+            )
+
+    compare_spectra(actual, spectrum)
+
+
+def test_creat_from_J(spectrum):
+    actual = TARDISSpectrum(
+            spectrum._frequency,
+            spectrum.luminosity.to('J / s')
             )
 
     compare_spectra(actual, spectrum)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -215,7 +215,6 @@ class Simulation(object):
             self._call_back()
         # Last iteration
         self.iterate(self.last_no_of_packets, self.no_of_virtual_packets, True)
-        self.runner.legacy_update_spectrum(self.no_of_virtual_packets)
 
         logger.info("Simulation finished in {0:d} iterations "
                     "and took {1:.2f} s".format(


### PR DESCRIPTION
The refactor changes the way a spectrum is handled. Instead of creating
a spectrum and updating it after each montecarlo iteration, we create a
new spectrum from the MontecarloRunner whenever it is needed.

Benefits:
- TARDISSpectrum is now a general purpose spectrum class that is not
linked to the Iteration sheme anymore.
- It is now possible to save spectra for all iterations without them
being updated each iteration.
- This class can now also be used for spectra created by the formal
integral approach (upcoming PR #726)