### PR TITLE
Correct index script spelling

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ Developing Tardis
 
     issues
     workflow/development_workflow
-    runnints_tests
+    running_tests
 
 ==========
 References


### PR DESCRIPTION
I think this was missing from the documentation: https://tardis-sn.github.io/tardis/index.html