### PR TITLE
Fixes numpydoc for util

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -133,11 +133,11 @@ def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_u
     distance: float
         Distance to star
     wavelength_column: int, optional(default = 0)
-        #UNSURE
+        Column index in which the wavelength is stored
     wavelength_unit: float, optional(default = u.angstrom)
         Dictates units used for calculating wavelength.
     flux_column: int, optional(default = 1)
-        #UNSURE
+        Column index in which the flux is stored
     flux_unit: str, optional(default = u.Unit('erg / (Angstrom cm2 s)')
         Dictates units used for flux
 
@@ -163,13 +163,18 @@ def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_u
 
 def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
     """
-    #UNSURE
+    Create a yaml file that is readable from syn++
+
     Parameters
     ----------
-    radial1d_mdl
-    fname
+    radial1d_mdl: Radial1DModel
+        Inputted object that will be read into YAML file
+    fname: str
+        File name for the synpp yaml
     shell_no: int, optional(default = 0)
-    lines_db:
+        Number of shells
+    lines_db: file, optional(default = None)
+        
     """
 
     logger.warning('Currently only works with Si and a special setup')
@@ -237,7 +242,7 @@ def intensity_black_body(nu, T):
 
     Parameters
     ----------
-    nu: flot
+    nu: float
         Frequency of light
     T: float
         Temperature in kelvin
@@ -287,7 +292,7 @@ def species_string_to_tuple(species_string):
     Parameters
     ----------
     species_string: str
-        String containing element symbol and number of electrons missing
+        String containing species symbol (e.g. Si II, Fe III)
 
     Returns
     -------

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -123,21 +123,31 @@ def roman_to_int(roman_string):
 def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_unit=u.angstrom, flux_column=1,
                          flux_unit=u.Unit('erg / (Angstrom cm2 s)')):
     """
+    Calculates luminosity of star
 
     Parameters
     ----------
-    spec_fname
-    distance
-    wavelength_column: int, optional
-    wavelength_unit: float
-    flux_column
-    flux_unit
+    spec_fname: file or str
+        File or file name to be read
+    distance: float
+        Distance to star
+    wavelength_column: int, optional(default = 0)
+        #UNSURE
+    wavelength_unit: float, optional(default = u.angstrom)
+        Dictates units used for calculating wavelength.
+    flux_column: int, optional(default = 1)
+        #UNSURE
+    flux_unit: str, optional(default = u.Unit('erg / (Angstrom cm2 s)')
+        Dictates units used for flux
 
     Returns
     -------
-    luminosity.value
+    luminosity.value: float
+        Returned luminosity value of star.
     wavelength.min()
+        Minimum value of wavelength of light
     wavelength.max()
+        Maximum value of wavelength of light
     """
     #BAD STYLE change to parse quantity
     distance = u.Unit(distance)
@@ -151,20 +161,14 @@ def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_u
 
 
 def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
-
     """
-
+    #UNSURE
     Parameters
     ----------
     radial1d_mdl
     fname
-    shell
-    lines_db
-
-    Returns
-    -------
-
-
+    shell_no: int, optional(default = 0)
+    lines_db:
     """
 
     logger.warning('Currently only works with Si and a special setup')
@@ -225,7 +229,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
 
 def intensity_black_body(nu, T):
     """
-        Calculate the intensity of a black-body according to the following formula
+    Calculate the intensity of a black-body according to the following formula
 
         .. math::
             I(\\nu, T) = \\frac{2h\\nu^3}{c^2}\frac{1}{e^{h\\nu \\beta_\\textrm{rad}} - 1}
@@ -240,7 +244,7 @@ def intensity_black_body(nu, T):
     Returns
     -------
     Intensity: float
-        Approximates the intensity of electromagnetic radiation for the black body
+        Returns the intensity of the black body
     """
     beta_rad = 1 / (k_B_cgs * T)
     coefficient = 2 * h_cgs / c_cgs ** 2
@@ -251,21 +255,20 @@ def intensity_black_body(nu, T):
 
 def species_tuple_to_string(species_tuple, roman_numerals=True):
     """
+    Convert a species tuple to its corresponding string representation.
+
     Parameters
     ----------
     species_tuple: tuple
-        Tuple of 2 values indicated atomic number and number of electrons(?)
+        Tuple of 2 values indicated atomic number and number of electrons missing
 
-    roman_numerals: bool, optional
+    roman_numerals: bool, optional(default = TRUE)
         Indicates whether the returned ion number is in roman numerals
 
     Returns
     -------
-    roman_ion_number: str
-        Returns element symbol and
-    ion_number: int
-        Returns element symbol and
-
+    element_symbol, roman_ion_number: str
+        Returns corresponding string representation of given tuple
     """
     atomic_number, ion_number = species_tuple
     element_symbol = ATOMIC_NUMBER2SYMBOL[atomic_number]
