### PR TITLE
Transition from atomic-dataset config option to tardis-refdata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
         - SETUP_CMD='test'
         - TEST_MODE='normal'
         - TARDIS_REF_DATA_URL='https://github.com/tardis-sn/tardis-refdata.git'
-        - TARDIS_REF_VERSION='0.2'
         - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh'
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,6 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs install --skip-smudge; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $TARDIS_REF_DATA_URL $HOME/tardis-refdata; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $HOME/tardis-refdata; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/2/head:plasma-ref2; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout plasma-ref2; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ env:
         - ASTROPY_USE_SYSTEM_PYTEST=1
         - SETUP_CMD='test'
         - TEST_MODE='normal'
-        - ATOM_DATA_URL='https://github.com/tardis-sn/tardis-atomdata/raw/master/kurucz_cd23_chianti_H_He.h5.zip'
+        - TARDIS_REF_DATA_URL='https://github.com/tardis-sn/tardis-refdata.git'
+        - TARDIS_REF_VERSION='0.2'
         - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh'
 
 matrix:
@@ -28,20 +29,20 @@ matrix:
         - python: 2.7
           env:
             - COMPILER=gcc
-            - SETUP_CMD='test --args="--atomic-dataset=$HOME/kurucz_cd23_chianti_H_He.h5"'
+            - SETUP_CMD='test --args="--tardis-refdata=$HOME/tardis-refdata/"'
             - TEST_MODE='spectrum'
 
         - python: 2.7
           env:
             - COMPILER=clang
-            - SETUP_CMD='test --args="--atomic-dataset=$HOME/kurucz_cd23_chianti_H_He.h5"'
+            - SETUP_CMD='test --args="--tardis-refdata=$HOME/tardis-refdata/"'
             - TEST_MODE='spectrum'
 
         - os: osx
           language: generic
           env:
             - COMPILER=clang
-            - SETUP_CMD='test --args="--atomic-dataset=$HOME/kurucz_cd23_chianti_H_He.h5"'
+            - SETUP_CMD='test --args="--tardis-refdata=$HOME/tardis-refdata/"'
             - TEST_MODE='spectrum'
             - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
 
@@ -66,9 +67,15 @@ before_install:
     - export PATH=$HOME/miniconda/bin:$PATH
     - hash -r
     - conda update --yes conda
-    - if [[ $TEST_MODE == 'spectrum' ]]; then wget $ATOM_DATA_URL; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then unzip kurucz_cd23_chianti_H_He.h5.zip; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then mv kurucz_cd23_chianti_H_He.h5 $HOME/; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then conda install -c conda-forge git-lfs=2.2.1 -y; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs install --skip-smudge; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $TARDIS_REF_DATA_URL $HOME/tardis-refdata; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then cd $HOME/tardis-refdata; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/2/head:plasma-ref2; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout plasma-ref2; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi
 
 install:
    - conda env create -f tardis_env27.yml

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -85,11 +85,12 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session")
 def atomic_data_fname():
-    atomic_data_fname = os.path.join(pytest.config.getvalue(
-        "tardis-refdata"), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')
-    if atomic_data_fname is None:
+    tardis_ref_path = pytest.config.getvalue("tardis-refdata")
+    if tardis_ref_path is None:
         pytest.skip('--tardis-refdata was not specified')
     else:
+        atomic_data_fname = os.path.join(
+            tardis_ref_path, 'atom_data', 'kurucz_cd23_chianti_H_He.h5')
         return os.path.expandvars(os.path.expanduser(atomic_data_fname))
 
 @pytest.fixture(scope="session")

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -66,8 +66,8 @@ except NameError:   # Needed to support Astropy <= 1.0.0
 
 def pytest_addoption(parser):
     _pytest_add_option(parser)
-    parser.addoption("--atomic-dataset", dest='atomic-dataset', default=None,
-                     help="filename for atomic dataset")
+    parser.addoption("--tardis-refdata", dest='tardis-refdata', default=None,
+                     help="Path to Tardis Reference Folder")
     parser.addoption("--integration-tests",
                      dest="integration-tests", default=None,
                      help="path to configuration file for integration tests")
@@ -78,7 +78,6 @@ def pytest_addoption(parser):
                      action="store_true", default=False,
                      help="Run integration tests with less packets.")
 
-
 # -------------------------------------------------------------------------
 # project specific fixtures
 # -------------------------------------------------------------------------
@@ -86,9 +85,10 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session")
 def atomic_data_fname():
