### PR TITLE
Add Travis Stages: Activate Integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,13 @@ matrix:
             - TEST_MODE='spectrum'
             - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
 
-cache:
-  apt: true
-  directories:
-    - $HOME/miniconda
-    #- $REF_DATA_HOME
+
+
+              #cache:
+              #  apt: true
+              #  directories:
+              #    - $HOME/miniconda
+              #    #- $REF_DATA_HOME
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+stages:
+  - test
+  - integration
+
+jobs:
+  include:
+    - stage: integration
+      script:
+        - echo $COMPILER
 os:
   - linux
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,9 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $REF_DATA_HOME; fi
 # Use the following to get the ref-data from the master;
     - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
+    # workaround to avoid refdata mixup introduced by PR 15
+    - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout ea89b9266d56de05fa84bc3d4bad62c09ce31486; fi
     # Use the following to get the ref-data from a specific pull request; 
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/14/head:update-ref; fi
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout update-ref; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ env:
         - SAVE_COVERAGE=false
         - GIT_LFS_SKIP_SMUDGE=1
 
-              #cache:
-              #  apt: true
-              #  directories:
-              #    - $HOME/miniconda
-              #    #- $REF_DATA_HOME
+cache:
+  apt: true
+  directories:
+    - $HOME/miniconda
+    #- $REF_DATA_HOME
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,3 @@
-stages:
-  - test
-  - integration
-
-jobs:
-  include:
-    - stage: integration
-      script:
-        - echo $COMPILER
 os:
   - linux
 language: python
@@ -105,3 +96,15 @@ after_success:
 
 after_failure:
     - cat /home/travis/.pip/pip.log
+
+
+stages:
+  - test
+  - integration
+
+jobs:
+  include:
+    - stage: test
+    - stage: integration
+      script:
+        - echo $COMPILER

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,32 +29,6 @@ env:
         - SAVE_COVERAGE=false
         - GIT_LFS_SKIP_SMUDGE=1
 
-          #matrix:
-          #    include:
-          #        - python: 2.7
-          #          env:
-          #            - COMPILER=gcc
-          #            - SETUP_CMD='test --coverage --args="--tardis-refdata=$REF_DATA_HOME"'
-          #            - TEST_MODE='spectrum'
-          #            - SAVE_COVERAGE=true
-          #
-          #        - python: 2.7
-          #          env:
-          #            - COMPILER=clang
-          #            - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
-          #            - TEST_MODE='spectrum'
-          #
-          ##trouble with osx building due to segfault at cython (https://github.com/cython/cython/issues/2199)
-          #        - os: osx
-          #          language: generic
-          #          env:
-          #            - COMPILER=clang
-          #            - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
-          #            - TEST_MODE='spectrum'
-          #            - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
-          #
-
-
               #cache:
               #  apt: true
               #  directories:
@@ -86,7 +60,6 @@ before_install:
 
 #- source ci-helpers/fetch_reference_data.sh
 
-
 install:
    - source ci-helpers/install_tardis_env.sh
 
@@ -114,35 +87,12 @@ jobs:
         - SETUP_CMD='test --coverage --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
         - SAVE_COVERAGE=true
-          #      script:
-          #        - echo COMPILER=$COMPILER
-          #        - echo PANDAS_VERSION=$PANDAS_VERSION
-          #        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
-          #        - echo SETUP_CMD=$SETUP_CMD
-          #        - echo TEST_MODE=$TEST_MODE
-          #        - echo REF_DATA_HOME=$REF_DATA_HOME
-          #        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
-          #        - echo SAVE_COVERAGE=$SAVE_COVERAGE
-          #        - echo MINICONDA_URL=$MINICONDA_URL
-          #        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
-          #        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
     - stage: test
       python: 2.7
       env:
         - COMPILER=clang
         - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
-          #       script:
-          #         - echo COMPILER=$COMPILER
-          #         - echo PANDAS_VERSION=$PANDAS_VERSION
-          #         - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
-          #         - echo SETUP_CMD=$SETUP_CMD
-          #         - echo TEST_MODE=$TEST_MODE
-          #         - echo REF_DATA_HOME=$REF_DATA_HOME
-          #         - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
-          #         - echo MINICONDA_URL=$MINICONDA_URL
-          #         - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
-          #         - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
     - stage: test
       os: osx
       language: generic