@@ -278,21 +281,22 @@ def species_tuple_to_string(species_tuple, roman_numerals=True):
 
 def species_string_to_tuple(species_string):
     """
+    Convert a species string to its corresponding tuple representation
 
     Parameters
     ----------
-    species_string
+    species_string: str
+        String containing element symbol and number of electrons missing
 
     Returns
     ----------
-    atomic_number
-    ion number
+    atomic_number, ion_number: tuple
+        Returns tuple of length 2 indicating atomic number and ion number
 
     Raises
     ----------
-    AttributeError:
-    ValueError:
-
+    MalformedSpeciesError
+        If the inputted string does not match the species format
     """
 
     try:
@@ -322,14 +326,22 @@ def species_string_to_tuple(species_string):
 
 def parse_quantity(quantity_string):
     """
+    Changes a string into it's corresponding astropy.Quantity object.
+
     Parameters
     ----------
-    quantity_string
+    quantity_string: str
+        String to be converted into astropy.Quantity
 
     Returns
     -------
-    q
+    q: ~u.Quantity
+        Corresponding astropy.Quantity object for passed string
 
+    Raises
+    ------
+    MalformedQuantitiyError
+        If string is not properly formatted for Astropy Quantity
     """
 
     if not isinstance(quantity_string, str):
@@ -356,6 +368,7 @@ def parse_quantity(quantity_string):
 def element_symbol2atomic_number(element_string):
     """
     Takes an element symbol and returns its corresponding atomic number
+
     Parameters
     ----------
     element_string: str
@@ -363,10 +376,8 @@ def element_symbol2atomic_number(element_string):
 
     Returns
     -------
-    SYMBOL2ATOMIC_NUMBER[reformatted_element_string]: int
+        :int
         Returned atomic number
-
-
     """
     reformatted_element_string = reformat_element_symbol(element_string)
     if reformatted_element_string not in SYMBOL2ATOMIC_NUMBER:
@@ -376,39 +387,34 @@ def element_symbol2atomic_number(element_string):
 
 def atomic_number2element_symbol(atomic_number):
     """
-    Convert atomic number to string symbol
+    Convert atomic number to string
 
     Parameters
     ----------
     atomic_number: int
         Inputted atomic number
 
-
     Returns
     -------
-    ATOMIC_NUMBER2SYMBOL[atomic_number]: str
+        :str
        Returned corresponding element symbol
-
-
     """
     return ATOMIC_NUMBER2SYMBOL[atomic_number]
 
 
 def reformat_element_symbol(element_string):
     """
-    Reformat the string so the first letter is uppercase and all subsequent letters lowercase
+    Reformat the string so the first letter is uppercase and all subsequent letters lowercase.
 
     Parameters
     ----------
     element_string: str
         Inputted element symbol
 
-
     Returns
     -------
-    reformatted element symbol: str
+        : str
         Returned reformatted element symbol
-
     """
 
     return element_string[0].upper() + element_string[1:].lower()
@@ -416,20 +422,26 @@ def reformat_element_symbol(element_string):
 
 def quantity_linspace(start, stop, num, **kwargs):
     """
-    Calculate the linspace for a quantity start and stop.
-    Other than that essentially the same input parameters as linspace
+    Essentially the same input parameters as linspace, but calculated for an astropy quantity start and stop.
 
     Parameters
     ----------
     start: ~astropy.Quantity
+        Starting value of the sequence
     stop: ~astropy.Quantity
+        End value of the sequence
     num: ~int
+        Number of samples to generate
 
     Returns
     -------
         : ~astropy.Quantity
+        Returns num evenly spaced characters of type astropy.Quantity
 
-
+    Raises
+    ------
+    ValueError
+        If start and stop values have no unit attribute.
     """
     if not (hasattr(start, 'unit') and hasattr(stop, 'unit')):
         raise ValueError('Both start and stop need to be quantities with a '
@@ -440,15 +452,19 @@ def quantity_linspace(start, stop, num, **kwargs):
 
 def convert_abundances_format(fname, delimiter='\s+'):
     """
+    Changes format of file containing abundances into data frame
+
     Parameters
     ----------
-    fname: str
-    delimiter: str, optional
+    fname: file, str
+        File or file name that contains abundance info
+    delimiter: str, optional(default = '\s+')
+        Determines the separator for splitting file
 
     Returns
     -------
-    df:
-
+        : DataFrame
+        Corresponding data frame
     """
     df = pd.read_csv(fname, delimiter=delimiter, comment='#', header=None)
     #Drop shell index column

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -94,16 +94,16 @@ def int_to_roman(i):
 
 def roman_to_int(roman_string):
     """
-
-
+    Convert a roman numeral into its corresponding integer.
     Parameters
     ----------
     roman_string: str
+        Roman numeral to be converted into an integer
 
     Returns
     -------
         : int
-
+        Returns integer representation of roman_string
     """
 
     NUMERALS_SET = set(list(zip(*NUMERAL_MAP))[1])
@@ -122,7 +122,23 @@ def roman_to_int(roman_string):
 
 def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_unit=u.angstrom, flux_column=1,
                          flux_unit=u.Unit('erg / (Angstrom cm2 s)')):