-    atomic_data_fname = pytest.config.getvalue("atomic-dataset")
+    atomic_data_fname = os.path.join(pytest.config.getvalue(
+        "tardis-refdata"), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')
     if atomic_data_fname is None:
-        pytest.skip('--atomic-dataset was not specified')
+        pytest.skip('--tardis-refdata was not specified')
     else:
         return os.path.expandvars(os.path.expanduser(atomic_data_fname))
 

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -96,6 +96,11 @@ def tardis_ref_path():
 def atomic_data_fname(tardis_ref_path):
     atomic_data_fname = os.path.join(
         tardis_ref_path, 'atom_data', 'kurucz_cd23_chianti_H_He.h5')
+
+    assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles"
+                                               " does not seem to "
+                                               "exist".format(
+                                                   atomic_data_fname))
     return atomic_data_fname
 
 

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -84,14 +84,20 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def atomic_data_fname():
+def tardis_ref_path():
     tardis_ref_path = pytest.config.getvalue("tardis-refdata")
     if tardis_ref_path is None:
         pytest.skip('--tardis-refdata was not specified')
     else:
-        atomic_data_fname = os.path.join(
-            tardis_ref_path, 'atom_data', 'kurucz_cd23_chianti_H_He.h5')
-        return os.path.expandvars(os.path.expanduser(atomic_data_fname))
+        return os.path.expandvars(os.path.expanduser(tardis_ref_path))
+
+
+@pytest.fixture(scope="session")
+def atomic_data_fname(tardis_ref_path):
+    atomic_data_fname = os.path.join(
+        tardis_ref_path, 'atom_data', 'kurucz_cd23_chianti_H_He.h5')
+    return atomic_data_fname
+
 
 @pytest.fixture(scope="session")
 def atomic_dataset(atomic_data_fname):

--- a/tardis/plasma/tests/test_plasmas_full.py
+++ b/tardis/plasma/tests/test_plasmas_full.py
@@ -22,14 +22,14 @@ def plasma_compare_data_fname():
 def plasma_compare_data(plasma_compare_data_fname):
     return h5py.File(plasma_compare_data_fname, 'r')
 
