### PR TITLE
Save integrated spectrum to hdf if requested

### DIFF
--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -181,6 +181,11 @@ def check_equality(item1, item2):
 
 
 class HDFWriterMixin(object):
+    def __new__(cls, *args, **kwargs):
+        instance = super(HDFWriterMixin, cls).__new__(cls)
+        instance.optional_hdf_properties = []
+        instance.__init__(*args, **kwargs)
+        return instance
 
     @staticmethod
     def to_hdf_util(path_or_buf, path, elements, complevel=9, complib='blosc'):
@@ -270,8 +275,12 @@ class HDFWriterMixin(object):
             buf.close()
 
     def get_properties(self):
-        data = {name: getattr(self, name) for name in self.hdf_properties}
+        data = {name: getattr(self, name) for name in self.full_hdf_properties}
         return data
+
+    @property
+    def full_hdf_properties(self):
+        return self.optional_hdf_properties + self.hdf_properties
 
     @staticmethod
     def convert_to_snake_case(s):

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -44,7 +44,7 @@ class MontecarloRunner(HDFWriterMixin):
                  sigma_thomson, enable_reflective_inner_boundary,
                  enable_full_relativity, inner_boundary_albedo,
                  line_interaction_type, integrator_settings,
-                 v_packet_settings):
+                 v_packet_settings, spectrum_method):
 
         self.seed = seed
         self.packet_source = packet_source.BlackBodySimpleSource(seed)
@@ -57,8 +57,11 @@ class MontecarloRunner(HDFWriterMixin):
         self.line_interaction_type = line_interaction_type
         self.integrator_settings = integrator_settings
         self.v_packet_settings = v_packet_settings
+        self.spectrum_method = spectrum_method
         self._integrator = None
         self._spectrum_integrated = None
+        if self.spectrum_method == 'integrated':
+            self.optional_hdf_properties.append('spectrum_integrated')
 
     def _initialize_estimator_arrays(self, no_of_shells, tau_sobolev_shape):
         """
@@ -423,4 +426,5 @@ class MontecarloRunner(HDFWriterMixin):
                    enable_full_relativity=config.montecarlo.enable_full_relativity,
                    line_interaction_type=config.plasma.line_interaction_type,
                    integrator_settings=config.spectrum.integrated,
-                   v_packet_settings=config.spectrum.virtual)
+                   v_packet_settings=config.spectrum.virtual,
+                   spectrum_method=config.spectrum.method)


### PR DESCRIPTION
Currently, the integrated spectrum is not saved with the `to_hdf` method. This PR adds this functionality if the spectrum method requested in the config is `integrated`.