### PR TITLE
Fix compatibility with networkx 2.0

### DIFF
--- a/tardis/plasma/base.py
+++ b/tardis/plasma/base.py
@@ -190,7 +190,7 @@ class BasePlasma(PlasmaWriterMixin):
             descendants_ob += nx.descendants(self.graph, node_name)
 
         descendants_ob = list(set(descendants_ob))
-        sort_order = nx.topological_sort(self.graph)
+        sort_order = list(nx.topological_sort(self.graph))
 
         descendants_ob.sort(key=lambda val: sort_order.index(val) )
 


### PR DESCRIPTION
Updating the networkx package to version 2.0 resulted in the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/tardis", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/lshingles/Dropbox/GitHub/tardis/scripts/tardis", line 67, in <module>
    simulation = Simulation.from_config(tardis_config)
  File "/Users/lshingles/Dropbox/GitHub/tardis/tardis/simulation/base.py", line 353, in from_config
    atom_data=kwargs.get('atom_data', None))
  File "/Users/lshingles/Dropbox/GitHub/tardis/tardis/plasma/standard_plasmas.py", line 147, in assemble_plasma
    property_kwargs=property_kwargs, **kwargs)
  File "/Users/lshingles/Dropbox/GitHub/tardis/tardis/plasma/base.py", line 27, in __init__
    self.update(**kwargs)
  File "/Users/lshingles/Dropbox/GitHub/tardis/tardis/plasma/base.py", line 160, in update
    for module_name in self._resolve_update_list(kwargs.keys()):
  File "/Users/lshingles/Dropbox/GitHub/tardis/tardis/plasma/base.py", line 195, in _resolve_update_list
    descendants_ob.sort(key=lambda val: sort_order.index(val) )
  File "/Users/lshingles/Dropbox/GitHub/tardis/tardis/plasma/base.py", line 195, in <lambda>
    descendants_ob.sort(key=lambda val: sort_order.index(val) )
AttributeError: 'generator' object has no attribute 'index'
```

I've fixed the error by converting the generator to a list.