### PR TITLE
[TEP007] Add cmfgen2tardis script

### DIFF
--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -5,8 +5,9 @@ Running scripts
 Convert CMFGEN files to TARDIS file format
 ==========================================
 
-This script takes a CMFGEN file as an input , and an output path to save the converted CSV file in new TARDIS file format. 
+This script takes a CMFGEN file as an input , and an output path to save converted files in new TARDIS file format. 
 CSV file contains abundances of both elements and isotopes.
+DAT file contains values of velocity, density, electron_density and temperature.  
 
 Format of command - :code:`cmfgen2tardis /path/to/input_file path/to/output/`  
 

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -1,0 +1,18 @@
+***************
+Running scripts
+***************
+
+Convert CMFGEN files to TARDIS file format
+==========================================
+
+This script takes a CMFGEN file as an input , and an output path to save the converted CSV file in new TARDIS file format. 
+CSV file contains abundances of both elements and isotopes.
+
+Format of command - :code:`cmfgen2tardis /path/to/input_file path/to/output/`  
+
+Example, for how to use-  
+
+
+.. code-block:: bash
+
+   $ cmfgen2tardis tardis_example/DDC15_SN_HYDRO_DATA_0.976d tardis_example/

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,0 @@
-from scripts.cmfgen2tardis import *

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+from scripts.cmfgen2tardis import *

--- a/scripts/cmfgen2tardis.py
+++ b/scripts/cmfgen2tardis.py
@@ -1,0 +1,62 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+from tardis.atomic import AtomData
+
+atomic_dataset = AtomData.from_hdf5()
+
+
+def get_atomic_number(element):
+    index = -1
+    for atomic_no, row in atomic_dataset.atom_data.iterrows():
+        if element in row['name']:
+            index = atomic_no
+            break
+    return index
+
+
+def convert_format(file_path):
+
+    with open(file_path, 'r') as f:
+        for line in f:
+            items = line.split()
+            n = len(items)
+
+            if 'data points' in line:
+                df = pd.DataFrame(columns=np.arange(int(items[n - 1])),
+                                  index=pd.Index([],
+                                                 name='element'),
+                                  dtype=np.float64)
+
+            if 'mass fraction\n' in line:
+                    abundances = []
+                    element_string = items[0]
+                    atomic_no = get_atomic_number(element_string.capitalize())
+                    element_symbol = atomic_dataset.atom_data.loc[atomic_no]['symbol']
+
+                    #Its a Isotope
+                    if n == 4:
+                        element_symbol += items[1]
+
+                    for line in f:
+                        items = line.split()
+                        if items:
+                            abundances.extend(
+                                np.array(items).astype(np.float64))
+                        else:
+                            break
+
+                    df.loc[element_symbol] = abundances
+        return df.transpose()
+
+
+def parse_file():
+    file_path = sys.argv[1]
+    output_path = sys.argv[2]
+    df = convert_format(file_path)
+    filename = os.path.basename(file_path)
+    save_name = '.'.join((os.path.splitext(filename)[0], 'csv'))
+    df.to_csv(os.path.join(output_path, save_name), index=False, sep=' ')

--- a/scripts/cmfgen2tardis.py
+++ b/scripts/cmfgen2tardis.py
@@ -1,10 +1,16 @@
 import os
 import sys
-
+import argparse
 import numpy as np
 import pandas as pd
 
 from tardis.atomic import AtomData
+
+parser = argparse.ArgumentParser()
+parser.add_argument('input_path', help='Path to a CMFGEN abundance file')
+parser.add_argument(
+    'output_path', help='Path to store converted TARDIS abundance file')
+args = parser.parse_args()
 
 atomic_dataset = AtomData.from_hdf5()
 
@@ -54,9 +60,7 @@ def convert_format(file_path):
 
 
 def parse_file():
-    file_path = sys.argv[1]
-    output_path = sys.argv[2]
-    df = convert_format(file_path)
-    filename = os.path.basename(file_path)
+    df = convert_format(args.input_path)
+    filename = os.path.basename(args.input_path)
     save_name = '.'.join((os.path.splitext(filename)[0], 'csv'))
