### PR TITLE
[TEP007] Isotope stratified file support

### DIFF
--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -108,7 +108,7 @@ def read_simple_ascii_isotopes(fname):
 
     #Reshape Numpy Structured arrays
     #File rows are read as tuples here, this line converts it to a Matrix form
-    #First colomn is ignored
+    #First column is ignored
     data = data.view(np.float64).reshape(-1, len(data.dtype))[:, 1:]
 
     #Parse isotopes

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -87,9 +87,14 @@ def read_abundances_file(abundance_filename, abundance_filetype,
     file_parsers = {'simple_ascii': read_simple_ascii_abundances,
                     'artis': read_simple_ascii_abundances,
                     'isotopes': read_simple_ascii_isotopes}
-
-    index, abundances, isotope_abundance = file_parsers[abundance_filetype](
-        abundance_filename)
+    
+    isotope_abundance = None
+    if abundance_filetype != 'isotopes':
+        index, abundances = file_parsers[abundance_filetype](
+            abundance_filename)
+    else:
+        index, abundances, isotope_abundance = file_parsers[abundance_filetype](
+            abundance_filename)
 
     if outer_boundary_index is not None:
         outer_boundary_index_m1 = outer_boundary_index - 1
@@ -240,4 +245,4 @@ def read_simple_ascii_abundances(fname):
     index = data[1:,0].astype(int)
     abundances = pd.DataFrame(data[1:,1:].transpose(), index=np.arange(1, data.shape[1]))
 
-    return index, abundances, None
+    return index, abundances

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -108,6 +108,7 @@ def read_simple_ascii_isotopes(fname):
 
     #Reshape Numpy Structured arrays
     #File rows are read as tuples here, this line converts it to a Matrix form
+    #First colomn is ignored
     data = data.view(np.float64).reshape(-1, len(data.dtype))[:, 1:]
 
     #Parse isotopes

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -102,10 +102,15 @@ def read_abundances_file(abundance_filename, abundance_filetype,
 
 
 def read_simple_ascii_isotopes(fname):
-    data = np.genfromtxt(fname, names=True, dtype=float)
-    isotopes_name = data.dtype.names[31:]
-    data = data.view(np.float).reshape(-1, len(data.dtype))[:, 1:]
 
+    data = np.genfromtxt(fname, names=True, dtype=np.float64)
+    isotopes_name = data.dtype.names[31:]
+
+    #Reshape Numpy Structured arrays
+    #File rows are read as tuples here, this line converts it to a Matrix form
+    data = data.view(np.float64).reshape(-1, len(data.dtype))[:, 1:]
+
+    #Parse isotopes
     mass_no = [nucname.anum(name) for name in isotopes_name]
     z = [nucname.znum(name) for name in isotopes_name]
     isotope_index = pd.MultiIndex.from_tuples(
@@ -114,8 +119,10 @@ def read_simple_ascii_isotopes(fname):
     isotope_abundance = pd.DataFrame(data[:, 30:].transpose(),
                                      index=isotope_index,
                                      dtype=np.float64)
-    index = np.arange(1, 30)
+
+    index = pd.Index(np.arange(1, 30), name='atomic_number')
     abundances = pd.DataFrame(data[:, :29].transpose(), index=index)
+
     return index, abundances, isotope_abundance
 
 

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import recfromtxt, genfromtxt
 import pandas as pd
 from astropy import units as u
-
+from pyne import nucname
 import logging
 # Adding logging support
 logger = logging.getLogger(__name__)
@@ -85,9 +85,12 @@ def read_abundances_file(abundance_filename, abundance_filetype,
     """
 
     file_parsers = {'simple_ascii': read_simple_ascii_abundances,
-                    'artis': read_simple_ascii_abundances}
+                    'artis': read_simple_ascii_abundances,
+                    'isotopes': read_simple_ascii_isotopes}
 
-    index, abundances = file_parsers[abundance_filetype](abundance_filename)
+    index, abundances, isotope_abundance = file_parsers[abundance_filetype](
+        abundance_filename)
+
     if outer_boundary_index is not None:
         outer_boundary_index_m1 = outer_boundary_index - 1
     else:
@@ -95,7 +98,25 @@ def read_abundances_file(abundance_filename, abundance_filetype,
     index = index[inner_boundary_index:outer_boundary_index]
     abundances = abundances.ix[:, slice(inner_boundary_index, outer_boundary_index_m1)]
     abundances.columns = np.arange(len(abundances.columns))
-    return index, abundances
+    return index, abundances, isotope_abundance
+
+
+def read_simple_ascii_isotopes(fname):
+    data = np.genfromtxt(fname, names=True, dtype=float)
+    isotopes_name = data.dtype.names[31:]
+    data = data.view(np.float).reshape(-1, len(data.dtype))[:, 1:]
+
+    mass_no = [nucname.anum(name) for name in isotopes_name]
+    z = [nucname.znum(name) for name in isotopes_name]
+    isotope_index = pd.MultiIndex.from_tuples(
+        zip(z, mass_no), names=['atomic_number', 'mass_number'])
+
+    isotope_abundance = pd.DataFrame(data[:, 30:].transpose(),
+                                     index=isotope_index,
+                                     dtype=np.float64)
+    index = np.arange(1, 30)
+    abundances = pd.DataFrame(data[:, :29].transpose(), index=index)
+    return index, abundances, isotope_abundance
 
 
 def read_simple_ascii_density(fname):
@@ -211,4 +232,4 @@ def read_simple_ascii_abundances(fname):
     index = data[1:,0].astype(int)
     abundances = pd.DataFrame(data[1:,1:].transpose(), index=np.arange(1, data.shape[1]))
 
-    return index, abundances
+    return index, abundances, None

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -378,6 +378,13 @@ class Radial1DModel(HDFWriterMixin):
         else:
             isotope_abundance = pd.DataFrame()
 
+        if not isotope_abundance.empty:
+            norm_factor = isotope_abundance.sum(axis=0)
+            if np.any(np.abs(norm_factor - 1) > 1e-12):
+                logger.warning("Isotope Abundances have not been normalized to 1."
+                               " - normalizing")
+                isotope_abundance /= norm_factor
+
         return cls(velocity=velocity,
                    homologous_density=homologous_density,
                    abundance=abundance,

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -352,8 +352,9 @@ class Radial1DModel(HDFWriterMixin):
                 abundances_fname = os.path.join(config.config_dirname,
                                                 abundances_section.filename)
 
-            index, abundance, isotope_abundance = read_abundances_file(abundances_fname,
-                                                    abundances_section.filetype)
+            index, abundance, isotopes = read_abundances_file(abundances_fname,
+                                                              abundances_section.filetype)
+            isotope_abundance = isotopes or isotope_abundance
 
         abundance = abundance.replace(np.nan, 0.0)
         abundance = abundance[abundance.sum(axis=1) > 0]

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -61,10 +61,9 @@ class Radial1DModel(HDFWriterMixin):
     hdf_properties = ['t_inner', 'w', 't_radiative', 'v_inner', 'v_outer', 'homologous_density']
     hdf_name = 'model'
 
-    def __init__(self, velocity, homologous_density, abundance, time_explosion,
-                 t_inner, isotope_abundance=None, luminosity_requested=None,
-                 t_radiative=None, dilution_factor=None, v_boundary_inner=None,
-                 v_boundary_outer=None):
+    def __init__(self, velocity, homologous_density, abundance, isotope_abundance,
+                 time_explosion, t_inner, luminosity_requested=None, t_radiative=None,
+                 dilution_factor=None, v_boundary_inner=None, v_boundary_outer=None):
         self._v_boundary_inner = None
         self._v_boundary_outer = None
         self._velocity = None
@@ -370,10 +369,10 @@ class Radial1DModel(HDFWriterMixin):
         return cls(velocity=velocity,
                    homologous_density=homologous_density,
                    abundance=abundance,
+                   isotope_abundance=isotope_abundance,
                    time_explosion=time_explosion,
                    t_radiative=t_radiative,
                    t_inner=t_inner,
-                   isotope_abundance=isotope_abundance,
                    luminosity_requested=luminosity_requested,
                    dilution_factor=None,
                    v_boundary_inner=structure.get('v_inner_boundary', None),

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -352,7 +352,7 @@ class Radial1DModel(HDFWriterMixin):
                 abundances_fname = os.path.join(config.config_dirname,
                                                 abundances_section.filename)
 
-            index, abundance = read_abundances_file(abundances_fname,
+            index, abundance, isotope_abundance = read_abundances_file(abundances_fname,
                                                     abundances_section.filetype)
 
         abundance = abundance.replace(np.nan, 0.0)

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -354,7 +354,8 @@ class Radial1DModel(HDFWriterMixin):
 
             index, abundance, isotopes = read_abundances_file(abundances_fname,
                                                               abundances_section.filetype)
-            isotope_abundance = isotopes or isotope_abundance
+            if isotopes is not None:
+                isotope_abundance = isotopes
 
         abundance = abundance.replace(np.nan, 0.0)
         abundance = abundance[abundance.sum(axis=1) > 0]


### PR DESCRIPTION
This PR is related to adding support for reading `stratified abundances with isotopes` . This is rebased over  PR #762 (Isotope uniform config)
For sample seeing output:
[Notebook](https://github.com/vg3095/decay/blob/master/isotope_file_config.ipynb)
[abund.dat](https://github.com/vg3095/decay/blob/master/abund.dat)
[Config](https://github.com/vg3095/decay/blob/master/isotope_file.yml)

Just want to clear 2 things,
- I have assumed, only `30 normal elements` (hardcoded in code), and rest isotopes.
- Currently the header is of following format (for Z=1 to 30 , numbers are used),
`1 2 3 4........30 Ni56 Ni58`
_Do we need the format same as above or format below_ (represent Z=1 to 30 , as symbols):
`H He ......Zn Ni56 Ni58`
_or you are thinking of some other format_.

- _Will number of `normal elements` be `variable` ?_ . If we want to make normal elements(Z<=30) variable in file, then I can think of this as of now,
   - if we follow 1st header format as I said above, then header is read as `str` format, because of mixed datatypes (1...30(`int`) then isotopes names(`str`) ), I could use regex here to find the index at which  isotope names(`str`) starts,
  - if we follow 2nd header format, then I can use `element_symbol2atomic_number` function defined in `util.py` , and at the header index at which it raises `MalformedElementSymbolError` ,  isotopes will start.   
 
 