### PR TITLE
Resurrect Integration Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,19 @@ before_install:
     - source ci-helpers/install_tardis_env.sh
     #- if [[ $TEST_MODE == 'spectrum' ]]; then conda install -c conda-forge git-lfs=2.2.1 -y; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs install --skip-smudge; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs install --skip-smudge; fi
     - echo git clone $REF_DATA_GITHUBURL $REF_DATA_HOME
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $REF_DATA_GITHUBURL $REF_DATA_HOME; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git clone $REF_DATA_GITHUBURL $REF_DATA_HOME; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $REF_DATA_HOME; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then cd $REF_DATA_HOME; fi
 # Use the following to get the ref-data from the master;
     - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git fetch origin; fi
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
     # workaround to avoid refdata mixup introduced by PR 15
     - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout ea89b9266d56de05fa84bc3d4bad62c09ce31486; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git fetch origin pull/16/head:update-ref; fi
     # Use the following to get the ref-data from a specific pull request; 
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/14/head:update-ref; fi
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout update-ref; fi
@@ -58,6 +63,11 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="unit_test_data.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then echo MD5 `md5sum unit_test_data.h5`; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then echo PWD $PWD; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then echo REF_DATA_HOME $REF_DATA_HOME; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then echo TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then echo `find * `; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then cd $TRAVIS_BUILD_DIR; fi
 
 #- source ci-helpers/fetch_reference_data.sh
 
@@ -82,6 +92,7 @@ stages:
 jobs:
   include:
     - stage: test
+      if: type = cron
       python: 2.7
       env:
         - COMPILER=gcc
@@ -89,12 +100,14 @@ jobs:
         - TEST_MODE='spectrum'
         - SAVE_COVERAGE=true
     - stage: test
+      if: type = cron
       python: 2.7
       env:
         - COMPILER=clang
         - SETUP_CMD='test --args="--tardis-refdata=$REF_DATA_HOME"'
         - TEST_MODE='spectrum'
     - stage: test
+      if: type = cron
       os: osx
       language: generic
       env:
@@ -103,7 +116,11 @@ jobs:
         - TEST_MODE='spectrum'
         - MINICONDA_URL='http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh'
     - stage: integration
-      if: type = cron
+#      if: type = cron
+      python: 2.7
+      env:
+        - TEST_MODE='integration'
       script:
+        - echo $TEST_MODE
         - echo $COMPILER
         - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,8 +128,8 @@ jobs:
 #      if: type = cron
       python: 2.7
       env:
-        - SETUP_CMD='test --args="--integration-tests=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml --less-packets"'
-        - SETUP_CMD='test --args="--integration-tests=/home/travis/tardis-refdata/integration/integration_lesspackets_travis.yml --less-packets"'
+        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"'
+#        - SETUP_CMD='test --args="--integration-tests=/home/travis/tardis-refdata/integration/integration_lesspackets_travis.yml --less-packets"'
         - TEST_MODE='integration'
 #      script:
 #        - echo $TEST_MODE

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ jobs:
 #      if: type = cron
       python: 2.7
       env:
-        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"
+        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"'
         - TEST_MODE='integration'
 #      script:
 #        - echo $TEST_MODE

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,21 +40,16 @@ before_install:
     # We do this to make sure we get the dependencies so pip works below
     - source ci-helpers/install_miniconda.sh
     - source ci-helpers/install_tardis_env.sh
+    - echo git clone $REF_DATA_GITHUBURL $REF_DATA_HOME
     #- if [[ $TEST_MODE == 'spectrum' ]]; then conda install -c conda-forge git-lfs=2.2.1 -y; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs install --skip-smudge; fi
-    - if [[ $TEST_MODE == 'integration' ]]; then git lfs install --skip-smudge; fi
-    - echo git clone $REF_DATA_GITHUBURL $REF_DATA_HOME
     - if [[ $TEST_MODE == 'spectrum' ]]; then git clone $REF_DATA_GITHUBURL $REF_DATA_HOME; fi
