### PR TITLE
Add pyside to requirements (needed for GUI)

### DIFF
--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -21,7 +21,7 @@ dependencies:
 - pyyaml=3.12
 - jsonschema=2.5.1
 - pyne=0.5.3
-- pyside=1.2.0
+- pyside=1.2
 - graphviz=2.38
 - pygraphviz
 

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -21,6 +21,7 @@ dependencies:
 - pyyaml=3.12
 - jsonschema=2.5.1
 - pyne=0.5.3
+- pyside=1.2.0
 - graphviz=2.38
 - pygraphviz
 


### PR DESCRIPTION
Mini PR to add QT package pyside to conda requirements. This is needed to run the Tardis gui.