### PR TITLE
[TEP007] Isotope uniform config option

### DIFF
--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -10,7 +10,7 @@ import logging
 # Adding logging support
 logger = logging.getLogger(__name__)
 
-from tardis.util import parse_quantity, element_symbol2atomic_number, MalformedElementSymbolError
+from tardis.util import parse_quantity
 
 class ConfigurationError(Exception):
     pass
@@ -126,14 +126,19 @@ def read_uniform_abundances(abundances_section, no_of_shells):
         if element_symbol_string == 'type':
             continue
         try:
-            z = element_symbol2atomic_number(element_symbol_string)
-            abundance.ix[z] = float(
-                abundances_section[element_symbol_string])
-        except MalformedElementSymbolError:
-            mass_no = nucname.anum(element_symbol_string)
-            z = nucname.znum(element_symbol_string)
-            isotope_abundance.loc[(z, mass_no), :] = float(
-                abundances_section[element_symbol_string])
+            if element_symbol_string in nucname.name_zz:
+                z = nucname.name_zz[element_symbol_string]
+                abundance.ix[z] = float(
+                    abundances_section[element_symbol_string])
+            else:
+                mass_no = nucname.anum(element_symbol_string)
+                z = nucname.znum(element_symbol_string)
+                isotope_abundance.loc[(z, mass_no), :] = float(
+                    abundances_section[element_symbol_string])
+
+        except RuntimeError as err:
+            raise RuntimeError(
+                "Abundances are not defined properly in config file : {}".format(err.args))
 
     return abundance, isotope_abundance
 

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -378,6 +378,13 @@ class Radial1DModel(HDFWriterMixin):
         else:
             isotope_abundance = pd.DataFrame()
 
+        if not isotope_abundance.empty:
+            norm_factor = isotope_abundance.sum(axis=0)
+            if np.any(np.abs(norm_factor - 1) > 1e-12):
+                logger.warning("Isotope Abundances have not been normalized to 1."
+                               " - normalizing")
+                isotope_abundance /= norm_factor
+
         return cls(velocity=velocity,
                    homologous_density=homologous_density,
                    abundance=abundance,

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -61,10 +61,9 @@ class Radial1DModel(HDFWriterMixin):
     hdf_properties = ['t_inner', 'w', 't_radiative', 'v_inner', 'v_outer', 'homologous_density']
     hdf_name = 'model'
 
-    def __init__(self, velocity, homologous_density, abundance, time_explosion,
-                 t_inner, isotope_abundance=None, luminosity_requested=None,
-                 t_radiative=None, dilution_factor=None, v_boundary_inner=None,
-                 v_boundary_outer=None):
+    def __init__(self, velocity, homologous_density, abundance, isotope_abundance,
+                 time_explosion, t_inner, luminosity_requested=None, t_radiative=None,
+                 dilution_factor=None, v_boundary_inner=None, v_boundary_outer=None):
         self._v_boundary_inner = None
         self._v_boundary_outer = None
         self._velocity = None
@@ -370,10 +369,10 @@ class Radial1DModel(HDFWriterMixin):
         return cls(velocity=velocity,
                    homologous_density=homologous_density,
                    abundance=abundance,
+                   isotope_abundance=isotope_abundance,
                    time_explosion=time_explosion,
                    t_radiative=t_radiative,
                    t_inner=t_inner,
-                   isotope_abundance=isotope_abundance,
                    luminosity_requested=luminosity_requested,
                    dilution_factor=None,
                    v_boundary_inner=structure.get('v_inner_boundary', None),


### PR DESCRIPTION
This PR is for adding support to read `uniform isotope abundances`.
For seeing sample output : 
[Notebook](https://github.com/vg3095/decay/blob/master/isotope_uniform_config.ipynb) (**Updated**)
[Config](https://github.com/vg3095/decay/blob/master/isotope.yml) (**Updated**)

For Isotopes , you will need to mention mass-no. in every case.
For example `Ni` will not work , `Ni56` , `Ni58` will work.

It is because ,I think Tardis does not store `mass_no.` of stable isotope elements, so as of now , it supports this type of format( `ElementMass_no`)  