-@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
-                    reason='--atomic_database was not specified')
+@pytest.mark.skipif(not pytest.config.getvalue("tardis-refdata"),
+                    reason='--tardis-refdata was not specified')
 class TestPlasmas():
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self):
         self.atom_data_filename = os.path.expanduser(os.path.expandvars(
-            pytest.config.getvalue('atomic-dataset')))
+            os.path.join(pytest.config.getvalue('tardis-refdata'), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')))
         assert os.path.exists(self.atom_data_filename), ("{0} atomic datafiles"
                                                          " does not seem to "
                                                          "exist".format(

--- a/tardis/plasma/tests/test_plasmas_full.py
+++ b/tardis/plasma/tests/test_plasmas_full.py
@@ -26,10 +26,6 @@ class TestPlasmas():
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, atomic_data_fname):
-        assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles"
-                                                         " does not seem to "
-                                                         "exist".format(
-            atomic_data_fname))
         self.config_yaml = yaml_load_config_file(
             'tardis/plasma/tests/data/plasma_test_config_lte.yml')
         self.config_yaml['atom_data'] = atomic_data_fname

--- a/tardis/plasma/tests/test_plasmas_full.py
+++ b/tardis/plasma/tests/test_plasmas_full.py
@@ -22,27 +22,23 @@ def plasma_compare_data_fname():
 def plasma_compare_data(plasma_compare_data_fname):
     return h5py.File(plasma_compare_data_fname, 'r')
 
-@pytest.mark.skipif(not pytest.config.getvalue("tardis-refdata"),
-                    reason='--tardis-refdata was not specified')
 class TestPlasmas():
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self):
-        self.atom_data_filename = os.path.expanduser(os.path.expandvars(
-            os.path.join(pytest.config.getvalue('tardis-refdata'), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')))
-        assert os.path.exists(self.atom_data_filename), ("{0} atomic datafiles"
+    def setup(self, atomic_data_fname):
+        assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles"
                                                          " does not seem to "
                                                          "exist".format(
-            self.atom_data_filename))
+            atomic_data_fname))
         self.config_yaml = yaml_load_config_file(
             'tardis/plasma/tests/data/plasma_test_config_lte.yml')
-        self.config_yaml['atom_data'] = self.atom_data_filename
+        self.config_yaml['atom_data'] = atomic_data_fname
         conf = Configuration.from_config_dict(self.config_yaml)
         self.lte_simulation = Simulation.from_config(conf)
         self.lte_simulation.run()
         self.config_yaml = yaml_load_config_file(
             'tardis/plasma/tests/data/plasma_test_config_nlte.yml')
-        self.config_yaml['atom_data'] = self.atom_data_filename
+        self.config_yaml['atom_data'] = atomic_data_fname
         conf = Configuration.from_config_dict(self.config_yaml)
         self.nlte_simulation = Simulation.from_config(conf)
         self.nlte_simulation.run()

--- a/tardis/tests/integration_tests/runner.py
+++ b/tardis/tests/integration_tests/runner.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser(description="Run slow integration tests")
 parser.add_argument("--integration-tests", dest="yaml_filepath",
                     help="Path to YAML config file for integration tests.")
-parser.add_argument("--atomic-dataset", dest="atomic_dataset",
-                    help="Path to atomic dataset.")
+parser.add_argument("--tardis-refdata", dest="tardis-refdata",
+                    help="Path to Tardis Reference Data.")
 parser.add_argument("--less-packets", action="store_true", default=False,
                     help="Run integration tests with less packets.")
 
@@ -34,7 +34,7 @@ def run_tests():
     test_command = [
         "python", "setup.py", "test",
         "--test-path=tardis/tests/integration_tests/test_integration.py", "--args",
-        "--capture=no --integration-tests={0} --atomic-dataset={1} --remote-data "
+        "--capture=no --integration-tests={0} --tardis-refdata={1} --remote-data "
         "{2}".format(args.yaml_filepath, args.atomic_dataset, less_packets)
     ]
     subprocess.call(test_command)

--- a/tardis/tests/integration_tests/runner.py
+++ b/tardis/tests/integration_tests/runner.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 parser = argparse.ArgumentParser(description="Run slow integration tests")
 parser.add_argument("--integration-tests", dest="yaml_filepath",
                     help="Path to YAML config file for integration tests.")
-parser.add_argument("--tardis-refdata", dest="tardis-refdata",
+parser.add_argument("--tardis-refdata", dest="tardis_refdata",
                     help="Path to Tardis Reference Data.")
 parser.add_argument("--less-packets", action="store_true", default=False,
                     help="Run integration tests with less packets.")
@@ -35,7 +35,7 @@ def run_tests():
         "python", "setup.py", "test",
         "--test-path=tardis/tests/integration_tests/test_integration.py", "--args",
         "--capture=no --integration-tests={0} --tardis-refdata={1} --remote-data "
-        "{2}".format(args.yaml_filepath, args.atomic_dataset, less_packets)
+        "{2}".format(args.yaml_filepath, args.tardis_refdata, less_packets)
     ]
     subprocess.call(test_command)
 

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -135,8 +135,7 @@ class TestIntegration(object):
                 pytest.skip(
                     'Reference data {0} does exist and tests will not '
                     'proceed generating new data'.format(ref_data_path))
-            self.result.to_hdf(path_or_buf=ref_data_path,
-                               suffix_count=False)
+            self.result.to_hdf(file_path=ref_data_path)
             pytest.skip("Reference data saved at {0}".format(
                 data_path['gen_ref_path']
             ))

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -135,11 +135,11 @@ def test_atomic_symbol():
 def test_atomic_symbol_reverse():
     assert atomic.symbol2atomic_number['Si'] == 14
 
-@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
-                    reason='--atomic_database was not specified')
+@pytest.mark.skipif(not pytest.config.getvalue("tardis-refdata"),
+                    reason='--tardis-refdata was not specified')
 def test_atomic_reprepare():
     atom_data_filename = os.path.expanduser(os.path.expandvars(
-        pytest.config.getvalue('atomic-dataset')))
+        os.path.join(pytest.config.getvalue('tardis-refdata'), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')))
     assert os.path.exists(atom_data_filename), ("{0} atomic datafiles "
                                                          "does not seem to "
                                                          "exist".format(

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -135,22 +135,19 @@ def test_atomic_symbol():
 def test_atomic_symbol_reverse():
     assert atomic.symbol2atomic_number['Si'] == 14
 
-@pytest.mark.skipif(not pytest.config.getvalue("tardis-refdata"),
-                    reason='--tardis-refdata was not specified')
-def test_atomic_reprepare():
-    atom_data_filename = os.path.expanduser(os.path.expandvars(
-        os.path.join(pytest.config.getvalue('tardis-refdata'), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')))
-    assert os.path.exists(atom_data_filename), ("{0} atomic datafiles "
-                                                         "does not seem to "
-                                                         "exist".format(
-        atom_data_filename))
-    atom_data = atomic.AtomData.from_hdf5(atom_data_filename)
+
+def test_atomic_reprepare(atomic_data_fname):
+    assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles "
+                                               "does not seem to "
+                                               "exist".format(
+                                                   atomic_data_fname))
+    atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
     atom_data.prepare_atom_data([14])
     assert len(atom_data.lines) > 0
     # Fix for new behavior of prepare_atom_data
     # Consider doing only one prepare_atom_data and check
     # len(atom_data.lines) == N where N is known
-    atom_data = atomic.AtomData.from_hdf5(atom_data_filename)
+    atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
     atom_data.prepare_atom_data([20])
     assert len(atom_data.lines) > 0
 

--- a/tardis/tests/test_atomic.py
+++ b/tardis/tests/test_atomic.py
@@ -137,10 +137,6 @@ def test_atomic_symbol_reverse():
 
 
 def test_atomic_reprepare(atomic_data_fname):
-    assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles "
-                                               "does not seem to "
-                                               "exist".format(
-                                                   atomic_data_fname))
     atom_data = atomic.AtomData.from_hdf5(atomic_data_fname)
     atom_data.prepare_atom_data([14])
     assert len(atom_data.lines) > 0

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -14,8 +14,8 @@ from tardis.io.config_reader import Configuration
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'tests', 'data', fname)
 
-@pytest.mark.skipif(not pytest.config.getvalue("atomic-dataset"),
-                    reason='--atomic_database was not specified')
+@pytest.mark.skipif(not pytest.config.getvalue("tardis-refdata"),
+                    reason='--tardis-refdata was not specified')
 class TestSimpleRun():
     """
     Very simple run
@@ -25,7 +25,7 @@ class TestSimpleRun():
     @pytest.fixture(scope="class", autouse=True)
     def setup(self):
         self.atom_data_filename = os.path.expanduser(os.path.expandvars(
-            pytest.config.getvalue('atomic-dataset')))
+            os.path.join(pytest.config.getvalue('tardis-refdata'), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')))
         assert os.path.exists(self.atom_data_filename), ("{0} atomic datafiles"
                                                          " does not seem to "
                                                          "exist".format(

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -22,10 +22,6 @@ class TestSimpleRun():
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
     def setup(self, atomic_data_fname):
-        assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles"
-                                                   " does not seem to "
-                                                   "exist".format(
-                                                       atomic_data_fname))
         self.config_yaml = yaml_load_config_file(
             'tardis/io/tests/data/tardis_configv1_verysimple.yml')
         self.config_yaml['atom_data'] = atomic_data_fname

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -14,8 +14,6 @@ from tardis.io.config_reader import Configuration
 def data_path(fname):
     return os.path.join(tardis.__path__[0], 'tests', 'data', fname)
 
-@pytest.mark.skipif(not pytest.config.getvalue("tardis-refdata"),
-                    reason='--tardis-refdata was not specified')
 class TestSimpleRun():
     """
     Very simple run
@@ -23,16 +21,14 @@ class TestSimpleRun():
 
     @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup(self):
-        self.atom_data_filename = os.path.expanduser(os.path.expandvars(
-            os.path.join(pytest.config.getvalue('tardis-refdata'), 'atom_data', 'kurucz_cd23_chianti_H_He.h5')))
-        assert os.path.exists(self.atom_data_filename), ("{0} atomic datafiles"
-                                                         " does not seem to "
-                                                         "exist".format(
-            self.atom_data_filename))
+    def setup(self, atomic_data_fname):
+        assert os.path.exists(atomic_data_fname), ("{0} atomic datafiles"
+                                                   " does not seem to "
+                                                   "exist".format(
+                                                       atomic_data_fname))
         self.config_yaml = yaml_load_config_file(
             'tardis/io/tests/data/tardis_configv1_verysimple.yml')
-        self.config_yaml['atom_data'] = self.atom_data_filename
+        self.config_yaml['atom_data'] = atomic_data_fname
 
         tardis_config = Configuration.from_config_dict(self.config_yaml)
         self.simulation = Simulation.from_config(tardis_config)


### PR DESCRIPTION
This PR replaces `atomic-dataset` config option with `tardis-refdata`. Now `tardis-refdata` should point to Tardis reference folder. [Repository Link](https://github.com/tardis-sn/tardis-refdata) 