### PR TITLE
Add full test for formal integral method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,10 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs install --skip-smudge; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $TARDIS_REF_DATA_URL $HOME/tardis-refdata; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $HOME/tardis-refdata; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/10/head:formalintegral-ref; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout formalintegral-ref; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/chianti_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,10 +74,12 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs install --skip-smudge; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $TARDIS_REF_DATA_URL $HOME/tardis-refdata; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $HOME/tardis-refdata; fi
-    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/10/head:formalintegral-ref; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout formalintegral-ref; fi
+    # Use the following to get the ref-data from the master; 
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    # Use the following to get the ref-data from a specific pull request; 
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/10/head:formalintegral-ref; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout formalintegral-ref; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/chianti_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi

--- a/docs/montecarlo/sourceintegration.rst
+++ b/docs/montecarlo/sourceintegration.rst
@@ -178,7 +178,6 @@ Current Limitations
 
 The current implementation of the formal integral has some limitations:
 
-* it only works with the downbranching line interaction mode
 * once electron scattering is included, the scheme only produces accurate
   results when multiple resonances occur on the rays. This is simply because
   otherwise the :math:`J^b` and :math:`J^r` do not provide an accurate

--- a/docs/running/index.rst
+++ b/docs/running/index.rst
@@ -8,4 +8,5 @@ Information regarding running and operating Tardis.
 
   ../configuration/index
   access
+  using_formal_integral
 

--- a/docs/running/using_formal_integral.rst
+++ b/docs/running/using_formal_integral.rst
@@ -1,0 +1,26 @@
+**************************************************
+Spectral Synthesis with the Formal Integral Method
+**************************************************
+
+In addition to generating the final Monte Carlo spectrum from the population of
+Monte Carlo packets and the implemented variant of the "peeling-off" technique
+(see :doc:`../montecarlo/virtualpackets`), TARDIS supports spectral synthesis with
+so-called formal integral method by :cite:`Lucy1999a` (see a detailed
+description of the method at :doc:`../montecarlo/sourceintegration`)
+
+Using the Formal Integral Method
+================================
+
+The formal integral spectral synthesis mode is activated by setting the
+
+.. code-block:: none
+
+    method: integrated 
+
+configuration option in the ``spectrum`` block of the yml file.
+
+Note that the integrated spectrum (``simulation.runner.spectrum_integrated``)
+is a lazy property so it will be only generated (and then cached) once it is
+accessed. The spectrum integration routine is Open-MP parallelized, so this
+process may be significantly sped-up if TARDIS is built with the
+``--with-openmp`` option and more then one threas is used.

--- a/tardis/tests/test_tardis_full_formal_integral.py
+++ b/tardis/tests/test_tardis_full_formal_integral.py
@@ -38,6 +38,9 @@ class TestRunnerSimpleFormalInegral():
             tardis_ref_data, generate_reference):
         config.atom_data = atomic_data_fname
 
+        self.name = (self.name +
+                     "_{:s}".format(config.plasma.line_interaction_type))
+
         simulation = Simulation.from_config(config)
         simulation.run()
 

--- a/tardis/tests/test_tardis_full_formal_integral.py
+++ b/tardis/tests/test_tardis_full_formal_integral.py
@@ -9,16 +9,15 @@ from tardis.simulation.base import Simulation
 from tardis.io.config_reader import Configuration
 
 
-@pytest.mark.parametrize('line_mode',
-                         ['downbranch',
-                          'macroatom'])
-@pytest.fixture(scope='module')
-def config(line_mode, atomic_data_fname):
+config_line_modes = ['downbranch', 'macroatom']
+
+
+@pytest.fixture(scope='module', params=config_line_modes)
+def config(request):
     config = Configuration.from_yaml(
         'tardis/io/tests/data/tardis_configv1_verysimple.yml')
 
-    config["atom_data"] = atomic_data_fname
-    config["plasma"]["line_interaction_type"] = line_mode
+    config["plasma"]["line_interaction_type"] = request.param
     config["montecarlo"]["no_of_packets"] = 4.0e+4
     config["montecarlo"]["last_no_of_packets"] = 1.0e+5
     config["montecarlo"]["no_of_virtual_packets"] = 0
@@ -35,10 +34,9 @@ class TestRunnerSimpleFormalInegral():
 
     @pytest.fixture(scope="class")
     def runner(
-            self, config,
+            self, config, atomic_data_fname,
             tardis_ref_data, generate_reference):
-        config = Configuration.from_yaml(
-                'tardis/io/tests/data/tardis_configv1_verysimple.yml')
+        config.atom_data = atomic_data_fname
 
         simulation = Simulation.from_config(config)
         simulation.run()

