### PR TITLE
Fix bug in plasma

### DIFF
--- a/tardis/plasma/properties/level_population.py
+++ b/tardis/plasma/properties/level_population.py
@@ -8,11 +8,13 @@ logger = logging.getLogger(__name__)
 
 __all__ = ['LevelNumberDensity', 'LevelNumberDensityHeNLTE']
 
+
 class LevelNumberDensity(ProcessingPlasmaProperty):
     """
     Attributes:
     level_number_density : Pandas DataFrame, dtype float
-                           Index atom number, ion number, level number. Columns are zones.
+                           Index atom number, ion number, level number.
+                           Columns are zones.
     """
     outputs = ('level_number_density',)
     latex_name = ('N_{i,j,k}',)
@@ -31,18 +33,20 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
                             index=partition_function.index)
         self._ion2level_idx = indexer.ix[levels.droplevel(2)].values
 
-    def calculate(self, level_boltzmann_factor, ion_number_density,
-        levels, partition_function):
+    def calculate(
+            self, level_boltzmann_factor, ion_number_density,
+            levels, partition_function):
         """
-        Reduces non-metastable level populations by a factor of W compared to LTE in the case of dilute-lte excitation.
+        Reduces non-metastable level populations by a factor of W
+        compared to LTE in the case of dilute-lte excitation.
         """
         if self.initialize_indices:
             self._initialize_indices(levels, partition_function)
             self.initialize_indices = False
         partition_function_broadcast = partition_function.values[
             self._ion2level_idx]