+    """
 
+    Parameters
+    ----------
+    spec_fname
+    distance
+    wavelength_column: int, optional
+    wavelength_unit: float
+    flux_column
+    flux_unit
+
+    Returns
+    -------
+    luminosity.value
+    wavelength.min()
+    wavelength.max()
+    """
     #BAD STYLE change to parse quantity
     distance = u.Unit(distance)
 
@@ -135,6 +151,22 @@ def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_u
 
 
 def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
+
+    """
+
+    Parameters
+    ----------
+    radial1d_mdl
+    fname
+    shell
+    lines_db
+
+    Returns
+    -------
+
+
+    """
+
     logger.warning('Currently only works with Si and a special setup')
     if radial1d_mdl.atom_data.synpp_refs is not None:
         raise ValueError(
@@ -198,6 +230,17 @@ def intensity_black_body(nu, T):
         .. math::
             I(\\nu, T) = \\frac{2h\\nu^3}{c^2}\frac{1}{e^{h\\nu \\beta_\\textrm{rad}} - 1}
 
+    Parameters
+    ----------
+    nu: int
+        Frequency of a wave of light
+    T: int
+        Temperature in kelvin
+
+    Returns
+    -------
+    Intensity: float
+        Approximates the intensity of electromagnetic radiation for the black body
     """
     beta_rad = 1 / (k_B_cgs * T)
     coefficient = 2 * h_cgs / c_cgs ** 2
@@ -207,6 +250,23 @@ def intensity_black_body(nu, T):
 
 
 def species_tuple_to_string(species_tuple, roman_numerals=True):
+    """
+    Parameters
+    ----------
+    species_tuple: tuple
+        Tuple of 2 values indicated atomic number and number of electrons(?)
+
+    roman_numerals: bool, optional
+        Indicates whether the returned ion number is in roman numerals
+
+    Returns
+    -------
+    roman_ion_number: str
+        Returns element symbol and
+    ion_number: int
+        Returns element symbol and
+
+    """
     atomic_number, ion_number = species_tuple
     element_symbol = ATOMIC_NUMBER2SYMBOL[atomic_number]
     if roman_numerals:
@@ -217,6 +277,23 @@ def species_tuple_to_string(species_tuple, roman_numerals=True):
 
 
 def species_string_to_tuple(species_string):
+    """
+
+    Parameters
+    ----------
+    species_string
+
+    Returns
+    ----------
+    atomic_number
+    ion number
+
+    Raises
+    ----------
+    AttributeError:
+    ValueError:
+
+    """
 
     try:
         element_symbol, ion_number_string = re.match('^(\w+)\s*(\d+)', species_string).groups()
@@ -244,6 +321,16 @@ def species_string_to_tuple(species_string):
 
 
 def parse_quantity(quantity_string):
+    """
+    Parameters
+    ----------
+    quantity_string
+
+    Returns
+    -------
+    q
+
+    """
 
     if not isinstance(quantity_string, str):
         raise MalformedQuantityError(quantity_string)
@@ -267,6 +354,20 @@ def parse_quantity(quantity_string):
 
 
 def element_symbol2atomic_number(element_string):
+    """
+    Takes an element symbol and returns its corresponding atomic number
+    Parameters
+    ----------
+    element_string: str
+        Inputted element symbol
+
+    Returns
+    -------
+    SYMBOL2ATOMIC_NUMBER[reformatted_element_string]: int
+        Returned atomic number
+
+
+    """
     reformatted_element_string = reformat_element_symbol(element_string)
     if reformatted_element_string not in SYMBOL2ATOMIC_NUMBER:
         raise MalformedElementSymbolError(element_string)
@@ -276,6 +377,19 @@ def element_symbol2atomic_number(element_string):
 def atomic_number2element_symbol(atomic_number):
     """
     Convert atomic number to string symbol
+
+    Parameters
+    ----------
+    atomic_number: int
+        Inputted atomic number
+
+
+    Returns
+    -------
+    ATOMIC_NUMBER2SYMBOL[atomic_number]: str
+       Returned corresponding element symbol
+
+
     """
     return ATOMIC_NUMBER2SYMBOL[atomic_number]
 
@@ -286,11 +400,15 @@ def reformat_element_symbol(element_string):
 
     Parameters
     ----------
-        element_symbol: str
+    element_string: str
+        Inputted element symbol
+
 
     Returns
     -------
-        reformated element symbol
+    reformatted element symbol: str
+        Returned reformatted element symbol
+
     """
 
     return element_string[0].upper() + element_string[1:].lower()
@@ -321,6 +439,17 @@ def quantity_linspace(start, stop, num, **kwargs):
 
 
 def convert_abundances_format(fname, delimiter='\s+'):
+    """
+    Parameters
+    ----------
+    fname: str
+    delimiter: str, optional
+
+    Returns
+    -------
+    df:
+
+    """
     df = pd.read_csv(fname, delimiter=delimiter, comment='#', header=None)
     #Drop shell index column
     df.drop(df.columns[0], axis=1, inplace=True)

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -72,6 +72,20 @@ NUMERAL_MAP = tuple(zip(
 ))
 
 def int_to_roman(i):
+    """
+    Convert an integer i into its roman numeral representation.
+
+    Parameters
+    ----------
+    i: int
+        Integer to be converted into roman numerals
+
+    Returns
+    -------
+        : str
+        Returns roman numeral representation of i in str format.
+
+    """
     result = []
     for integer, numeral in NUMERAL_MAP:
         count = i // integer

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -73,7 +73,7 @@ NUMERAL_MAP = tuple(zip(
 
 def int_to_roman(i):
     """
-    Convert an integer i into its roman numeral representation.
+    Convert an integer into its roman numeral representation.
 
     Parameters
     ----------
@@ -84,7 +84,6 @@ def int_to_roman(i):
     -------
         : str
         Returns roman numeral representation of i in str format.
-
     """
     result = []
     for integer, numeral in NUMERAL_MAP:
@@ -95,6 +94,7 @@ def int_to_roman(i):
 
 def roman_to_int(roman_string):
     """
+
 
     Parameters
     ----------

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -95,6 +95,7 @@ def int_to_roman(i):
 def roman_to_int(roman_string):
     """
     Convert a roman numeral into its corresponding integer.
+
     Parameters
     ----------
     roman_string: str
@@ -123,7 +124,7 @@ def roman_to_int(roman_string):
 def calculate_luminosity(spec_fname, distance, wavelength_column=0, wavelength_unit=u.angstrom, flux_column=1,
                          flux_unit=u.Unit('erg / (Angstrom cm2 s)')):
     """
-    Calculates luminosity of star
+    Calculates luminosity of star.
 
     Parameters
     ----------
@@ -236,9 +237,9 @@ def intensity_black_body(nu, T):
 
     Parameters
     ----------
-    nu: int
-        Frequency of a wave of light
-    T: int
+    nu: flot
+        Frequency of light
+    T: float
         Temperature in kelvin
 
     Returns
@@ -289,12 +290,12 @@ def species_string_to_tuple(species_string):
         String containing element symbol and number of electrons missing
 
     Returns
-    ----------
+    -------
     atomic_number, ion_number: tuple
         Returns tuple of length 2 indicating atomic number and ion number
 
     Raises
-    ----------
+    ------
     MalformedSpeciesError
         If the inputted string does not match the species format
     """
@@ -376,7 +377,7 @@ def element_symbol2atomic_number(element_string):
 
     Returns
     -------
-        :int
+        : int
         Returned atomic number
     """
     reformatted_element_string = reformat_element_symbol(element_string)
@@ -396,7 +397,7 @@ def atomic_number2element_symbol(atomic_number):
 
     Returns
     -------
-        :str
+        : str
        Returned corresponding element symbol
     """
     return ATOMIC_NUMBER2SYMBOL[atomic_number]


### PR DESCRIPTION
In the process of fixing all the numpydoc problems in the util package. This is in relation to #680. 

- [x] int_to_roman

- [x] roman_to_int

- [x] calculate_luminosity

- [x] create_synpp_yaml

- [x] intensity_black_body

- [x] species_tuple_to_string

- [x] species_string_to_tuple

- [x] parse_quantity

- [x] element_symbol2atomic_number

- [x] atomic_number2element_symbol

- [x] reformat_element_symbol

- [x] quantity_linspace

- [x] convert_abundances_format