### PR TITLE
Update Documentation: new location of tardis_example

### DIFF
--- a/docs/configuration/configuration.rst
+++ b/docs/configuration/configuration.rst
@@ -1,3 +1,5 @@
+.. _config-file:
+
 ******************
 Configuration File
 ******************

--- a/docs/examples/tardis_example.rst
+++ b/docs/examples/tardis_example.rst
@@ -2,9 +2,9 @@ tardis_example
 --------------
 
 The simple and fast TARDIS setup is provided by ``tardis_example.yml`` which
-may be obtained from `tardis-refdata
-<https://github.com/tardis-sn/tardis-refdata>`_ repository. It is located in
-the ``configs/example`` subfolder. We suggest every new user of TARDIS to run this
+may be obtained from `tardis-setups
+<https://github.com/tardis-sn/tardis-setups>`_ repository. It is located in
+the ``tardis-setups/2014/2014_kerzendorf_sim/appendix_A1`` subfolder. We suggest every new user of TARDIS to run this
 setup first.
 
 It calculates a spectrum for a Type Ia supernova model 13 days after explosion,

--- a/docs/examples/tardis_example.yml
+++ b/docs/examples/tardis_example.yml
@@ -1,4 +1,6 @@
+# Example YAML configuration for TARDIS
 tardis_config_version: v1.0
+
 supernova:
   luminosity_requested: 9.44 log_lsun
   time_explosion: 13 day
@@ -14,6 +16,7 @@ model:
       num: 20
     density:
       type: branch85_w7
+
   abundances:
     type: uniform
     O: 0.19
@@ -34,12 +37,19 @@ montecarlo:
   seed: 23111963
   no_of_packets: 4.0e+4
   iterations: 20
-  black_body_sampling:
-    start: 1 angstrom
-    stop: 1000000 angstrom
-    num: 1.e+6
+  nthreads: 1
+
   last_no_of_packets: 1.e+5
   no_of_virtual_packets: 10
+
+  convergence_strategy:
+    type: damped
+    damping_constant: 1.0
+    threshold: 0.05
+    fraction: 0.8
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 1.0
 
 spectrum:
   start: 500 angstrom

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -14,7 +14,8 @@ To run TARDIS requires two files. The atomic database (for more info refer to
 Running TARDIS in the commandline
 =================================
 
-After installing TARDIS just download the configuration file and the standard
+After installing TARDIS just download the configuration file from the
+`tardis-setups <https://github.com/tardis-sn/tardis-setups>`_ and the standard
 atomic data set from the `tardis-refdata
 <https://github.com/tardis-sn/tardis-refdata>`_ repository and run TARDIS.
 Assuming you have ``wget``, you could follow the procedure:
@@ -24,7 +25,7 @@ Assuming you have ``wget``, you could follow the procedure:
 
     mkdir tardis_example
     cd tardis_example
-    wget https://github.com/tardis-sn/tardis-refdata/raw/master/configs/examples/tardis_example.yml
+    wget https://github.com/tardis-sn/tardis-setups/raw/master/tardis-setups/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
     wget https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He.h5
     tardis tardis_example.yml output_spectrum.dat
 


### PR DESCRIPTION
This small PR updates the location of the ``tardis_example.yml`` config file in the documentation since it now lives in the ``tardis-setups`` repository.