### PR TITLE
Remove tardis_example.tar.gz from documentation; fixes #824

### DIFF
--- a/docs/examples/tardis_example.rst
+++ b/docs/examples/tardis_example.rst
@@ -1,10 +1,11 @@
 tardis_example
 --------------
 
-The simple and fast TARDIS setup is provided by tardis_example archive which
-may be obtained from `<http://opensupernova.org/~ftsamis/tardis_example.tar.gz>`
-and which we suggest every new user of TARDIS to run
-first.
+The simple and fast TARDIS setup is provided by ``tardis_example.yml`` which
+may be obtained from `tardis-refdata
+<https://github.com/tardis-sn/tardis-refdata>`_ repository. It is located in
+the ``configs/example`` subfolder. We suggest every new user of TARDIS to run this
+setup first.
 
 It calculates a spectrum for a Type Ia supernova model 13 days after explosion,
 requesting a total output luminosity of

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -14,15 +14,18 @@ To run TARDIS requires two files. The atomic database (for more info refer to
 Running TARDIS in the commandline
 =================================
 
-After installing TARDIS just download the `example directory
-<http://opensupernova.org/~ftsamis/tardis_example.tar.gz>`_
-and run TARDIS with:
+After installing TARDIS just download the configuration file and the standard
+atomic data set from the `tardis-refdata
+<https://github.com/tardis-sn/tardis-refdata>`_ repository and run TARDIS.
+Assuming you have ``wget``, you could follow the procedure:
 
 
 .. code-block:: none
 
-    tar zxvf tardis_example.tar.gz
+    mkdir tardis_example
     cd tardis_example
+    wget https://github.com/tardis-sn/tardis-refdata/raw/master/configs/examples/tardis_example.yml
+    wget https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He.h5
     tardis tardis_example.yml output_spectrum.dat
 
 


### PR DESCRIPTION
This PR updates the documentation concerning the tardis example setup. We now suggest to take both the atomic data set and the config file from the tardis-refdata repository.