### PR TITLE
Request specific sphinx version

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -8,6 +8,7 @@ pytest>=2.6.3
 mock
 
 ### TARDIS docs requirements ###
+sphinx==1.6.7
 numpydoc
 pybtex
 sphinx_bootstrap_theme


### PR DESCRIPTION
Read the docs is currently not building our documentation:
```
Running Sphinx v1.7.2
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/tardis/conda/latest/lib/python2.7/site-packages/sphinx/cmdline.py", line 303, in main
    args.warningiserror, args.tags, args.verbosity, args.jobs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tardis/conda/latest/lib/python2.7/site-packages/sphinx/application.py", line 191, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tardis/conda/latest/lib/python2.7/site-packages/sphinx/application.py", line 411, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/tardis/conda/latest/lib/python2.7/site-packages/sphinx/registry.py", line 318, in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname, err)
ExtensionError: Could not import extension numpydoc (exception: cannot import name Directive)

Extension error:
Could not import extension numpydoc (exception: cannot import name Directive)
```

I have the suspicion, that this may be connect to the new sphinx version. In this PR, an older sphinx version is explicitly given in the requirements file.