@@ -151,17 +101,6 @@ jobs:
         - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
         - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
-          #      script:
-          #        - echo COMPILER=$COMPILER
-          #        - echo PANDAS_VERSION=$PANDAS_VERSION
-          #        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
-          #        - echo SETUP_CMD=$SETUP_CMD
-          #        - echo TEST_MODE=$TEST_MODE
-          #        - echo REF_DATA_HOME=$REF_DATA_HOME
-          #        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
-          #        - echo MINICONDA_URL=$MINICONDA_URL
-          #        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
-          #        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
     - stage: integration
       if: type = cron
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,57 @@ stages:
 jobs:
   include:
     - stage: test
+      python: 2.7
+      env:
+        - COMPILER=gcc
+        - SETUP_CMD='test --coverage --args="--tardis-refdata=$REF_DATA_HOME"'
+        - TEST_MODE='spectrum'
+        - SAVE_COVERAGE=true
+      script:
+        - echo COMPILER=$COMPILER
+        - echo PANDAS_VERSION=$PANDAS_VERSION
+        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
+        - echo SETUP_CMD=$SETUP_CMD
+        - echo TEST_MODE=$TEST_MODE
+        - echo REF_DATA_HOME=$REF_DATA_HOME
+        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
+        - echo SAVE_COVERAGE=$SAVE_COVERAGE
+        - echo MINICONDA_URL=$MINICONDA_URL
+        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+    - stage: test
+      python: 2.7
+      env:
+        - COMPILER=clang
+        - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
+        - TEST_MODE='spectrum'
+      script:
+        - echo COMPILER=$COMPILER
+        - echo PANDAS_VERSION=$PANDAS_VERSION
+        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
+        - echo SETUP_CMD=$SETUP_CMD
+        - echo TEST_MODE=$TEST_MODE
+        - echo REF_DATA_HOME=$REF_DATA_HOME
+        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
+        - echo MINICONDA_URL=$MINICONDA_URL
+        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+    - stage: test
+      os: osx
+      language: generic
+      env:
+        - COMPILER=clang
+        - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
+        - TEST_MODE='spectrum'
+        - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
+      script:
+        - echo COMPILER=$COMPILER
+        - echo PANDAS_VERSION=$PANDAS_VERSION
+        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
+        - echo SETUP_CMD=$SETUP_CMD
+        - echo TEST_MODE=$TEST_MODE
+        - echo REF_DATA_HOME=$REF_DATA_HOME
+        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
+        - echo MINICONDA_URL=$MINICONDA_URL
+        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
     - stage: integration
       script:
         - echo $COMPILER

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,30 +29,30 @@ env:
         - SAVE_COVERAGE=false
         - GIT_LFS_SKIP_SMUDGE=1
 
-matrix:
-    include:
-        - python: 2.7
-          env:
-            - COMPILER=gcc
-            - SETUP_CMD='test --coverage --args="--tardis-refdata=$REF_DATA_HOME"'
-            - TEST_MODE='spectrum'
-            - SAVE_COVERAGE=true
-
-        - python: 2.7
-          env:
-            - COMPILER=clang
-            - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
-            - TEST_MODE='spectrum'
-
-#trouble with osx building due to segfault at cython (https://github.com/cython/cython/issues/2199)
-        - os: osx
-          language: generic
-          env:
-            - COMPILER=clang
-            - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
-            - TEST_MODE='spectrum'
-            - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
-
+          #matrix:
+          #    include:
+          #        - python: 2.7
+          #          env:
+          #            - COMPILER=gcc
+          #            - SETUP_CMD='test --coverage --args="--tardis-refdata=$REF_DATA_HOME"'
+          #            - TEST_MODE='spectrum'
+          #            - SAVE_COVERAGE=true
+          #
+          #        - python: 2.7
+          #          env:
+          #            - COMPILER=clang
+          #            - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
+          #            - TEST_MODE='spectrum'
+          #
+          ##trouble with osx building due to segfault at cython (https://github.com/cython/cython/issues/2199)
+          #        - os: osx
+          #          language: generic
+          #          env:
+          #            - COMPILER=clang
+          #            - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
+          #            - TEST_MODE='spectrum'
+          #            - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
+          #
 
 
               #cache:
