### PR TITLE
Some small fixes related to the documentation and the building process (Fix #842)

### DIFF
--- a/ci-helpers/install_tardis_env.sh
+++ b/ci-helpers/install_tardis_env.sh
@@ -8,6 +8,7 @@ else
    #trouble with building due to segfault at cython (https://github.com/cython/cython/issues/2199)
    #remove if we can get normal cython through conda
    source activate tardis
+   conda uninstall -y cython
    git clone https://github.com/cython/cython
    cd cython
    git checkout c485b1b77264c3c75d090a3c526de24966830d42

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,6 +13,11 @@ simple TARDIS calculations.
 
 .. _requirements_label:
 
+
+.. warning::
+
+    TARDIS is currently only compatbile with Python 2.7.
+
 .. note::
     We strongly recommond to install TARDIS within an Anaconda environment and
     to always use the lastest github development version.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,7 +25,7 @@ Assuming you have ``wget``, you could follow the procedure:
 
     mkdir tardis_example
     cd tardis_example
-    wget https://github.com/tardis-sn/tardis-setups/raw/master/tardis-setups/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
+    wget https://raw.githubusercontent.com/tardis-sn/tardis-setups/master/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
     wget https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He.h5
     tardis tardis_example.yml output_spectrum.dat
 

--- a/tardis_env27.yml
+++ b/tardis_env27.yml
@@ -13,7 +13,7 @@ dependencies:
 - matplotlib=2.0
 - astropy=1.3
 - numexpr=2.6
-#- Cython=0.28.4
+- Cython=0.28.4
 - networkx=1.10
 - pytest=3.0
 - pyyaml=3.12


### PR DESCRIPTION
This small PR addresses a number of small issues which came up when resolving #872 (should also fix #842)

- [x] add warning about need for Python 2.7
- [x] update link to tardis_example.yml file on the docu
- [x] add cython back into the env file