### PR TITLE
Prevent pandas SettingWithCopyWarning by copying DataFrames when slicing

### DIFF
--- a/tardis/io/atomic.py
+++ b/tardis/io/atomic.py
@@ -324,13 +324,13 @@ class AtomData(object):
 
             self.macro_atom_data = self.macro_atom_data_all.loc[
                 self.macro_atom_data_all['atomic_number'].isin(self.selected_atomic_numbers)
-            ]
+            ].copy()
 
             self.macro_atom_references = self.macro_atom_references_all[
                 self.macro_atom_references_all.index.isin(
                     self.selected_atomic_numbers,
                     level='atomic_number')
-            ]
+            ].copy()
 
             if line_interaction_type == 'downbranch':
                 self.macro_atom_data = self.macro_atom_data.loc[


### PR DESCRIPTION
Newer versions of pandas give a SettingWithCopyWarning when values are set on a copy of a slice of a DataFrame. Explicitly copying the DataFrame when making the slice removes the warning.

Running the tardis example would previously output the following warning messages:
```
[py.warnings         ][WARNING]  /usr/local/lib/python2.7/site-packages/pandas/core/indexing.py:337: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
  self.obj[key] = _infer_fill_value(value)
 (generic.py:1873)
py.warnings - WARNING - /usr/local/lib/python2.7/site-packages/pandas/core/indexing.py:337: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
  self.obj[key] = _infer_fill_value(value)

[py.warnings         ][WARNING]  /usr/local/lib/python2.7/site-packages/pandas/core/indexing.py:517: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
  self.obj[item] = s
 (generic.py:1873)
py.warnings - WARNING - /usr/local/lib/python2.7/site-packages/pandas/core/indexing.py:517: SettingWithCopyWarning: 
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
  self.obj[item] = s
```