### PR TITLE
Csvy model config dict

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -7,6 +7,7 @@ from astropy import units as u
 import tardis
 from tardis.io import config_validator
 from tardis.io.util import YAMLLoader, yaml_load_file
+from tardis.io.parsers.csvy import load_yaml_from_csvy
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -115,6 +116,22 @@ class ConfigurationNameSpace(dict):
                 self.__setitem__(key, value[key])
         else:
             raise (TypeError, 'expected dict')
+
+        if hasattr(self, 'csvy_model') and hasattr(self, 'model'):
+            raise ValueError('Cannot specify both model and csvy_model in main config file.')
+        if hasattr(self, 'csvy_model'):
+            model = dict()
+            csvy_model_path = os.path.join(self.config_dirname,self.csvy_model)
+            csvy_yml = load_yaml_from_csvy(csvy_model_path)
+            if 'v_inner_boundary' in csvy_yml:
+                model['v_inner_boundary'] = csvy_yml['v_inner_boundary']
+            if 'v_outer_boundary' in csvy_yml:
+                model['v_outer_boundary'] = csvy_yml['v_outer_boundary']
+
+            self.__setitem__('model',model)
+            for key in self.model:
+                self.model.__setitem__(key, self.model[key])
+
 
     def __setitem__(self, key, value):
         if isinstance(value, dict) and not isinstance(value,

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -533,15 +533,29 @@ class Radial1DModel(HDFWriterMixin):
         electron_densities = None
         temperature = None
 
-        if hasattr(csvy_model_config, 'v_inner_boundary'):
-            v_boundary_inner = csvy_model_config.v_inner_boundary
+        #if hasattr(csvy_model_config, 'v_inner_boundary'):
+        #    v_boundary_inner = csvy_model_config.v_inner_boundary
+        #else:
+        #    v_boundary_inner = None
+
+        #if hasattr(csvy_model_config, 'v_outer_boundary'):
+        #    v_boundary_outer = csvy_model_config.v_outer_boundary
+        #else:
+        #    v_boundary_outer = None
+
+        if hasattr(config, 'model'):
+            if hasattr(config.model, 'v_inner_boundary'):
+                v_boundary_inner = config.model.v_inner_boundary
+            else:
+                v_boundary_inner = None
+
+            if hasattr(config.model, 'v_outer_boundary'):
+                v_boundary_outer = config.model.v_outer_boundary
+            else:
+                v_boundary_outer = None
         else:
             v_boundary_inner = None
-
-        if hasattr(csvy_model_config, 'v_outer_boundary'):
-            v_boundary_outer = csvy_model_config.v_outer_boundary
-        else:
-            v_boundary_outer = None 
+            v_boundary_outer = None
 
         if hasattr(csvy_model_config, 'velocity'):
             velocity = quantity_linspace(csvy_model_config.velocity.start,

--- a/tardis/model/tests/data/config_csvy_full.yml
+++ b/tardis/model/tests/data/config_csvy_full.yml
@@ -11,31 +11,6 @@ atom_data: kurucz_cd23_chianti_H_He.h5
 
 csvy_model: csvy_full.csvy
 
-model:
-  structure:
-    #v_inner_boundary: 9500 km/s
-    type: file
-    filename: density.dat
-    filetype: simple_ascii
-      # showing different configuration options separated by comments
-      # simple uniform
-      #---------------
-      #type: uniform
-      #value: 1e-40 g/cm^3
-      #---------------
-      # branch85_w7 - fit of seven order polynomial to W7 (like Branch 85)
-      #---------------
-      #type: branch85_w7
-      # default, no need to change
-      #w7_time_0: 19.9999584 s
-      # default, no need to change
-      #w7_rho_0: 3e29 g/cm^3
-      #---------------
-
-  abundances:
-    type: file
-    filename: abund.dat
-    filetype: custom_composition
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_full_old.yml
+++ b/tardis/model/tests/data/config_csvy_full_old.yml
@@ -9,8 +9,32 @@ supernova:
 # standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
 
-csvy_model: csvy_nocsv_exponential.csvy
 
+model:
+  structure:
+    #v_inner_boundary: 9500 km/s
+    type: file
+    filename: density.dat
+    filetype: simple_ascii
+      # showing different configuration options separated by comments
+      # simple uniform
+      #---------------
+      #type: uniform
+      #value: 1e-40 g/cm^3
+      #---------------
+      # branch85_w7 - fit of seven order polynomial to W7 (like Branch 85)
+      #---------------
+      #type: branch85_w7
+      # default, no need to change
+      #w7_time_0: 19.9999584 s
+      # default, no need to change
+      #w7_rho_0: 3e29 g/cm^3
+      #---------------
+
+  abundances:
+    type: file
+    filename: abund.dat
+    filetype: custom_composition
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_full_rad.yml
+++ b/tardis/model/tests/data/config_csvy_full_rad.yml
@@ -11,31 +11,6 @@ atom_data: kurucz_cd23_chianti_H_He.h5
 
 csvy_model: csvy_full_rad.csvy
 
-model:
-  structure:
-    #v_inner_boundary: 9500 km/s
-    type: file
-    filename: density.dat
-    filetype: simple_ascii
-      # showing different configuration options separated by comments
-      # simple uniform
-      #---------------
-      #type: uniform
-      #value: 1e-40 g/cm^3
-      #---------------
-      # branch85_w7 - fit of seven order polynomial to W7 (like Branch 85)
-      #---------------
-      #type: branch85_w7
-      # default, no need to change
-      #w7_time_0: 19.9999584 s
-      # default, no need to change
-      #w7_rho_0: 3e29 g/cm^3
-      #---------------
-
-  abundances:
-    type: file
-    filename: abund.dat
-    filetype: custom_composition
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_full_rad_old.yml
+++ b/tardis/model/tests/data/config_csvy_full_rad_old.yml
@@ -9,12 +9,36 @@ supernova:
 # standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
 
-csvy_model: csvy_nocsv_exponential.csvy
 
+model:
+  structure:
+    #v_inner_boundary: 9500 km/s
+    type: file
+    filename: density.dat
+    filetype: simple_ascii
+      # showing different configuration options separated by comments
+      # simple uniform
+      #---------------
+      #type: uniform
+      #value: 1e-40 g/cm^3
+      #---------------
+      # branch85_w7 - fit of seven order polynomial to W7 (like Branch 85)
+      #---------------
+      #type: branch85_w7
+      # default, no need to change
+      #w7_time_0: 19.9999584 s
+      # default, no need to change
+      #w7_rho_0: 3e29 g/cm^3
+      #---------------
+
+  abundances:
+    type: file
+    filename: abund.dat
+    filetype: custom_composition
 
 plasma:
   #initial_t_inner: 10000 K
-  #initial_t_rad: 10000 K
+  initial_t_rad: 7000 K
   disable_electron_scattering: no
   ionization: lte
   excitation: lte

--- a/tardis/model/tests/data/config_csvy_nocsv_branch85.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_branch85.yml
@@ -11,23 +11,6 @@ atom_data: kurucz_cd23_chianti_H_He.h5
 
 csvy_model: csvy_nocsv.csvy
 
-model:
-  structure:
-    type: specific
-    velocity:
-      start: 9000 km/s
-      stop: 12000 km/s
-      num: 5
-    density:
-      type: branch85_w7
-
-  abundances:
-    type: uniform
-    H: 0.5
-    He: 0.2
-    O: 0.25
-    Ni56: 0.04
-    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_nocsv_branch85_old.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_branch85_old.yml
@@ -9,8 +9,24 @@ supernova:
 # standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
 
-csvy_model: csvy_nocsv_exponential.csvy
 
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 9000 km/s
+      stop: 12000 km/s
+      num: 5
+    density:
+      type: branch85_w7
+
+  abundances:
+    type: uniform
+    H: 0.5
+    He: 0.2
+    O: 0.25
+    Ni56: 0.04
+    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_nocsv_exponential_old.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_exponential_old.yml
@@ -9,8 +9,26 @@ supernova:
 # standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
 
-csvy_model: csvy_nocsv_exponential.csvy
 
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 9000 km/s
+      stop: 12000 km/s
+      num: 5
+    density:
+      type: exponential
+      rho_0: 1e-9 g/cm^3
+      v_0: 10000 km/s
+
+  abundances:
+    type: uniform
+    H: 0.5
+    He: 0.2
+    O: 0.25
+    Ni56: 0.04
+    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_nocsv_powerlaw.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_powerlaw.yml
@@ -11,26 +11,6 @@ atom_data: kurucz_cd23_chianti_H_He.h5
 
 csvy_model: csvy_nocsv_powerlaw.csvy
 
-model:
-  structure:
-    type: specific
-    velocity:
-      start: 9000 km/s
-      stop: 12000 km/s
-      num: 5
-    density:
-      type: power_law
-      rho_0: 1e-9 g/cm^3
-      v_0: 10000 km/s
-      exponent: -2
-
-  abundances:
-    type: uniform
-    H: 0.5
-    He: 0.2
-    O: 0.25
-    Ni56: 0.04
-    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_nocsv_powerlaw_old.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_powerlaw_old.yml
@@ -9,8 +9,27 @@ supernova:
 # standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
 
-csvy_model: csvy_nocsv_exponential.csvy
 
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 9000 km/s
+      stop: 12000 km/s
+      num: 5
+    density:
+      type: power_law
+      rho_0: 1e-9 g/cm^3
+      v_0: 10000 km/s
+      exponent: -2
+
+  abundances:
+    type: uniform
+    H: 0.5
+    He: 0.2
+    O: 0.25
+    Ni56: 0.04
+    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_nocsv_uniform.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_uniform.yml
@@ -11,24 +11,6 @@ atom_data: kurucz_cd23_chianti_H_He.h5
 
 csvy_model: csvy_nocsv_uniform.csvy
 
-model:
-  structure:
-    type: specific
-    velocity:
-      start: 9000 km/s
-      stop: 12000 km/s
-      num: 5
-    density:
-      type: uniform
-      value: 1e-9 g/cm^3
-
-  abundances:
-    type: uniform
-    H: 0.5
-    He: 0.2
-    O: 0.25
-    Ni56: 0.04
-    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/data/config_csvy_nocsv_uniform_old.yml
+++ b/tardis/model/tests/data/config_csvy_nocsv_uniform_old.yml
@@ -9,8 +9,25 @@ supernova:
 # standard atomic data base; get it from the tardis-refdata repository
 atom_data: kurucz_cd23_chianti_H_He.h5
 
-csvy_model: csvy_nocsv_exponential.csvy
 
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 9000 km/s
+      stop: 12000 km/s
+      num: 5
+    density:
+      type: uniform
+      value: 1e-9 g/cm^3
+
+  abundances:
+    type: uniform
+    H: 0.5
+    He: 0.2
+    O: 0.25
+    Ni56: 0.04
+    Ni58: 0.01
 
 plasma:
   #initial_t_inner: 10000 K

--- a/tardis/model/tests/test_csvy_model.py
+++ b/tardis/model/tests/test_csvy_model.py
@@ -9,20 +9,24 @@ import pytest
 
 DATA_PATH = os.path.join(tardis.__path__[0],'model','tests','data')
 
-@pytest.fixture(scope="module", params=['config_csvy_full.yml',
-                                        'config_csvy_nocsv_branch85.yml',
-                                        'config_csvy_nocsv_uniform.yml',
-                                        'config_csvy_nocsv_powerlaw.yml',
-                                        'config_csvy_nocsv_exponential.yml',
-                                        'config_csvy_full_rad.yml'])
-def full_filename(request):
-    return os.path.join(DATA_PATH, request.param)
+@pytest.fixture(scope="module", params=[('config_csvy_full.yml','config_csvy_full_old.yml'),
+                                        ('config_csvy_nocsv_branch85.yml','config_csvy_nocsv_branch85_old.yml'),
+                                        ('config_csvy_nocsv_uniform.yml','config_csvy_nocsv_uniform_old.yml'),
+                                        ('config_csvy_nocsv_powerlaw.yml','config_csvy_nocsv_powerlaw_old.yml'),
+                                        ('config_csvy_nocsv_exponential.yml','config_csvy_nocsv_exponential_old.yml'),
+                                        ('config_csvy_full_rad.yml','config_csvy_full_rad_old.yml')])
+def filename(request):
+    fn_tup = request.param
+    fn = os.path.join(DATA_PATH, fn_tup[0])
+    fnold = os.path.join(DATA_PATH, fn_tup[1])
+    return fn, fnold
 
-
-def test_compare_models(full_filename):
-    tardis_config = Configuration.from_yaml(full_filename)
+def test_compare_models(filename):
+    fn, fnold = filename
+    tardis_config = Configuration.from_yaml(fn)
+    tardis_config_old = Configuration.from_yaml(fnold)
     csvy_model = Radial1DModel.from_csvy(tardis_config)
-    config_model = Radial1DModel.from_config(tardis_config)
+    config_model = Radial1DModel.from_config(tardis_config_old)
     csvy_model_props = csvy_model.get_properties().keys()
     config_model_props = config_model.get_properties().keys()
     npt.assert_array_equal(csvy_model_props, config_model_props)


### PR DESCRIPTION
*You can NO LONGER specify csvy_model AND old model in main config.
*When csvy_model is specified, v_boundary velocities are copied from csvy yaml header into the main config file Configuration Object. 
*Model from_csvy gets v_boundary velocities from the COPIED values in the main Configuration Object.