-    - if [[ $TEST_MODE == 'integration' ]]; then git clone $REF_DATA_GITHUBURL $REF_DATA_HOME; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $REF_DATA_HOME; fi
-    - if [[ $TEST_MODE == 'integration' ]]; then cd $REF_DATA_HOME; fi
 # Use the following to get the ref-data from the master;
     - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-    - if [[ $TEST_MODE == 'integration' ]]; then git fetch origin; fi
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
     # workaround to avoid refdata mixup introduced by PR 15
     - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout ea89b9266d56de05fa84bc3d4bad62c09ce31486; fi
-    - if [[ $TEST_MODE == 'integration' ]]; then git fetch origin pull/16/head:update-ref; fi
     # Use the following to get the ref-data from a specific pull request; 
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/14/head:update-ref; fi
     # - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout update-ref; fi
@@ -63,6 +58,18 @@ before_install:
     - if [[ $TEST_MODE == 'spectrum' ]]; then git lfs pull --include="unit_test_data.h5" origin; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then echo MD5 `md5sum unit_test_data.h5`; fi
     - if [[ $TEST_MODE == 'spectrum' ]]; then cd $TRAVIS_BUILD_DIR; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs install --skip-smudge; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git clone $REF_DATA_GITHUBURL $REF_DATA_HOME; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then cd $REF_DATA_HOME; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git fetch origin pull/16/head:update-ref; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git checkout update-ref; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="atom_data/kurucz_atom_chianti_many.h5" origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="integration/reference_lesspackets/at.h5" origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="integration/reference_lesspackets/paper1_downbranch.h5" origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="integration/reference_lesspackets/paper1_macroatom.h5" origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="integration/reference_lesspackets/paper1_scatter.h5" origin; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then git lfs pull --include="integration/reference_lesspackets/w7.h5" origin; fi
     - if [[ $TEST_MODE == 'integration' ]]; then echo PWD $PWD; fi
     - if [[ $TEST_MODE == 'integration' ]]; then echo REF_DATA_HOME $REF_DATA_HOME; fi
     - if [[ $TEST_MODE == 'integration' ]]; then echo TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR; fi
@@ -119,8 +126,9 @@ jobs:
 #      if: type = cron
       python: 2.7
       env:
+        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"
         - TEST_MODE='integration'
-      script:
-        - echo $TEST_MODE
-        - echo $COMPILER
-        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE
+#      script:
+#        - echo $TEST_MODE
+#        - echo $COMPILER
+#        - echo TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ before_install:
     - if [[ $TEST_MODE == 'integration' ]]; then echo REF_DATA_HOME $REF_DATA_HOME; fi
     - if [[ $TEST_MODE == 'integration' ]]; then echo TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR; fi
     - if [[ $TEST_MODE == 'integration' ]]; then echo `find * `; fi
+    - if [[ $TEST_MODE == 'integration' ]]; then cat $REF_DATA_HOME/integration/integration_lesspackets_travis.yml; fi
     - if [[ $TEST_MODE == 'integration' ]]; then cd $TRAVIS_BUILD_DIR; fi
 
 #- source ci-helpers/fetch_reference_data.sh
@@ -128,7 +129,8 @@ jobs:
 #      if: type = cron
       python: 2.7
       env:
-        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"'
+        #        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"'
+        - SETUP_CMD='test --args="--integration=/home/travis/tardis-refdata/integration/integration_lesspackets_travis.yml -m integration --less-packets"'
 #        - SETUP_CMD='test --args="--integration-tests=/home/travis/tardis-refdata/integration/integration_lesspackets_travis.yml --less-packets"'
         - TEST_MODE='integration'
 #      script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,7 @@ jobs:
 #      if: type = cron
       python: 2.7
       env:
-        - SETUP_CMD='test --args="--integration=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml -m integration --less-packets"'
+        - SETUP_CMD='test --args="--integration-tests=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml --less-packets"'
         - TEST_MODE='integration'
 #      script:
 #        - echo $TEST_MODE

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ env:
         - SAVE_COVERAGE=false
         - GIT_LFS_SKIP_SMUDGE=1
 
-cache:
-  apt: true
-  directories:
-    - $HOME/miniconda
-    #- $REF_DATA_HOME
+# cache:
+#   apt: true
+#   directories:
+#     - $HOME/miniconda
+#     #- $REF_DATA_HOME
 
 
 before_install:
@@ -82,7 +82,9 @@ install:
    - source ci-helpers/install_tardis_env.sh
 
 script:
