### PR TITLE
Simplify convergence strategies

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -30,9 +30,7 @@ def parse_convergence_section(convergence_section_dict):
         dictionary
     """
 
-
-    convergence_parameters = ['damping_constant', 'threshold', 'fraction',
-            'hold_iterations']
+    convergence_parameters = ['damping_constant', 'threshold']
 
     for convergence_variable in ['t_inner', 't_rad', 'w']:
         if convergence_variable not in convergence_section_dict:

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -258,9 +258,17 @@ class Configuration(ConfigurationNameSpace):
         validated_config_dict['config_dirname'] = config_dirname
 
         montecarlo_section = validated_config_dict['montecarlo']
-        montecarlo_section['convergence_strategy'] = (
-                parse_convergence_section(
-                    montecarlo_section['convergence_strategy']))
+        if montecarlo_section['convergence_strategy']['type'] == "damped":
+            montecarlo_section['convergence_strategy'] = (
+                    parse_convergence_section(
+                        montecarlo_section['convergence_strategy']))
+        elif montecarlo_section['convergence_strategy']['type'] == "custom":
+            raise NotImplementedError(
+                'convergence_strategy is set to "custom"; '
+                'you need to implement your specific convergence treatment')
+        else:
+            raise ValueError('convergence_strategy is not "damped" '
+                             'or "custom"')
 
         return cls(validated_config_dict)
 

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -90,6 +90,12 @@ definitions:
         type:
           enum:
           - specific
+        stop_if_converged:
+          type: boolean
+          default: false
+          description: stop plasma iterations before number of specified
+            iterations are reached if the simulation is plasma and inner
+            boundary state is converged
         threshold:
           type: number
           description: specifies the threshold that is taken as convergence  (i.e.

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -75,7 +75,6 @@ properties:
   convergence_strategy:
     oneOf:
     - $ref: '#/definitions/convergence_strategy/damped'
-    - $ref: '#/definitions/convergence_strategy/specific'
     default:
       type: 'damped'
 required:
@@ -85,68 +84,6 @@ required:
 definitions:
   convergence_strategy:
     damped:
-      type: object
-      additionalProperties: false
-      properties:
-        type:
-          enum:
-          - damped
-        damping_constant:
-          type: number
-          default: 0.5
-          description: damping constant
-        t_inner:
-          type: object
-          additionalProperties: false
-          properties:
-            damping_constant:
-              type: number
-              default: 0.5
-              description: damping constant
-            threshold:
-              type: number
-              description: specifies the threshold that is taken as convergence  (i.e.
-                0.05 means that the value does not change more than 5%)
-        t_rad:
-          type: object
-          additionalProperties: false
-          properties:
-            damping_constant:
-              type: number
-              default: 0.5
-              description: damping constant
-            threshold:
-              type: number
-              description: specifies the threshold that is taken as convergence  (i.e.
-                0.05 means that the value does not change more than 5%)
-          required:
-          - threshold
-        w:
-          type: object
-          additionalProperties: false
-          properties:
-            damping_constant:
-              type: number
-              default: 0.5
-              description: damping constant
-            threshold:
-              type: number
-              description: specifies the threshold that is taken as convergence  (i.e.
-                0.05 means that the value does not change more than 5%)
-          required:
-          - threshold
-        lock_t_inner_cycles:
-          type: number
-          multipleOf: 1.0
-          default: 1
-          description: The number of cycles to lock the update of the inner boundary
-            temperature. This process helps with convergence. The default is to switch
-            it off (1 cycle)
-        t_inner_update_exponent:
-          type: number
-          default: -0.5
-          description: L=4*pi*r**2*T^y
-    specific:
       type: object
       additionalProperties: false
       properties:

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -73,95 +73,115 @@ properties:
     default: 0.0
     description: albedo of the reflective boundary
   convergence_strategy:
-    type: object
-    additionalProperties: false
-    properties:
-      type:
-        enum:
-        - damped
-      stop_if_converged:
-        type: boolean
-        default: false
-        description: stop plasma iterations before number of specified
-          iterations are reached if the simulation is plasma and inner
-          boundary state is converged
-      fraction:
-        type: number
-        default: 0.8
-        description: the fraction of shells that have to converge to the given  convergence
-          threshold. For example, 0.8 means that 80% of shells have to converge
-          to the threshold that convergence is established
-      hold_iterations:
-        type: number
-        multipleOf: 1.0
-        default: 3
-        description: the number of iterations that the convergence criteria need
-          to be fulfilled before TARDIS accepts the simulation as converged
-      damping_constant:
-        type: number
-        default: 1.0
-        description: damping constant
-      threshold:
-        type: number
-        default: 0.05
-        description: specifies the threshold that is taken as convergence  (i.e.
-          0.05 means that the value does not change more than 5%)
-      t_inner:
-        type: object
-        additionalProperties: false
-        properties:
-          damping_constant:
-            type: number
-            default: 0.5
-            description: damping constant
-          threshold:
-            type: number
-            description: specifies the threshold that is taken as convergence  (i.e.
-              0.05 means that the value does not change more than 5%)
-      t_rad:
-        type: object
-        additionalProperties: false
-        properties:
-          damping_constant:
-            type: number
-            default: 0.5
-            description: damping constant
-          threshold:
-            type: number
-            description: specifies the threshold that is taken as convergence  (i.e.
-              0.05 means that the value does not change more than 5%)
-        required:
-        - threshold
-      w:
-        type: object
-        additionalProperties: false
-        properties:
-          damping_constant:
-            type: number
-            default: 0.5
-            description: damping constant
-          threshold:
-            type: number
-            description: specifies the threshold that is taken as convergence  (i.e.
-              0.05 means that the value does not change more than 5%)
-        required:
-        - threshold
-      lock_t_inner_cycles:
-        type: number
-        multipleOf: 1.0
-        default: 1
-        description: The number of cycles to lock the update of the inner boundary
-          temperature. This process helps with convergence. The default is to switch
-          it off (1 cycle)
-      t_inner_update_exponent:
-        type: number
-        default: -0.5
-        description: L=4*pi*r**2*T^y
+    oneOf:
+    - $ref: '#/definitions/convergence_strategy/damped'
+    - $ref: '#/definitions/convergence_strategy/custom'
+    default:
+      type: 'damped'
+required:
+- no_of_packets
+- iterations
+
+definitions:
+  convergence_strategy:
+    damped:
+      type: object
+      additionalProperties: false
+      properties:
+      properties:
+        type:
+          enum:
+          - damped
+        default: damped
+        stop_if_converged:
+          type: boolean
+          default: false
+          description: stop plasma iterations before number of specified
+            iterations are reached if the simulation is plasma and inner
+            boundary state is converged
+        fraction:
+          type: number
+          default: 0.8
+          description: the fraction of shells that have to converge to the given  convergence
+            threshold. For example, 0.8 means that 80% of shells have to converge
+            to the threshold that convergence is established
+        hold_iterations:
+          type: number
+          multipleOf: 1.0
+          default: 3
+          description: the number of iterations that the convergence criteria need
+            to be fulfilled before TARDIS accepts the simulation as converged
+        damping_constant:
+          type: number
+          default: 1.0
+          description: damping constant
+        threshold:
+          type: number
+          default: 0.05
+          description: specifies the threshold that is taken as convergence  (i.e.
+            0.05 means that the value does not change more than 5%)
+        t_inner:
+          type: object
+          additionalProperties: false
+          properties:
+            damping_constant:
+              type: number
+              default: 0.5
+              description: damping constant
+            threshold:
+              type: number
+              description: specifies the threshold that is taken as convergence  (i.e.
+                0.05 means that the value does not change more than 5%)
+        t_rad:
+          type: object
+          additionalProperties: false
+          properties:
+            damping_constant:
+              type: number
+              default: 0.5
+              description: damping constant
+            threshold:
+              type: number
+              description: specifies the threshold that is taken as convergence  (i.e.
+                0.05 means that the value does not change more than 5%)
+          required:
+          - threshold
+        w:
+          type: object
+          additionalProperties: false
+          properties:
+            damping_constant:
+              type: number
+              default: 0.5
+              description: damping constant
+            threshold:
+              type: number
+              description: specifies the threshold that is taken as convergence  (i.e.
+                0.05 means that the value does not change more than 5%)
+          required:
+          - threshold
+        lock_t_inner_cycles:
+          type: number
+          multipleOf: 1.0
+          default: 1
+          description: The number of cycles to lock the update of the inner boundary
+            temperature. This process helps with convergence. The default is to switch
+            it off (1 cycle)
+        t_inner_update_exponent:
+          type: number
+          default: -0.5
+          description: L=4*pi*r**2*T^y
+    custom:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          enum:
+          - custom
+        description: Use this convergence_strategy for your specific needs. You
+          need to change the codebase accordingly
     required:
     - fraction
     - damping_constant
     - threshold
     - hold_iterations
-required:
-- no_of_packets
-- iterations

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -73,92 +73,95 @@ properties:
     default: 0.0
     description: albedo of the reflective boundary
   convergence_strategy:
-    oneOf:
-    - $ref: '#/definitions/convergence_strategy/damped'
-    default:
-      type: 'damped'
+    type: object
+    additionalProperties: false
+    properties:
+      type:
+        enum:
+        - damped
+      stop_if_converged:
+        type: boolean
+        default: false
+        description: stop plasma iterations before number of specified
+          iterations are reached if the simulation is plasma and inner
+          boundary state is converged
+      fraction:
+        type: number
+        default: 0.8
+        description: the fraction of shells that have to converge to the given  convergence
+          threshold. For example, 0.8 means that 80% of shells have to converge
+          to the threshold that convergence is established
+      hold_iterations:
+        type: number
+        multipleOf: 1.0
+        default: 3
+        description: the number of iterations that the convergence criteria need
+          to be fulfilled before TARDIS accepts the simulation as converged
+      damping_constant:
+        type: number
+        default: 1.0
+        description: damping constant
+      threshold:
+        type: number
+        default: 0.05
+        description: specifies the threshold that is taken as convergence  (i.e.
+          0.05 means that the value does not change more than 5%)
+      t_inner:
+        type: object
+        additionalProperties: false
+        properties:
+          damping_constant:
+            type: number
+            default: 0.5
+            description: damping constant
+          threshold:
+            type: number
+            description: specifies the threshold that is taken as convergence  (i.e.
+              0.05 means that the value does not change more than 5%)
+      t_rad:
+        type: object
+        additionalProperties: false
+        properties:
+          damping_constant:
+            type: number
+            default: 0.5
+            description: damping constant
+          threshold:
+            type: number
+            description: specifies the threshold that is taken as convergence  (i.e.
+              0.05 means that the value does not change more than 5%)
+        required:
+        - threshold
+      w:
+        type: object
+        additionalProperties: false
+        properties:
+          damping_constant:
+            type: number
+            default: 0.5
+            description: damping constant
+          threshold:
+            type: number
+            description: specifies the threshold that is taken as convergence  (i.e.
+              0.05 means that the value does not change more than 5%)
+        required:
+        - threshold
+      lock_t_inner_cycles:
+        type: number
+        multipleOf: 1.0
+        default: 1
+        description: The number of cycles to lock the update of the inner boundary
+          temperature. This process helps with convergence. The default is to switch
+          it off (1 cycle)
+      t_inner_update_exponent:
+        type: number
+        default: -0.5
+        description: L=4*pi*r**2*T^y
+    required:
+    - fraction
+    - damping_constant
+    - threshold
+    - hold_iterations
 required:
 - no_of_packets
 - iterations
-
-definitions:
-  convergence_strategy:
-    damped:
-      type: object
-      additionalProperties: false
-      properties:
-        type:
-          enum:
-          - specific
-        stop_if_converged:
-          type: boolean
-          default: false
-          description: stop plasma iterations before number of specified
-            iterations are reached if the simulation is plasma and inner
-            boundary state is converged
-        fraction:
-          type: number
-          default: 0.8
-          description: the fraction of shells that have to converge to the given  convergence
-            threshold. For example, 0.8 means that 80% of shells have to converge
-            to the threshold that convergence is established
-        hold_iterations:
-          type: number
-          multipleOf: 1.0
-          default: 3
-          description: the number of iterations that the convergence criteria need
-            to be fulfilled before TARDIS accepts the simulation as converged
-        t_inner:
-          type: object
-          additionalProperties: false
-          properties:
-            damping_constant:
-              type: number
-              default: 0.5
-              description: damping constant
-            threshold:
-              type: number
-              description: specifies the threshold that is taken as convergence  (i.e.
-                0.05 means that the value does not change more than 5%)
-        t_rad:
-          type: object
-          additionalProperties: false
-          properties:
-            damping_constant:
-              type: number
-              default: 0.5
-              description: damping constant
-            threshold:
-              type: number
-              description: specifies the threshold that is taken as convergence  (i.e.
-                0.05 means that the value does not change more than 5%)
-          required:
-          - threshold
-        w:
-          type: object
-          additionalProperties: false
-          properties:
-            damping_constant:
-              type: number
-              default: 0.5
-              description: damping constant
-            threshold:
-              type: number
-              description: specifies the threshold that is taken as convergence  (i.e.
-                0.05 means that the value does not change more than 5%)
-          required:
-          - threshold
-        lock_t_inner_cycles:
-          type: number
-          multipleOf: 1.0
-          default: 1
-          description: The number of cycles to lock the update of the inner boundary
-            temperature. This process helps with convergence. The default is to switch
-            it off (1 cycle)
-        t_inner_update_exponent:
-          type: number
-          default: -0.5
-          description: L=4*pi*r**2*T^y
-      required:
-      - fraction
-      - hold_iterations

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -96,10 +96,6 @@ definitions:
           description: stop plasma iterations before number of specified
             iterations are reached if the simulation is plasma and inner
             boundary state is converged
-        threshold:
-          type: number
-          description: specifies the threshold that is taken as convergence  (i.e.
-            0.05 means that the value does not change more than 5%)
         fraction:
           type: number
           default: 0.8
@@ -159,15 +155,10 @@ definitions:
           description: The number of cycles to lock the update of the inner boundary
             temperature. This process helps with convergence. The default is to switch
             it off (1 cycle)
-        damping_constant:
-          type: number
-          default: 0.5
-          description: damping constant
         t_inner_update_exponent:
           type: number
           default: -0.5
           description: L=4*pi*r**2*T^y
       required:
-      - threshold
       - fraction
       - hold_iterations

--- a/tardis/io/tests/data/tardis_configv1_ascii_density_abund.yml
+++ b/tardis/io/tests/data/tardis_configv1_ascii_density_abund.yml
@@ -11,7 +11,7 @@ supernova:
 atom_data: kurucz_atom_pure_simple.h5
 
 model:
-            
+
     structure:
         type: file
         filename: density.dat
@@ -35,7 +35,7 @@ montecarlo:
     seed: 23111963
     no_of_packets : 1.0e+5
     iterations: 20
-    
+
     black_body_sampling:
         start: 1 angstrom
         stop: 1000000 angstrom
@@ -44,28 +44,15 @@ montecarlo:
     no_of_virtual_packets: 5
 
     convergence_strategy:
-        type: specific
+        type: damped
         damping_constant: 1.0
         threshold: 0.05
         fraction: 0.8
         hold_iterations: 3
         t_inner:
             damping_constant: 1.0
-    
+
 spectrum:
     start : 500 angstrom
     stop : 20000 angstrom
     num: 10000
-    
-
-
-
-    
-    
-
-
-
-    
-
-
-

--- a/tardis/io/tests/data/tardis_configv1_uniform_density.yml
+++ b/tardis/io/tests/data/tardis_configv1_uniform_density.yml
@@ -48,7 +48,7 @@ montecarlo:
     no_of_virtual_packets: 10
 
     convergence_strategy:
-        type: specific
+        type: damped
         damping_constant: 1.0
         threshold: 0.05
         fraction: 0.8

--- a/tardis/io/tests/data/tardis_configv1_verysimple.yml
+++ b/tardis/io/tests/data/tardis_configv1_verysimple.yml
@@ -39,6 +39,12 @@ montecarlo:
     iterations: 5
     last_no_of_packets: 5.0e+5
     no_of_virtual_packets: 5
+    convergence_strategy:
+      type: damped
+      damping_constant: 0.5
+      threshold: 0.05
+      lock_t_inner_cycles: 1
+      t_inner_update_exponent: -0.5
 
 spectrum:
     start: 500 angstrom

--- a/tardis/plasma/tests/data/plasma_test_config_lte.yml
+++ b/tardis/plasma/tests/data/plasma_test_config_lte.yml
@@ -40,6 +40,12 @@ montecarlo:
     iterations: 10
     last_no_of_packets: 1.0e+5
     no_of_virtual_packets: 5
+    convergence_strategy:
+      type: damped
+      damping_constant: 0.5
+      threshold: 0.05
+      lock_t_inner_cycles: 1
+      t_inner_update_exponent: -0.5
 
 spectrum:
     start: 500 angstrom

--- a/tardis/plasma/tests/data/plasma_test_config_nlte.yml
+++ b/tardis/plasma/tests/data/plasma_test_config_nlte.yml
@@ -42,6 +42,12 @@ montecarlo:
     iterations: 10
     last_no_of_packets: 1.0e+5
     no_of_virtual_packets: 5
+    convergence_strategy:
+      type: damped
+      damping_constant: 0.5
+      threshold: 0.05
+      lock_t_inner_cycles: 1
+      t_inner_update_exponent: -0.5
 
 spectrum:
     start: 500 angstrom

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -60,10 +60,15 @@ class Simulation(HDFWriterMixin):
             self.convergence_strategy = convergence_strategy
             self.converged = False
             self.consecutive_converges_count = 0
+        elif convergence_strategy.type in ('custom'):
+            raise NotImplementedError(
+                'Convergence strategy type is custom; '
+                'you need to implement your specific treatment!'
+            )
         else:
             raise ValueError(
                     'Convergence strategy type is '
-                    'not damped '
+                    'not damped or custom '
                     '- input is {0}'.format(convergence_strategy.type))
 
         self._callbacks = OrderedDict()

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -160,9 +160,12 @@ class Simulation(HDFWriterMixin):
             self.convergence_strategy.t_rad.damping_constant)
         next_w = self.damped_converge(
             self.model.w, estimated_w, self.convergence_strategy.w.damping_constant)
-        next_t_inner = self.damped_converge(
-            self.model.t_inner, estimated_t_inner,
-            self.convergence_strategy.t_inner.damping_constant)
+        if (self.iterations_executed + 1) % self.convergence_strategy.lock_t_inner_cycles == 0:
+            next_t_inner = self.damped_converge(
+                self.model.t_inner, estimated_t_inner,
+                self.convergence_strategy.t_inner.damping_constant)
+        else:
+            next_t_inner = self.model.t_inner
 
         self.log_plasma_state(self.model.t_rad, self.model.w,
                               self.model.t_inner, next_t_rad, next_w,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -213,9 +213,8 @@ class Simulation(HDFWriterMixin):
             self.converged = self.advance_state()
             self._call_back()
             if self.converged:
-                # this restructure will be later used to either stop after
-                # convergence of continue until all iterations are executed
-                break
+                if self.convergence_strategy.stop_if_converged:
+                    break
         # Last iteration
         self.iterate(self.last_no_of_packets, self.no_of_virtual_packets, True)
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -103,7 +103,7 @@ class Simulation(HDFWriterMixin):
             / no_of_shells)
 
         t_rad_converged = (
-            fraction_t_rad_converged > self.convergence_strategy.t_rad.threshold)
+            fraction_t_rad_converged > self.convergence_strategy.fraction)
 
         fraction_w_converged = (
             np.count_nonzero(
@@ -111,7 +111,7 @@ class Simulation(HDFWriterMixin):
             / no_of_shells)
 
         w_converged = (
-            fraction_w_converged > self.convergence_strategy.w.threshold)
+            fraction_w_converged > self.convergence_strategy.fraction)
 
         t_inner_converged = (
             convergence_t_inner < self.convergence_strategy.t_inner.threshold)


### PR DESCRIPTION
Currently, there is very little difference between the two supported convergence strategies, ``damped`` and ``specific``. Also, as noted in issue #695, a number of properties of the ``convergence_strategy`` are unused. This PR tries to simply the convergence strategy handling by

- merging the two existing strategies into one, which will be called ``damped`` (the name describes the current strategy to update the plasma variables best)
- introduce support for currently unused properties, in particular for ``lock_t_inner_cycles``, ``t_inner_update_exponent``
- remove remaining unused properties
- introduce new property that controls whether the simulation stops before the specified number of iterations if the plasma quantities converged or not 