### PR TITLE
Formal Integral: including electron scattering

### DIFF
--- a/tardis/montecarlo/formal_integral.py
+++ b/tardis/montecarlo/formal_integral.py
@@ -128,7 +128,7 @@ class FormalIntegrator(object):
         att_S_ul =  ( wave * (q_ul * e_dot_u) * t  / (4*np.pi) )
 
         result = pd.DataFrame(att_S_ul.as_matrix(), index=transitions.transition_line_id.values)
-        att_S_ul = result.ix[atomic_data.lines.index.values].as_matrix()
+        att_S_ul = result.ix[atomic_data.lines.index.values].values
 
         # Jredlu should already by in the correct order, i.e. by wavelength of
         # the transition l->u (similar to Jbluelu)

--- a/tardis/montecarlo/formal_integral.py
+++ b/tardis/montecarlo/formal_integral.py
@@ -116,7 +116,7 @@ class FormalIntegrator(object):
         # functions
         Jbluelu_norm_factor = (const.c.cgs * model.time_explosion /
                                 (4 * np.pi * runner.time_of_simulation *
-                                 model.volume)).to("1/cm^2/s").value
+                                 model.volume)).to("1/(cm^2 s)").value
         # Jbluelu should already by in the correct order, i.e. by wavelength of
         # the transition l->u
         Jbluelu = runner.j_blue_estimator * Jbluelu_norm_factor
@@ -134,4 +134,9 @@ class FormalIntegrator(object):
         att_S_ul =  ( wave * (q_ul * e_dot_u) * t  / (4*np.pi) )
 
         result = pd.DataFrame(att_S_ul.as_matrix(), index=transitions.transition_line_id.values)
-        return result.ix[atomic_data.lines.index.values].as_matrix(), Jbluelu, e_dot_u
+        att_S_ul = result.ix[atomic_data.lines.index.values].as_matrix()
+
+        # Jredlu should already by in the correct order, i.e. by wavelength of
+        # the transition l->u (similar to Jbluelu)
+        Jredlu = Jbluelu * np.exp(-plasma.tau_sobolevs.values) + att_S_ul
+        return att_S_ul, Jredlu, Jbluelu, e_dot_u

--- a/tardis/montecarlo/formal_integral.py
+++ b/tardis/montecarlo/formal_integral.py
@@ -50,12 +50,6 @@ class FormalIntegrator(object):
                     'line_interaction_type == "downbranch"'
                     )
 
-        if self.runner.sigma_thomson.value > 1e-100:
-            return raise_or_return(
-                    'The FormalIntegrator currently only works with '
-                    'disable_electron_scattering turned on.'
-                    )
-
         return True
 
     def calculate_spectrum(self, frequency, points=None, raises=True):

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -120,6 +120,8 @@ cdef extern from "src/integrator.h":
             double *nu,
             int_type_t nu_size,
             double *att_S_ul,
+            double *Jred_lu,
+            double *Jblue_lu,
             int N)
 
 
@@ -307,7 +309,10 @@ def formal_integral(self, nu, N):
 
     initialize_storage_model(self.model, self.plasma, self.runner, &storage)
 
-    att_S_ul = self.make_source_function()[0].flatten(order='F')
+    res = self.make_source_function()
+    att_S_ul = res[0].flatten(order='F')
+    Jred_lu = res[1].flatten(order='F')
+    Jblue_lu = res[2].flatten(order='F')
 
     cdef double *L = _formal_integral(
             &storage,
@@ -315,6 +320,8 @@ def formal_integral(self, nu, N):
             <double*> PyArray_DATA(nu),
             nu.shape[0],
             <double*> PyArray_DATA(att_S_ul),
+            <double*> PyArray_DATA(Jred_lu),
+            <double*> PyArray_DATA(Jblue_lu),
             N
             )
     return c_array_to_numpy(L, np.NPY_DOUBLE, nu.shape[0])