-    df.to_csv(os.path.join(output_path, save_name), index=False, sep=' ')
+    df.to_csv(os.path.join(args.output_path, save_name), index=False, sep=' ')

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,8 @@ for hook in [('prereleaser', 'middle'), ('releaser', 'middle'),
     entry_points[hook_ep] = ['%s = %s' % (hook_name, hook_func)]
 
 entry_points['console_scripts'] = [
-    'tardis_test_runner = tardis.tests.integration_tests.runner:run_tests'
+    'tardis_test_runner = tardis.tests.integration_tests.runner:run_tests',
+    'cmfgen2tardis = scripts.cmfgen2tardis:parse_file'
 ]
 
 #from Cython.Build import cythonize

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ for hook in [('prereleaser', 'middle'), ('releaser', 'middle'),
 
 entry_points['console_scripts'] = [
     'tardis_test_runner = tardis.tests.integration_tests.runner:run_tests',
-    'cmfgen2tardis = scripts.cmfgen2tardis:parse_file'
+    'cmfgen2tardis = tardis.scripts.cmfgen2tardis:main'
 ]
 
 #from Cython.Build import cythonize

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -77,8 +77,8 @@ def convert_format(file_path):
 
         density_df = pd.DataFrame.from_records(
             [velocity, temperature * 10**4, density, electron_density]).transpose()
-        density_df.columns = ['velocity', 'densities',
-                              'electron_densities', 'temperature']
+        density_df.columns = ['velocity', 'temperature',
+                              'densities', 'electron_densities']
         quantities_row += abundances_df.shape[0] * [1]
         return abundances_df.transpose(), density_df, time_of_model, quantities_row
 

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -30,7 +30,10 @@ def extract_file_block(f):
             break
 
     qty = np.array(qty)
-
+    # Convention in CMFGEN files is different from TARDIS files.
+    # CMFGEN stores velocity values in decreasing order, while
+    # TARDIS stores it in ascending order, so alongwith
+    # velocity, all columns will be reversed.
     return qty[::-1]
 
 

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -51,7 +51,7 @@ def convert_format(file_path):
                                                             name='element'),
                                              dtype=np.float64)
             if any(prop in line for prop in prop_list):
-                quantities_row.append(items[n - 1])
+                quantities_row.append(items[n - 1].replace('gm', 'g'))
             if 'Time' in line:
                 time_of_model = float(items[n - 1])
             if 'Velocity' in line:

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -19,6 +19,21 @@ def get_atomic_number(element):
     return index
 
 
+def extract_file_block(f):
+    qty = []
+
+    for line in f:
+        items = line.split()
+        if items:
+            qty.extend(np.array(items).astype(np.float64))
+        else:
+            break
+
+    qty = np.array(qty)
+
+    return qty[::-1]
+
+
 def convert_format(file_path):
 
     with open(file_path, 'r') as f:
@@ -27,13 +42,22 @@ def convert_format(file_path):
             n = len(items)
 
             if 'data points' in line:
-                df = pd.DataFrame(columns=np.arange(int(items[n - 1])),
-                                  index=pd.Index([],
-                                                 name='element'),
-                                  dtype=np.float64)
+                abundances_df = pd.DataFrame(columns=np.arange(int(items[n - 1])),
+                                             index=pd.Index([],
+                                                            name='element'),
+                                             dtype=np.float64)
+            if 'Time' in line:
+                time_of_model = float(items[n - 1])
+            if 'Velocity' in line:
+                velocity = extract_file_block(f)
+            if 'Density' in line:
+                density = extract_file_block(f)
+            if 'Electron density' in line:
+                electron_density = extract_file_block(f)
+            if 'Temperature' in line:
+                temperature = extract_file_block(f)
 
             if 'mass fraction\n' in line:
-                    abundances = []
                     element_string = items[0]
                     atomic_no = get_atomic_number(element_string.capitalize())
                     element_symbol = atomic_dataset.atom_data.loc[atomic_no]['symbol']
@@ -42,29 +66,42 @@ def convert_format(file_path):
                     if n == 4:
                         element_symbol += items[1]
 
-                    for line in f:
-                        items = line.split()
-                        if items:
-                            abundances.extend(
-                                np.array(items).astype(np.float64))
-                        else:
-                            break
+                    abundances = extract_file_block(f)
+                    abundances_df.loc[element_symbol] = abundances
 
-                    df.loc[element_symbol] = abundances
-        return df.transpose()
+        density_df = pd.DataFrame.from_records(
+            [velocity, density, electron_density, temperature]).transpose()
+        density_df.columns = ['Velocity', 'Densities',
+                              'ElectronDensities', 'Temperature']
+
+        return abundances_df.transpose(), density_df, time_of_model
 
 
 def parse_file(args):
