### PR TITLE
Isotope time0

### DIFF
--- a/tardis/io/schemas/csvy_model.yml
+++ b/tardis/io/schemas/csvy_model.yml
@@ -12,8 +12,7 @@ properties:
 
   model_isotope_time_0:
     type: quantity
-    default: -1 day
-    description: initial time for isotope decay
+    description: Initial time for isotope decay. Set to 0 for no isotopes.
 
   description:
     type: string
@@ -63,6 +62,7 @@ properties:
 
 required:
 - tardis_model_config_version
+- model_isotope_time_0
 
 definitions:
   density:

--- a/tardis/model/tests/data/csvy_full.csvy
+++ b/tardis/model/tests/data/csvy_full.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_full
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 datatype:

--- a/tardis/model/tests/data/csvy_full_rad.csvy
+++ b/tardis/model/tests/data/csvy_full_rad.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_full
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 datatype:

--- a/tardis/model/tests/data/csvy_full_rad_abundance_test.csvy
+++ b/tardis/model/tests/data/csvy_full_rad_abundance_test.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_full
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 datatype:

--- a/tardis/model/tests/data/csvy_nocsv.csvy
+++ b/tardis/model/tests/data/csvy_nocsv.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_nocsv
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 

--- a/tardis/model/tests/data/csvy_nocsv_exponential.csvy
+++ b/tardis/model/tests/data/csvy_nocsv_exponential.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_nocsv
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 

--- a/tardis/model/tests/data/csvy_nocsv_powerlaw.csvy
+++ b/tardis/model/tests/data/csvy_nocsv_powerlaw.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_nocsv
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 

--- a/tardis/model/tests/data/csvy_nocsv_uniform.csvy
+++ b/tardis/model/tests/data/csvy_nocsv_uniform.csvy
@@ -1,6 +1,7 @@
 ---
 name: csvy_nocsv
 model_density_time_0: 1 day
+model_isotope_time_0: 0 day
 description: Example csvy config file for TARDIS.
 tardis_model_config_version: v1.0
 


### PR DESCRIPTION
Made model_isotope_time_0 a required property in the csvy_model schema.  

Added model_isotope_time_0 explicitly to some of the test csvy files.