--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -270,10 +270,12 @@ _formal_integral(
                        ++patt_S_ul)
                     {
                       if (*pline < nu_end)
+                      {
                         // Calculate e-scattering optical depth to grid cell boundary
                         zend = storage->time_explosion / C_INV * (1. - nu_end / nu);
                         dtau += (zend - zstart) * escat_op;
                         break;
+                      }
 
                       // Calculate e-scattering optical depth to next resonance point
                       zend = storage->time_explosion / C_INV * (1. - *pline / nu);

--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -11,14 +11,7 @@
 #include "integrator.h"
 #include "cmontecarlo.h"
 
-
-#ifdef WITHOPENMP
-  #include <omp.h>
-#else
-int64_t omp_get_num_threads(){
-    return 1;
-}
-#endif
+#include "omp_helper.h"
 
 #define NULEN   0
 #define LINELEN 1
@@ -175,19 +168,18 @@ _formal_integral(
   double R_max = storage->r_outer[size_shell - 1];
   double pp[N];
   double *exp_tau = calloc(size_tau, sizeof(double));
-#ifdef WITHOPENMP
-#pragma omp parallel firstprivate(L, exp_tau, finished_nus)
+#pragma omp parallel firstprivate(L, exp_tau)
     {
 
 #pragma omp master
         {
-          fprintf(stderr, "Doing the formal integral\nRunning with OpenMP - %d threads\n", omp_get_num_threads());
+          if (omp_get_num_threads() > 1) {
+              fprintf(stderr, "Doing the formal integral\nRunning with OpenMP - %d threads\n", omp_get_num_threads());
+          } else {
+              fprintf(stderr, "Doing the formal integral\nRunning without OpenMP\n");
+          }
           print_progress_fi(0, inu_size);
         }
-#else
-      fprintf(stderr, "Doing the formal integral\nRunning without OpenMP\n");
-      print_progress_fi(0, inu_size);
-#endif
 
       // Initializing all the thread-local variables
       int64_t offset = 0, i = 0,
@@ -335,19 +327,14 @@ _formal_integral(
             }
           // TODO: change integration to match the calculation of p values
           L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu, R_max/N, N);
-          if (++finished_nus%10 == 0){
-#ifdef WITHOPENMP
-            if (omp_get_thread_num() == 0 )
-              print_progress_fi(finished_nus * omp_get_num_threads(), inu_size);
-#else
-            print_progress_fi(nu_idx, inu_size);
-#endif
+#pragma omp atomic update
+          ++finished_nus;
+          if (finished_nus%10 == 0){
+              print_progress_fi(finished_nus, inu_size);
           }
         }
       // Free everything allocated on heap
       printf("\n");
-#ifdef WITHOPENMP
     }
-#endif
   return L;
 }

--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -291,17 +291,16 @@ _formal_integral(
                         // conditions) is not in Lucy 1999; should be
                         // re-examined carefully 
                         escat_contrib += (zend - zstart) * escat_op * (*pJblue_lu - I_nu[p_idx]) ;
-                        I_nu[p_idx] = I_nu[p_idx] + escat_contrib;
                         first = 0;
                       }
                       else{
                         // Account for e-scattering, c.f. Eqs 27, 28 in Lucy 1999
                         Jkkp = 0.5 * (*pJred_lu + *pJblue_lu);
                         escat_contrib += (zend - zstart) * escat_op * (Jkkp - I_nu[p_idx]) ;
-                        I_nu[p_idx] = I_nu[p_idx] + escat_contrib;
                         // this introduces the necessary offset of one element between pJblue_lu and pJred_lu
                         pJred_lu += 1;
                       }
+                      I_nu[p_idx] = I_nu[p_idx] + escat_contrib;
 
                       // Lucy 1999, Eq 26
                       I_nu[p_idx] = I_nu[p_idx] * (*pexp_tau) + *patt_S_ul;

