### PR TITLE
Downgrade to Cython 0.21 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,13 +40,13 @@ matrix:
             - TEST_MODE='spectrum'
 
 #trouble with osx building due to segfault at cython (https://github.com/cython/cython/issues/2199)
-#        - os: osx
-#          language: generic
-#          env:
-#            - COMPILER=clang
-#            - SETUP_CMD='test --args="--tardis-refdata=$HOME/tardis-refdata/"'
-#            - TEST_MODE='spectrum'
-#            - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
+        - os: osx
+          language: generic
+          env:
+            - COMPILER=clang
+            - SETUP_CMD='test --args="--tardis-refdata=$HOME/tardis-refdata/"'
+            - TEST_MODE='spectrum'
+            - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
 
 
         - python: 2.7

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -15,7 +15,7 @@ dependencies:
 - matplotlib=2.0
 - astropy=1.3
 - numexpr=2.6
-- Cython=0.21
+- Cython=0.28.2
 - networkx=1.10
 - pytest=3.0
 - pyyaml=3.12

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -8,10 +8,10 @@ channels:
 dependencies:
 - python=2.7
 - numpy=1.12
-- scipy=1
+- scipy=0.18
 - pandas=0.20
 - pytables
-- h5py=2
+- h5py=2.6
 - matplotlib=2.0
 - astropy=1.3
 - numexpr=2.6
@@ -20,7 +20,8 @@ dependencies:
 - pytest=3.0
 - pyyaml=3.12
 - jsonschema=2.5.1
-- pyne=0.5
+- pyne=0.5.3
+- pyside=1.2
 - graphviz=2.38
 - pygraphviz
 

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -15,7 +15,7 @@ dependencies:
 - matplotlib=2.0
 - astropy=1.3
 - numexpr=2.6
-- Cython=0.28.2
+#- Cython=0.28.2
 - networkx=1.10
 - pytest=3.0
 - pyyaml=3.12
@@ -47,3 +47,4 @@ dependencies:
   - pytest-html==1.10.0
   - dokuwiki
   - dot2tex
+  - git+https://github.com/cython/cython

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -15,7 +15,7 @@ dependencies:
 - matplotlib=2.0
 - astropy=1.3
 - numexpr=2.6
-- Cython=0.28
+- Cython=0.21
 - networkx=1.10
 - pytest=3.0
 - pyyaml=3.12


### PR DESCRIPTION
With this PR, we try to restore the environment state prior to addressing #810. By upgrading to Cython 0.28, a mysterious segmentation fault during cythonizing breaks our Travis testing process. This segmentation fault is very hard to reproduce locally. For this reason, we try to revert to 0.21 (with this version, Travis should at least work) and suggest to users facing issues similar to #810 to manually upgrade to a newer version of Cython.