+    - echo PWD=$PWD
     - echo CC=$COMPILER python setup.py $SETUP_CMD
+    - echo `ls /home/travis/tardis-refdata/integration/integration_lesspackets_travis.yml`
     - CC=$COMPILER python setup.py $SETUP_CMD
 
 after_success:
@@ -127,6 +129,7 @@ jobs:
       python: 2.7
       env:
         - SETUP_CMD='test --args="--integration-tests=$REF_DATA_HOME/integration/integration_lesspackets_travis.yml --less-packets"'
+        - SETUP_CMD='test --args="--integration-tests=/home/travis/tardis-refdata/integration/integration_lesspackets_travis.yml --less-packets"'
         - TEST_MODE='integration'
 #      script:
 #        - echo $TEST_MODE

--- a/tardis/tests/integration_tests/at/config.yml
+++ b/tardis/tests/integration_tests/at/config.yml
@@ -11,10 +11,6 @@ model:
     v_inner_boundary: 12000.000 km/s
     v_outer_boundary: 35000.000 km/s
 montecarlo:
-  black_body_sampling:
-    num: 1000000
-    start: 1 angstrom
-    stop: 1000000 angstrom
   convergence_strategy:
     damping_constant: 1.0
     fraction: 0.8
@@ -22,7 +18,7 @@ montecarlo:
     t_inner:
       damping_constant: 1.0
     threshold: 0.05
-    type: specific
+    type: damped
   iterations: 20
   last_no_of_packets: 5.0e+5
   no_of_packets: 5.0e+4

--- a/tardis/tests/integration_tests/paper1_downbranch/config.yml
+++ b/tardis/tests/integration_tests/paper1_downbranch/config.yml
@@ -49,13 +49,6 @@ plasma:
 
 
 montecarlo:
-  black_body_sampling:
-    start: 1 angstrom
-#    end: 1000000 angstrom
-    stop: 1000000 angstrom
-#    samples: 1.e+6
-    num: 1000000
-
   convergence_strategy:
     damping_constant: 1.0
     fraction: 1.0
@@ -66,7 +59,7 @@ montecarlo:
     threshold: -0.01
     lock_t_inner_cycles: 3
     t_inner_update_exponent: -0.5
-    type: specific
+    type: damped
 
   no_of_packets : 1.0e+7
   no_of_virtual_packets: 1

--- a/tardis/tests/integration_tests/paper1_macroatom/config.yml
+++ b/tardis/tests/integration_tests/paper1_macroatom/config.yml
@@ -49,13 +49,6 @@ plasma:
 
 
 montecarlo:
-  black_body_sampling:
-    start: 1 angstrom
-#    end: 1000000 angstrom
-    stop: 1000000 angstrom
-#    samples: 1.e+6
-    num: 1000000
-
   convergence_strategy:
     damping_constant: 1.0
     fraction: 1.0
@@ -66,7 +59,7 @@ montecarlo:
     threshold: -0.01
     lock_t_inner_cycles: 3
     t_inner_update_exponent: -0.5
-    type: specific
+    type: damped 
 
   no_of_packets : 1.0e+7
   no_of_virtual_packets: 1

--- a/tardis/tests/integration_tests/paper1_scatter/config.yml
+++ b/tardis/tests/integration_tests/paper1_scatter/config.yml
@@ -49,13 +49,6 @@ plasma:
 
 
 montecarlo:
-  black_body_sampling:
-    start: 1 angstrom
-#    end: 1000000 angstrom
-    stop: 1000000 angstrom
-#    samples: 1.e+6
-    num: 1000000
-
   convergence_strategy:
     damping_constant: 1.0
     fraction: 1.0
@@ -66,7 +59,7 @@ montecarlo:
     threshold: -0.01
     lock_t_inner_cycles: 3
     t_inner_update_exponent: -0.5
-    type: specific
+    type: damped
 
   no_of_packets : 1.0e+7
   no_of_virtual_packets: 1

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -159,19 +159,19 @@ class TestIntegration(object):
 
         ax = figure.add_subplot(111)
         ax.set_xlabel("Shell id")