-    df = convert_format(args.input_path)
-    filename = os.path.basename(args.input_path)
-    save_name = '.'.join((os.path.splitext(filename)[0], 'csv'))
-    df.to_csv(os.path.join(args.output_path, save_name), index=False, sep=' ')
+    abundances_df, density_df, time_of_model = convert_format(args.input_path)
+
+    filename = os.path.splitext(os.path.basename(args.input_path))[0]
+    abundances_fname = '.'.join((filename, 'csv'))
+    density_fname = '.'.join((filename, 'dat'))
+
+    abundances_file_path = os.path.join(
+        args.output_path, abundances_fname)
+    density_file_path = os.path.join(
+        args.output_path, density_fname)
+
+    abundances_df.to_csv(abundances_file_path, index=False, sep=' ')
+
+    with open(density_file_path, 'w') as f:
+        f.write(" ".join((str(time_of_model), "day")))
+        f.write("\n")
+    density_df.to_csv(density_file_path, index=True,
+                      index_label='Index', sep=' ', mode='a')
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('input_path', help='Path to a CMFGEN abundance file')
+    parser.add_argument('input_path', help='Path to a CMFGEN file')
     parser.add_argument(
-        'output_path', help='Path to store converted TARDIS abundance file')
+        'output_path', help='Path to store converted TARDIS format files')
     args = parser.parse_args()
     parse_file(args)

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -6,11 +6,6 @@ import pandas as pd
 
 from tardis.atomic import AtomData
 
-parser = argparse.ArgumentParser()
-parser.add_argument('input_path', help='Path to a CMFGEN abundance file')
-parser.add_argument(
-    'output_path', help='Path to store converted TARDIS abundance file')
-args = parser.parse_args()
 
 atomic_dataset = AtomData.from_hdf5()
 
@@ -59,8 +54,17 @@ def convert_format(file_path):
         return df.transpose()
 
 
-def parse_file():
+def parse_file(args):
     df = convert_format(args.input_path)
     filename = os.path.basename(args.input_path)
     save_name = '.'.join((os.path.splitext(filename)[0], 'csv'))
     df.to_csv(os.path.join(args.output_path, save_name), index=False, sep=' ')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_path', help='Path to a CMFGEN abundance file')
+    parser.add_argument(
+        'output_path', help='Path to store converted TARDIS abundance file')
+    args = parser.parse_args()
+    parse_file(args)

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -84,20 +84,14 @@ def parse_file(args):
     abundances_df, density_df, time_of_model = convert_format(args.input_path)
 
     filename = os.path.splitext(os.path.basename(args.input_path))[0]
-    abundances_fname = '.'.join((filename, 'csv'))
-    density_fname = '.'.join((filename, 'dat'))
-
-    abundances_file_path = os.path.join(
-        args.output_path, abundances_fname)
-    density_file_path = os.path.join(
-        args.output_path, density_fname)
-
-    abundances_df.to_csv(abundances_file_path, index=False, sep=' ')
-
-    with open(density_file_path, 'w') as f:
+    save_fname = '.'.join((filename, 'csv'))
+    resultant_df = pd.concat([density_df, abundances_df], axis=1)
+    save_file_path = os.path.join(args.output_path, save_fname)
+    with open(save_file_path, 'w') as f:
         f.write(" ".join((str(time_of_model), "day")))
         f.write("\n")
-    density_df.to_csv(density_file_path, index=False, sep=' ', mode='a')
+
+    resultant_df.to_csv(save_file_path, index=False, sep=' ', mode='a')
 
 
 def main():

--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -74,8 +74,8 @@ def convert_format(file_path):
 
         density_df = pd.DataFrame.from_records(
             [velocity, density, electron_density, temperature]).transpose()
-        density_df.columns = ['Velocity', 'Densities',
-                              'ElectronDensities', 'Temperature']
+        density_df.columns = ['velocity', 'densities',
+                              'electron_densities', 'temperature']
 
         return abundances_df.transpose(), density_df, time_of_model
 
@@ -97,8 +97,7 @@ def parse_file(args):
     with open(density_file_path, 'w') as f:
         f.write(" ".join((str(time_of_model), "day")))
         f.write("\n")
-    density_df.to_csv(density_file_path, index=True,
-                      index_label='Index', sep=' ', mode='a')
+    density_df.to_csv(density_file_path, index=False, sep=' ', mode='a')
 
 
 def main():


### PR DESCRIPTION
This script takes a `CMFGEN file` as an input , and an output path to save the converted CSV file in new TARDIS file format. 
An example of input CMFGEN file ([Link](https://github.com/vg3095/decay/blob/master/DDC15_SN_HYDRO_DATA_0.976d)) and its converted CSV file ([Link](https://github.com/vg3095/decay/blob/master/DDC15_SN_HYDRO_DATA_0.csv))
Example, for how to use-
Format - `cmfgen2tardis /path/to/input_file path/to/output/`
`cmfgen2tardis tardis_example/DDC15_SN_HYDRO_DATA_0.976d tardis_example/`
______
- Now velocity, density, electron_density and temperature are also saved.

- Values are stored in reverse order, to match how Tardis stores things. For ex - velocity values in Tardis are stored in increasing order, while in Cmfgen files , it is in decreasing order .