-        level_population_fraction = (level_boltzmann_factor.values
-                                     / partition_function_broadcast)
+        level_population_fraction = (level_boltzmann_factor.values /
+                                     partition_function_broadcast)
         ion_number_density_broadcast = ion_number_density.values[
             self._ion2level_idx]
         level_number_density = (level_population_fraction *
@@ -50,18 +54,22 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
         return pd.DataFrame(level_number_density,
                             index=level_boltzmann_factor.index)
 
+
 class LevelNumberDensityHeNLTE(LevelNumberDensity):
     """
     Attributes:
     level_number_density : Pandas DataFrame, dtype float
-                           Index atom number, ion number, level number. Columns are zones.
+                           Index atom number, ion number, level number.
+                           Columns are zones.
     """
 
-    def calculate(self, level_boltzmann_factor,
-        ion_number_density, levels, partition_function,
-                               helium_population_updated):
+    def calculate(
+            self, level_boltzmann_factor,
+            ion_number_density, levels, partition_function,
+            helium_population_updated):
         """
-        If one of the two helium NLTE methods is used, this updates the helium level populations to the appropriate
+        If one of the two helium NLTE methods is used, this updates
+        the helium level populations to the appropriate
         values.
         """
         level_number_density = super(LevelNumberDensityHeNLTE, self).calculate(

--- a/tardis/plasma/properties/level_population.py
+++ b/tardis/plasma/properties/level_population.py
@@ -11,6 +11,8 @@ __all__ = ['LevelNumberDensity', 'LevelNumberDensityHeNLTE']
 
 class LevelNumberDensity(ProcessingPlasmaProperty):
     """
+    Calculates the level populations
+
     Attributes:
     level_number_density : Pandas DataFrame, dtype float
                            Index atom number, ion number, level number.
@@ -21,9 +23,6 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
     latex_formula = ('N_{i,j}\\dfrac{bf_{i,j,k}}{Z_{i,j}}',)
 
     def __init__(self, plasma_parent):
-        """
-        Calculates the level populations with the Boltzmann equation in LTE.
-        """
         super(LevelNumberDensity, self).__init__(plasma_parent)
         self._update_inputs()
         self.initialize_indices = True
@@ -33,12 +32,12 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
                             index=partition_function.index)
         self._ion2level_idx = indexer.ix[levels.droplevel(2)].values
 
-    def calculate(
+    def _calculate_dilute_lte(
             self, level_boltzmann_factor, ion_number_density,
             levels, partition_function):
         """
-        Reduces non-metastable level populations by a factor of W
-        compared to LTE in the case of dilute-lte excitation.
+        Calculate the level populations from the level_boltzmann_factor,
+        ion_number_density and partition_function
         """
         if self.initialize_indices:
             self._initialize_indices(levels, partition_function)
@@ -53,6 +52,8 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
                                 ion_number_density_broadcast)
         return pd.DataFrame(level_number_density,
                             index=level_boltzmann_factor.index)
+
+    calculate = _calculate_dilute_lte
 
 
 class LevelNumberDensityHeNLTE(LevelNumberDensity):
@@ -72,7 +73,7 @@ class LevelNumberDensityHeNLTE(LevelNumberDensity):
         the helium level populations to the appropriate
         values.
         """
-        level_number_density = super(LevelNumberDensityHeNLTE, self).calculate(
+        level_number_density = self._calculate_dilute_lte(
             level_boltzmann_factor, ion_number_density, levels,
             partition_function)
         if helium_population_updated is not None:

--- a/tardis/plasma/properties/level_population.py
+++ b/tardis/plasma/properties/level_population.py
@@ -18,15 +18,11 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
     latex_name = ('N_{i,j,k}',)
     latex_formula = ('N_{i,j}\\dfrac{bf_{i,j,k}}{Z_{i,j}}',)
 
-    def calculate(self):
-        pass
-
     def __init__(self, plasma_parent):
         """
         Calculates the level populations with the Boltzmann equation in LTE.
         """
         super(LevelNumberDensity, self).__init__(plasma_parent)
-        self.calculate = self._calculate_dilute_lte
         self._update_inputs()
         self.initialize_indices = True
 
@@ -35,7 +31,7 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
                             index=partition_function.index)
         self._ion2level_idx = indexer.ix[levels.droplevel(2)].values
 
-    def _calculate_dilute_lte(self, level_boltzmann_factor, ion_number_density,
+    def calculate(self, level_boltzmann_factor, ion_number_density,
         levels, partition_function):
         """
         Reduces non-metastable level populations by a factor of W compared to LTE in the case of dilute-lte excitation.
@@ -54,61 +50,21 @@ class LevelNumberDensity(ProcessingPlasmaProperty):
         return pd.DataFrame(level_number_density,
                             index=level_boltzmann_factor.index)
 
-class LevelNumberDensityHeNLTE(ProcessingPlasmaProperty):
+class LevelNumberDensityHeNLTE(LevelNumberDensity):
     """
     Attributes:
     level_number_density : Pandas DataFrame, dtype float
                            Index atom number, ion number, level number. Columns are zones.
     """
-    outputs = ('level_number_density',)
-    latex_name = ('N_{i,j,k}',)
-    latex_formula = ('N_{i,j}\\dfrac{bf_{i,j,k}}{Z_{i,j}}',)
 
-    def calculate(self):
-        pass
-
-    def __init__(self, plasma_parent):
-        """
-        Calculates the level populations with the Boltzmann equation in LTE.
-        """
-        super(LevelNumberDensityHeNLTE, self).__init__(plasma_parent)
-        self.calculate = self._calculate_helium_nlte
-        self._update_inputs()
-        self.initialize_indices = True
-
-
-    def _initialize_indices(self, levels, partition_function):
-        indexer = pd.Series(np.arange(partition_function.shape[0]),
-                            index=partition_function.index)
-        self._ion2level_idx = indexer.ix[levels.droplevel(2)].values
-
-    def _calculate_dilute_lte(self, level_boltzmann_factor, ion_number_density,
-        levels, partition_function):
-        """
-        Reduces non-metastable level populations by a factor of W compared to LTE in the case of dilute-lte excitation.
-        """
-        if self.initialize_indices:
-            self._initialize_indices(levels, partition_function)
-            self.initialize_indices = False
-        partition_function_broadcast = partition_function.values[
-            self._ion2level_idx]
-        level_population_fraction = (level_boltzmann_factor.values
-                                     / partition_function_broadcast)
-        ion_number_density_broadcast = ion_number_density.values[
-            self._ion2level_idx]
-        level_number_density = (level_population_fraction *
-                                ion_number_density_broadcast)
-        return pd.DataFrame(level_number_density,
-                            index=level_boltzmann_factor.index)
-
-    def _calculate_helium_nlte(self, level_boltzmann_factor,
+    def calculate(self, level_boltzmann_factor,
         ion_number_density, levels, partition_function,
                                helium_population_updated):
         """
         If one of the two helium NLTE methods is used, this updates the helium level populations to the appropriate
         values.
         """
-        level_number_density = self._calculate_dilute_lte(
+        level_number_density = super(LevelNumberDensityHeNLTE, self).calculate(
             level_boltzmann_factor, ion_number_density, levels,
             partition_function)
         if helium_population_updated is not None:


### PR DESCRIPTION
While having a second look at the LevelNumberDensity module in plasma I found a bug.
Instead of defining the `calculate` function as a method, we assigned an attribute with a reference to a method during the `__init__`. That is a so called `instancemethod` and should only be used in special cases. In our case the `calculate` method is the same for all instances which should be reflected by the class.

If this fix hides implementation details, one could leave the original names and assign the function on the class level instead of in the `__init__`.