-        ax.set_ylabel("t_rad")
+        ax.set_ylabel("t_radiative")
 
         result_line = ax.plot(
-            self.result.model.t_rad.cgs, color="blue", marker=".", label="Result"
+            self.result.model.t_radiative.cgs, color="blue", marker=".", label="Result"
         )
         reference_line = ax.plot(
-            self.reference['/simulation/model/t_rad'],
+            self.reference['/simulation/model/t_radiative'],
             color="green", marker=".", label="Reference"
         )
 
         error_ax = ax.twinx()
         error_line = error_ax.plot(
-            (1 - self.result.model.t_rad.cgs.value / self.reference['/simulation/model/t_rad']),
+            (1 - self.result.model.t_radiative.cgs.value / self.reference['/simulation/model/t_radiative']),
             color="red", marker=".", label="Rel. Error"
         )
         error_ax.set_ylabel("Relative error (1 - result / reference)")
@@ -187,16 +187,12 @@ class TestIntegration(object):
         plot_object.add(self.plot_spectrum(), "{0}_spectrum".format(self.name))
 
         assert_allclose(
-            self.reference['/simulation/runner/spectrum/luminosity_density_nu'],
-            self.result.runner.spectrum.luminosity_density_nu.cgs.value)
+            self.reference['/simulation/runner/spectrum/luminosity'],
+            self.result.runner.spectrum.luminosity.cgs.value)
 
         assert_allclose(
-            self.reference['/simulation/runner/spectrum/wavelength'],
-            self.result.runner.spectrum.wavelength.cgs.value)
-
-        assert_allclose(
-            self.reference['/simulation/runner/spectrum/luminosity_density_lambda'],
-            self.result.runner.spectrum.luminosity_density_lambda.cgs.value)
+            self.reference['/simulation/runner/spectrum/_frequency'],
+            self.result.runner.spectrum._frequency.cgs.value)
 
     def plot_spectrum(self):
 
@@ -209,28 +205,32 @@ class TestIntegration(object):
 
         spectrum_ax.set_ylabel("Flux [cgs]")
         deviation = 1 - (
-            self.result.runner.spectrum.luminosity_density_lambda.cgs.value /
+            self.result.runner.spectrum.luminosity.cgs.value /
             self.reference[
-                '/simulation/runner/spectrum/luminosity_density_lambda']
+                '/simulation/runner/spectrum/luminosity']
 
         )
 
+        reference_frequency = \
+            self.reference['/simulation/runner/spectrum/_frequency'].values
+        reference_frequency_mid = 0.5 * (reference_frequency[1:] +
+                                         reference_frequency[:-1])
 
         spectrum_ax.plot(
-            self.reference['/simulation/runner/spectrum/wavelength'],
+            reference_frequency_mid,
             self.reference[
-                '/simulation/runner/spectrum/luminosity_density_lambda'],
+                '/simulation/runner/spectrum/luminosity'],
             color="black"
         )
 
         spectrum_ax.plot(
-            self.reference['/simulation/runner/spectrum/wavelength'],
+            reference_frequency_mid,
             self.result.runner.spectrum.luminosity_density_lambda.cgs.value,
             color="red"
         )
         spectrum_ax.set_xticks([])
         deviation_ax = plt.subplot(gs[1])
-        deviation_ax.plot(self.reference['/simulation/runner/spectrum/wavelength'],
+        deviation_ax.plot(reference_frequency_mid,
                    deviation, color='black')
         deviation_ax.set_xlabel("Wavelength [Angstrom]")
 

--- a/tardis/tests/integration_tests/w7/config.yml
+++ b/tardis/tests/integration_tests/w7/config.yml
@@ -11,10 +11,6 @@ model:
     v_inner_boundary: 12000.000 km/s
     v_outer_boundary: 35000.000 km/s
 montecarlo:
-  black_body_sampling:
-    num: 1000000
-    start: 1 angstrom
-    stop: 1000000 angstrom
   iterations: 20
   last_no_of_packets: 2.0e+5
   no_of_packets: 4.0e+4


### PR DESCRIPTION
This PR updates various config and python files such that the integration test suite can be run locally. In a next step (future PR), the integration tests will be integrated as a cron job into the Travis continuous integration process.

Verify the following features
- [x] reference generation and validation with few packets
- [ ] reference generation and validation with high statistics
- [x] local reporting
- [ ] (*optional*) remote reporting