--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -196,8 +196,9 @@ _formal_integral(
               direction = 0,
               first = 0;
 
-      double I_nu_b[N],
-             I_nu_r[N],
+      double I_nu[N],
+             //I_nu_b[N],
+             //I_nu_r[N],
              z[2 * storage->no_of_shells],
              p = 0,
              nu_start,
@@ -237,10 +238,9 @@ _formal_integral(
 
               // initialize I_nu
               if (p <= R_ph)
-                I_nu_b[p_idx] = intensity_black_body(nu, iT);
+                I_nu[p_idx] = intensity_black_body(nu, iT);
               else
-                I_nu_b[p_idx] = 0;
-              I_nu_r[p_idx] = 0;
+                I_nu[p_idx] = 0;
 
               // Find first contributing line
               nu_start = nu * z[0];
@@ -299,19 +299,19 @@ _formal_integral(
                         // NOTE: this treatment of I_nu_b (given by boundary
                         // conditions) is not in Lucy 1999; should be
                         // re-examined carefully 
-                        I_nu_b[p_idx] = I_nu_b[p_idx] + dtau * (*pJblue_lu - I_nu_b[p_idx]);
+                        I_nu[p_idx] = I_nu[p_idx] + dtau * (*pJblue_lu - I_nu[p_idx]);
                         first = 0;
                       }
                       else{
                         // Account for e-scattering, c.f. Eqs 27, 28 in Lucy 1999
                         Jkkp = 0.5 * (*pJred_lu + *pJblue_lu);
-                        I_nu_b[p_idx] = I_nu_r[p_idx] + dtau * (Jkkp - I_nu_r[p_idx]);
+                        I_nu[p_idx] = I_nu[p_idx] + dtau * (Jkkp - I_nu[p_idx]);
                         // this introduces the necessary offset of one element between pJblue_lu and pJred_lu
                         pJred_lu += 1;
                       }
 
                       // Lucy 1999, Eq 26
-                      I_nu_r[p_idx] = I_nu_b[p_idx] * (*pexp_tau) + *patt_S_ul;
+                      I_nu[p_idx] = I_nu[p_idx] * (*pexp_tau) + *patt_S_ul;
 
                       // reset e-scattering opacity 
                       dtau = 0;
@@ -331,10 +331,10 @@ _formal_integral(
                       pJblue_lu += direction * size_line;
                     }
                 }
-              I_nu_r[p_idx] *= p;
+              I_nu[p_idx] *= p;
             }
           // TODO: change integration to match the calculation of p values
-          L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu_r, R_max/N, N);
+          L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu, R_max/N, N);
           if (++finished_nus%10 == 0){
 #ifdef WITHOPENMP
             if (omp_get_thread_num() == 0 )

--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -186,7 +186,8 @@ _formal_integral(
               size_z = 0,
               idx_nu_start = 0;
 
-      double I_nu[N],
+      double I_nu_b[N],
+             I_nu_r[N],
              z[2 * storage->no_of_shells],
              p = 0,
              nu_start,
@@ -219,9 +220,10 @@ _formal_integral(
 
               // initialize I_nu
               if (p <= R_ph)
-                I_nu[p_idx] = intensity_black_body(nu, iT);
+                I_nu_b[p_idx] = intensity_black_body(nu, iT);
               else
-                I_nu[p_idx] = 0;
+                I_nu_b[p_idx] = 0;
+              I_nu_r[p_idx] = 0;
 
               // TODO: Ugly loop
               // Loop over all intersections
@@ -257,14 +259,16 @@ _formal_integral(
                     {
                       if (*pline < nu_end)
                         break;
-                      I_nu[p_idx] = I_nu[p_idx] * (*pexp_tau) + *patt_S_ul;
-
+                      I_nu_r[p_idx] = I_nu_b[p_idx] * (*pexp_tau) + *patt_S_ul;
+                      // In the absence of electron scattering, simple recursion as in Lucy 1991
+                      // TODO: e-scattering: Replace by Lucy 1999, Eq. 27
+                      I_nu_b[p_idx] = I_nu_r[p_idx];
                     }
                 }
-              I_nu[p_idx] *= p;
+              I_nu_r[p_idx] *= p;
             }
           // TODO: change integration to match the calculation of p values
-          L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu, R_max/N, N);
+          L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu_r, R_max/N, N);
         }
 
       // Free everything allocated on heap

