### PR TITLE
[TEP007] [WIP] Isotope Abundances class

### DIFF
--- a/tardis/atomic.py
+++ b/tardis/atomic.py
@@ -493,7 +493,7 @@ class AtomData(object):
             self.lines = self.lines[self.lines['ion_number'] <= max_ion_number]
 
         # self.lines.sort(['wavelength', 'line_id'], inplace=True)
-        self.lines.sort(['wavelength'], inplace=True)
+        self.lines.sort_values(by='wavelength', inplace=True)
         self.lines.set_index('line_id', inplace=True)
 
 
@@ -672,4 +672,3 @@ class NLTEData(object):
                                            t_electrons.reshape((1, 1, t_electrons.shape[0]))) * \
                       self.g_ratio_matrices[species].reshape((no_of_levels, no_of_levels, 1))
         return c_ul_matrix + c_lu_matrix.transpose(1, 0, 2)
-

--- a/tardis/io/decay.py
+++ b/tardis/io/decay.py
@@ -1,0 +1,87 @@
+import pandas as pd
+from pyne import nucname, material
+from astropy import units as u
+
+class IsotopeAbundances(pd.DataFrame):
+
+    @property
+    def _constructor(self):
+        return IsotopeAbundances
+
+    def _update_material(self):
+        self.comp_dicts = [{}] * len(self.columns)
+        for (atomic_number, mass_number), abundances in self.iterrows():
+            nuclear_symbol = '%s%d'.format(nucname.name(atomic_number),
+                                           mass_number)
+            for i in xrange(len(self.columns)):
+                self.comp_dicts[i][nuclear_symbol] = abundances[i]
+
+    @classmethod
+    def from_materials(cls, materials):
+        multi_index_tuples = set([])
+        for material in materials:
+            multi_index_tuples.update([cls.id_to_tuple(key)
+                                       for key in material.keys()])
+
+        index = pd.MultiIndex.from_tuples(
+            multi_index_tuples, names=['atomic_number', 'mass_number'])
+
+
+        abundances = pd.DataFrame(index=index, columns=xrange(len(materials)))
+
+        for i, material in enumerate(materials):
+            for key, value in material.items():
+                abundances.loc[cls.id_to_tuple(key), i] = value
+
+        return abundances
+
+
+
+
+    @staticmethod
+    def id_to_tuple(atomic_id):
+        return nucname.znum(atomic_id), nucname.anum(atomic_id)
+
+
+    def to_materials(self):
+        """
+        Convert DataFrame to a list of materials interpreting the MultiIndex as
+        atomic_number and mass_number
+
+        Returns
+        -------
+            : ~list
+            list of pyne Materialss
+        :return:
+        """
+
+        comp_dicts = [{}] * len(self.columns)
+        for (atomic_number, mass_number), abundances in self.iterrows():
+            nuclear_symbol = '{0:s}{1:d}'.format(nucname.name(atomic_number),
+                                           mass_number)
+            for i in xrange(len(self.columns)):
+                comp_dicts[i][nuclear_symbol] = abundances[i]
+        return [material.Material(comp_dict) for comp_dict in comp_dicts]
+
+
+
+    def decay(self, t):
+        """
+        Decay the Model
+
+        Parameters
+        ----------
+
+        t: ~float or ~astropy.units.Quantity
+            if float it will be understood as days
+
+        Returns:
+            : decayed abundances
+        """
+
+        materials = self.to_materials()
+        t_second = u.Quantity(t, u.day).to(u.s).value
+
+        decayed_materials = [item.decay(t_second) for item in materials]
+
+        return IsotopeAbundances.from_materials(decayed_materials)

--- a/tardis/io/decay.py
+++ b/tardis/io/decay.py
@@ -83,5 +83,7 @@ class IsotopeAbundances(pd.DataFrame):
         t_second = u.Quantity(t, u.day).to(u.s).value
 
         decayed_materials = [item.decay(t_second) for item in materials]
-
-        return IsotopeAbundances.from_materials(decayed_materials)
+        
+        df = IsotopeAbundances.from_materials(decayed_materials)
+        df.sort_index(inplace=True)
+        return df 

