### PR TITLE
Fix compatibility bug in radiative_properties

### DIFF
--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -68,11 +68,11 @@ class StimulatedEmissionFactor(ProcessingPlasmaProperty):
         stimulated_emission_factor[meta_stable_upper &
                                    (stimulated_emission_factor < 0)] = 0.0
         if self.nlte_species:
-            nlte_lines_mask = \
-                np.zeros(stimulated_emission_factor.shape[0]).astype(bool)
-            for species in self.nlte_species:
-                nlte_lines_mask |= (lines.atomic_number == species[0]) & \
-                                   (lines.ion_number == species[1])
+            nlte_lines_mask = lines.apply(
+                    lambda row:
+                    (row.atomic_number, row.ion_number) in self.nlte_species,
+                    axis=1
+            ).values
             stimulated_emission_factor[(stimulated_emission_factor < 0) &
                 nlte_lines_mask[np.newaxis].T] = 0.0
         return stimulated_emission_factor


### PR DESCRIPTION
Not idea what exactly happened there but the `/=` operator converted the
array to a series which is a problem for [np.newaxis] as well as
potentially overwriting data in the loop. This should fix it and
reflects more clearly what exactly happens.