--- a/tardis/montecarlo/src/integrator.h
+++ b/tardis/montecarlo/src/integrator.h
@@ -14,6 +14,6 @@ calculate_p_values(double R_max, int64_t N, double *opp);
 
 double
 *_formal_integral(
-                  const storage_model_t *storage, double T, double *nu, int64_t nu_size, double *att_S_ul, int N);
+                  const storage_model_t *storage, double T, double *nu, int64_t nu_size, double *att_S_ul, double *Jred_lu, double *Jblue_lu, int N);
 
 #endif

--- a/tardis/montecarlo/src/io.h
+++ b/tardis/montecarlo/src/io.h
@@ -5,7 +5,7 @@
 #include <stdio.h>
 
 #define STATUS_FORMAT "\r\033[2K\t[%" PRId64 "%%] Packets(finished/total): %" PRId64 "/%" PRId64
-#define STATUS_FORMAT_FI "\r\033[2K\t[%" PRId64 "%%] Rays(finished/total): %" PRId64 "/%" PRId64
+#define STATUS_FORMAT_FI "\r\033[2K\t[%" PRId64 "%%] Bins(finished/total): %" PRId64 "/%" PRId64
 
 static inline void
 print_progress (const int64_t current, const int64_t total)

--- a/tardis/montecarlo/src/io.h
+++ b/tardis/montecarlo/src/io.h
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #define STATUS_FORMAT "\r\033[2K\t[%" PRId64 "%%] Packets(finished/total): %" PRId64 "/%" PRId64
+#define STATUS_FORMAT_FI "\r\033[2K\t[%" PRId64 "%%] Rays(finished/total): %" PRId64 "/%" PRId64
 
 static inline void
 print_progress (const int64_t current, const int64_t total)
@@ -12,6 +13,18 @@ print_progress (const int64_t current, const int64_t total)
   if (isatty(fileno(stderr)))
     {
       fprintf(stderr, STATUS_FORMAT,
+              current * 100 / total,
+              current,
+              total);
+    }
+}
+
+static inline void
+print_progress_fi (const int64_t current, const int64_t total)
+{
+  if (isatty(fileno(stderr)))
+    {
+      fprintf(stderr, STATUS_FORMAT_FI,
               current * 100 / total,
               current,
               total);

--- a/tardis/montecarlo/src/omp_helper.h
+++ b/tardis/montecarlo/src/omp_helper.h
@@ -1,0 +1,7 @@
+#ifdef WITHOPENMP
+  #include <omp.h>
+#else
+int omp_get_num_threads(){
+  return 1;
+}
+#endif


### PR DESCRIPTION
The goal of this PR is the inclusion of the electron scattering into the Formal Integral scheme, introduced by @yeganer in PR #740.

For this purpose, the mean intensity in the blue and red wings of each line transition have to be calculated (see Eqs. 23, 24 and 28 in Lucy 1999) and passed to the Formal Integral integrator. The most obvious place for this calculation is alongside the determination of the attenuated line source functions ``att_S_ul`` in the routine ``make_source_function`` in ``formal_integral.py``.

The intensities have to be passed to the formal integrator (alongside ``att_S_ul``). In the integrator, the recursive stepping through the line list has to be adjusted to include the electron scattering contribution (see Eqs. 26, 27 and 28 in Lucy 1999). For this purpose, the electron scattering optical depth accumulated along the constant p paths has to be calculated.

Finally, unit tests for these additions have to be devised, the sanity checks revised and the integration with the configuration system checked.

**Note:** Even after this change, the Formal Integral will only work with the downbranching scheme for now.

**Milestones:**
- [x] calculate Jblues_lu and Jreds_lu
- [x] calculate electron scattering optical depths on integration segments
- [x] adjust recursive integration along z for const-p rays
- [ ] properly account for the edges of the line list
- [x] properly treat e-scattering effect across shell interfaces (not only record dtau but dtau * Jkkp)
- [ ] add unit tests
- [x] verification with single and multiline setups
- [x] update documentation