--- a/tardis/io/tests/test_decay.py
+++ b/tardis/io/tests/test_decay.py
@@ -1,0 +1,14 @@
+import pytest
+import pandas as pd
+
+from tardis.io.decay import IsotopeAbundances
+
+@pytest.fixture
+def simple_abundance_model():
+    index = pd.MultiIndex.from_tuples([(28, 56)],
+                                      names=['atomic_number', 'mass_number'])
+    return IsotopeAbundances([[1.0, 1.0]], index=index)
+
+
+def test_simple_decay(simple_abundance_model):
+    1/0

--- a/tardis/io/tests/test_decay.py
+++ b/tardis/io/tests/test_decay.py
@@ -2,6 +2,7 @@ import pytest
 import pandas as pd
 
 from tardis.io.decay import IsotopeAbundances
+from numpy.testing import assert_almost_equal
 
 @pytest.fixture
 def simple_abundance_model():
@@ -9,6 +10,11 @@ def simple_abundance_model():
                                       names=['atomic_number', 'mass_number'])
     return IsotopeAbundances([[1.0, 1.0]], index=index)
 
-
 def test_simple_decay(simple_abundance_model):
-    1/0
+    decayed_abundance = simple_abundance_model.decay(100)
+    assert_almost_equal(decayed_abundance.ix[26, 56][0], 0.55752)
+    assert_almost_equal(decayed_abundance.ix[26, 56][1], 0.55752)
+    assert_almost_equal(decayed_abundance.ix[27, 56][0], 0.4423791)
+    assert_almost_equal(decayed_abundance.ix[27, 56][1], 0.4423791)
+    assert_almost_equal(decayed_abundance.ix[28, 56][0], 1.1086e-05)
+    assert_almost_equal(decayed_abundance.ix[28, 56][1], 1.1086e-05)

--- a/tardis/montecarlo/tests/test_formal_integral.py
+++ b/tardis/montecarlo/tests/test_formal_integral.py
@@ -49,7 +49,7 @@ def test_trapezoid_integration(clib, N):
     func = clib.trapezoid_integration
     func.restype = c_double
     h = 1.
-
+    N = int(N)
     func.argtypes = [
             ndpointer(c_double),
             c_double,

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -1,20 +1,25 @@
 name: tardis
+
+channels:
+    - defaults
+    - conda-forge
+
 dependencies:
 - python=2.7
-- numpy=1.10
-- scipy=0.17.0
-- pandas=0.16.2
-- pytables=3.2.2
-- h5py=2.5
-- matplotlib=1.4.3
-- astropy=1.1.2
-- numexpr=2.4.4
+- numpy=1.12
+- scipy=0.18
+- pandas=0.20
+- pytables
+- h5py=2.6
+- matplotlib=2.0
+- astropy=1.3
+- numexpr=2.6
 - Cython=0.21
 - networkx=1.10
 - pytest=3.0
 - pyyaml=3.12
 - jsonschema=2.5.1
-
+- pyne=0.5.3
 
 # RTD requirements
 - sphinx=1.5.1


### PR DESCRIPTION
This PR just contains Isotope Abundance class, a simple unit test and changes in tardis environment file.
I am not able to resolve conflict for Mac-OS build for `pyne` .

#### 
- Current version of `pyne` is `0.5.3` , but I have used `0.5.0` , as `0.5.3` requires updating almost everything (pandas, numpy, astropy, h5py,etc)
- I have added  `cyclus` and `pyne` as `channels` in `tardis_env27.yml` as  `pyne` is not available through default channel
- `libgcc` was also required for `pyne` . I have not mentioned version no. for it because in case of Linux `5.2` works , and in case of `Mac` `4.8` is available. (I will check it one more time). Without updating `libgcc` in `Linux` , `pyne` is not properly imported.
- Mac OS build has conflict with `astropy` build, and If I update it , it will result in updating almost all packages as I said in point 1. 

I will try to resolve MacOS issue, if anybody as any suggestion, then most welcome. 
I have tried various combinations. 
 