@@ -99,7 +99,6 @@ after_success:
 after_failure:
     - cat /home/travis/.pip/pip.log
 
-
 stages:
   - test
   - integration
@@ -113,33 +112,35 @@ jobs:
         - SETUP_CMD='test --coverage --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
         - SAVE_COVERAGE=true
-      script:
-        - echo COMPILER=$COMPILER
-        - echo PANDAS_VERSION=$PANDAS_VERSION
-        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
-        - echo SETUP_CMD=$SETUP_CMD
-        - echo TEST_MODE=$TEST_MODE
-        - echo REF_DATA_HOME=$REF_DATA_HOME
-        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
-        - echo SAVE_COVERAGE=$SAVE_COVERAGE
-        - echo MINICONDA_URL=$MINICONDA_URL
-        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+          #      script:
+          #        - echo COMPILER=$COMPILER
+          #        - echo PANDAS_VERSION=$PANDAS_VERSION
+          #        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
+          #        - echo SETUP_CMD=$SETUP_CMD
+          #        - echo TEST_MODE=$TEST_MODE
+          #        - echo REF_DATA_HOME=$REF_DATA_HOME
+          #        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
+          #        - echo SAVE_COVERAGE=$SAVE_COVERAGE
+          #        - echo MINICONDA_URL=$MINICONDA_URL
+          #        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+          #        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
     - stage: test
       python: 2.7
       env:
         - COMPILER=clang
         - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
-      script:
-        - echo COMPILER=$COMPILER
-        - echo PANDAS_VERSION=$PANDAS_VERSION
-        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
-        - echo SETUP_CMD=$SETUP_CMD
-        - echo TEST_MODE=$TEST_MODE
-        - echo REF_DATA_HOME=$REF_DATA_HOME
-        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
-        - echo MINICONDA_URL=$MINICONDA_URL
-        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+          #       script:
+          #         - echo COMPILER=$COMPILER
+          #         - echo PANDAS_VERSION=$PANDAS_VERSION
+          #         - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
+          #         - echo SETUP_CMD=$SETUP_CMD
+          #         - echo TEST_MODE=$TEST_MODE
+          #         - echo REF_DATA_HOME=$REF_DATA_HOME
+          #         - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
+          #         - echo MINICONDA_URL=$MINICONDA_URL
+          #         - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+          #         - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
     - stage: test
       os: osx
       language: generic
@@ -148,16 +149,19 @@ jobs:
         - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
         - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
-      script:
-        - echo COMPILER=$COMPILER
-        - echo PANDAS_VERSION=$PANDAS_VERSION
-        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
-        - echo SETUP_CMD=$SETUP_CMD
-        - echo TEST_MODE=$TEST_MODE
-        - echo REF_DATA_HOME=$REF_DATA_HOME
-        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
-        - echo MINICONDA_URL=$MINICONDA_URL
-        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+          #      script:
+          #        - echo COMPILER=$COMPILER
+          #        - echo PANDAS_VERSION=$PANDAS_VERSION
+          #        - echo ASTROPY_USE_SYSTEM_PYTEST=$ASTROPY_USE_SYSTEM_PYTEST
+          #        - echo SETUP_CMD=$SETUP_CMD
+          #        - echo TEST_MODE=$TEST_MODE
+          #        - echo REF_DATA_HOME=$REF_DATA_HOME
+          #        - echo REF_DATA_GITHUBURL=$REF_DATA_GITHUBURL
+          #        - echo MINICONDA_URL=$MINICONDA_URL
+          #        - echo GIT_LFS_SKIP_SMUDGE=$GIT_LFS_SKIP_SMUDGE
+          #        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
     - stage: integration
+      if: type = cron
       script:
         - echo $COMPILER
+        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE


### PR DESCRIPTION
This PR activates the Travis stages feature. The idea is to introduce another stage for the integration tests which ultimately are to be triggered by Travis cron jobs.