--- a/tardis/tests/test_tardis_full_formal_integral.py
+++ b/tardis/tests/test_tardis_full_formal_integral.py
@@ -1,0 +1,74 @@
+import os
+import pytest
+import numpy as np
+import numpy.testing as npt
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+
+from tardis.simulation.base import Simulation
+from tardis.io.config_reader import Configuration
+
+
+class TestRunnerSimpleFormalInegral():
+    """
+    Very simple run with the formal integral spectral synthesis method
+    """
+    name = 'test_runner_simple_integral'
+
+    @pytest.fixture(scope="class")
+    def runner(
+            self, atomic_data_fname,
+            tardis_ref_data, generate_reference):
+        config = Configuration.from_yaml(
+                'tardis/io/tests/data/tardis_configv1_verysimple.yml')
+        config['atom_data'] = atomic_data_fname
+        config["plasma"]["line_interaction_type"] = "downbranch"
+        config["montecarlo"]["no_of_virtual_packets"] = 0
+        config["spectrum"]["method"] = "integrated"
+
+        simulation = Simulation.from_config(config)
+        simulation.run()
+
+        if not generate_reference:
+            return simulation.runner
+        else:
+            simulation.runner.hdf_properties = [
+                    'j_blue_estimator',
+                    'spectrum',
+                    'spectrum_integrated'
+                    ]
+            simulation.runner.to_hdf(
+                    tardis_ref_data,
+                    '',
+                    self.name)
+            pytest.skip(
+                    'Reference data was generated during this run.')
+
+    @pytest.fixture(scope='class')
+    def refdata(self, tardis_ref_data):
+        def get_ref_data(key):
+            return tardis_ref_data[os.path.join(
+                    self.name, key)]
+        return get_ref_data
+
+    def test_j_blue_estimators(self, runner, refdata):
+        j_blue_estimator = refdata('j_blue_estimator').values
+
+        npt.assert_allclose(
+                runner.j_blue_estimator,
+                j_blue_estimator)
+
+    def test_spectrum(self, runner, refdata):
+        luminosity = u.Quantity(refdata('spectrum/luminosity'), 'erg /s')
+
+        assert_quantity_allclose(
+            runner.spectrum.luminosity,
+            luminosity)
+
+    def test_virtual_integrated(self, runner, refdata):
+        luminosity = u.Quantity(
+                refdata('spectrum_virtual/luminosity'), 'erg /s')
+
+        assert_quantity_allclose(
+            runner.spectrum_integrated.luminosity,
+            luminosity)

--- a/tardis/tests/test_tardis_full_formal_integral.py
+++ b/tardis/tests/test_tardis_full_formal_integral.py
@@ -9,6 +9,24 @@ from tardis.simulation.base import Simulation
 from tardis.io.config_reader import Configuration
 
 
+@pytest.mark.parametrize('line_mode',
+                         ['downbranch',
+                          'macroatom'])
+@pytest.fixture(scope='module')
+def config(line_mode, atomic_data_fname):
+    config = Configuration.from_yaml(
+        'tardis/io/tests/data/tardis_configv1_verysimple.yml')
+
+    config["atom_data"] = atomic_data_fname
+    config["plasma"]["line_interaction_type"] = line_mode
+    config["montecarlo"]["no_of_packets"] = 4.0e+4
+    config["montecarlo"]["last_no_of_packets"] = 1.0e+5
+    config["montecarlo"]["no_of_virtual_packets"] = 0
+    config["spectrum"]["method"] = "integrated"
+
+    return config
+
+
 class TestRunnerSimpleFormalInegral():
     """
     Very simple run with the formal integral spectral synthesis method
@@ -17,14 +35,10 @@ class TestRunnerSimpleFormalInegral():
 
     @pytest.fixture(scope="class")
     def runner(
-            self, atomic_data_fname,
+            self, config,
             tardis_ref_data, generate_reference):
         config = Configuration.from_yaml(
                 'tardis/io/tests/data/tardis_configv1_verysimple.yml')
-        config['atom_data'] = atomic_data_fname
-        config["plasma"]["line_interaction_type"] = "downbranch"
-        config["montecarlo"]["no_of_virtual_packets"] = 0
-        config["spectrum"]["method"] = "integrated"
 
         simulation = Simulation.from_config(config)
         simulation.run()
@@ -65,9 +79,9 @@ class TestRunnerSimpleFormalInegral():
             runner.spectrum.luminosity,
             luminosity)
 
-    def test_virtual_integrated(self, runner, refdata):
+    def test_spectrum_integrated(self, runner, refdata):
         luminosity = u.Quantity(
-                refdata('spectrum_virtual/luminosity'), 'erg /s')
+                refdata('spectrum_integrated/luminosity'), 'erg /s')
 
         assert_quantity_allclose(
             runner.spectrum_integrated.luminosity,


### PR DESCRIPTION
This PR adds another test for the formal integral method, specifically checking the final spectrum determined with this scheme. The setup is very similar to the one used for ``test_tardis_full.py``.

- [x] add new test with modified setup
- [x] test for integrated spectrum
- [x] test formal integral for both macroatom and downbranch modes
- [x] update reference data
- [x] update documentation