### PR TITLE
Unify unittest hdfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/chianti_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="unit_test_data.h5" origin; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then echo MD5 `md5sum unit_test_data.h5`
+    - if [[ $TEST_MODE == 'spectrum' ]]; then echo MD5 `md5sum unit_test_data.h5`; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,14 +75,13 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $TARDIS_REF_DATA_URL $HOME/tardis-refdata; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $HOME/tardis-refdata; fi
     # Use the following to get the ref-data from the master; 
-    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
     # Use the following to get the ref-data from a specific pull request; 
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/14/head:update-ref; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout update-ref; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/14/head:update-ref; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout update-ref; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/chianti_He.h5" origin; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="unit_test_data.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then echo MD5 `md5sum unit_test_data.h5`; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/chianti_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="unit_test_data.h5" origin; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then echo MD5 `md5sum unit_test_data.h5`
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,11 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $TARDIS_REF_DATA_URL $HOME/tardis-refdata; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $HOME/tardis-refdata; fi
     # Use the following to get the ref-data from the master; 
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
     # Use the following to get the ref-data from a specific pull request; 
-    # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/11/head:thomson-ref; fi
-    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout thomson-ref; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/14/head:update-ref; fi
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout update-ref; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="atom_data/chianti_He.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="plasma_reference/" origin; fi

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -108,7 +108,7 @@ from tardis.tests.fixtures.atom_data import *
 @pytest.yield_fixture(scope="session")
 def tardis_ref_data(tardis_ref_path, generate_reference):
     if generate_reference:
-        mode = 'a'
+        mode = 'w'
     else:
         mode = 'r'
     with pd.HDFStore(

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -108,7 +108,7 @@ from tardis.tests.fixtures.atom_data import *
 @pytest.yield_fixture(scope="session")
 def tardis_ref_data(tardis_ref_path, generate_reference):
     if generate_reference:
-        mode = 'w'
+        mode = 'a'
     else:
         mode = 'r'
     with pd.HDFStore(

--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -137,7 +137,7 @@ class TestPlasma(object):
     @pytest.yield_fixture(scope="class")
     def reference(self, reference_fpath, generate_reference):
         if generate_reference:
-            mode = 'w'
+            mode = 'a'
         else:
             mode = 'r'
         with pd.HDFStore(

--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -120,7 +120,7 @@ class TestPlasma(object):
             else:
                 config.plasma[prop] = value
                 hash_string = '_'.join((hash_string, str(value)))
-        hash_string = "plasma_unittest/" + hash_string
+        hash_string = os.path.join("plasma_unittest", hash_string)
         setattr(config.plasma, 'save_path', hash_string)
         return config
 

--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -103,11 +103,11 @@ class TestPlasma(object):
     @pytest.fixture(scope="class")
     def reference_fpath(self, tardis_ref_path):
         path = os.path.join(
-            tardis_ref_path, 'plasma_reference', 'reference_data.h5')
-        if pytest.config.getvalue("--generate-reference"):
-            if os.path.exists(path):
-                pytest.skip('Reference data {0} does exist and tests will not '
-                            'proceed generating new data'.format(path))
+            tardis_ref_path, 'unit_test_data.h5')
+        # if pytest.config.getvalue("--generate-reference"):
+        #     if os.path.exists(path):
+        #         pytest.skip('Reference data {0} does exist and tests will not '
+        #                     'proceed generating new data'.format(path))
         return path
 
     @pytest.fixture(
@@ -130,6 +130,7 @@ class TestPlasma(object):
             else:
                 config.plasma[prop] = value
                 hash_string = '_'.join((hash_string, str(value)))
+        hash_string = "plasma_unittest/" + hash_string
         setattr(config.plasma, 'save_path', hash_string)
         return config
 

--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -142,12 +142,12 @@ class TestPlasma(object):
         return config
 
     @pytest.fixture(scope="class")
-    def plasma(self, chianti_he_db_fpath, config, reference_fpath):
+    def plasma(self, chianti_he_db_fpath, config, tardis_ref_data):
         config['atom_data'] = chianti_he_db_fpath
         sim = Simulation.from_config(config)
         if pytest.config.getvalue("--generate-reference"):
-            sim.plasma.to_hdf(reference_fpath, path=config.plasma.save_path)
-            pytest.skip("Reference data saved at {0}".format(reference_fpath))
+            sim.plasma.to_hdf(tardis_ref_data, path=config.plasma.save_path)
+            pytest.skip("Reference data saved at {0}".format(tardis_ref_data))
         return sim.plasma
 
     @pytest.mark.parametrize("attr", combined_properties)


### PR DESCRIPTION
This PR unifies the HDF5 files containing the reference data for the unit tests. Currently, the data are stored in 

*  ``unit_test_data.h5``
*  ``plasma_reference/reference_data.h5``

With this PR all data will be migrated to ``unit_test_data.h5``.