### PR TITLE
Fixed csvy abundance indexing bug

### DIFF
--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -594,6 +594,8 @@ class Radial1DModel(HDFWriterMixin):
 
         abundance = abundance.replace(np.nan, 0.0)
         abundance = abundance[abundance.sum(axis=1) > 0]
+        abundance = abundance.loc[:, 1:]
+        abundance.columns = np.arange(abundance.shape[1])
 
         norm_factor = abundance.sum(axis=0) + isotope_abundance.sum(axis=0)
 

--- a/tardis/model/tests/data/config_v_filter.yml
+++ b/tardis/model/tests/data/config_v_filter.yml
@@ -1,0 +1,53 @@
+# Example YAML configuration for TARDIS
+tardis_config_version: v1.0
+
+supernova:
+  luminosity_requested: 8.770 log_lsun
+  time_explosion: 1 day
+  distance: 8.32 Mpc
+
+# standard atomic data base; get it from the tardis-refdata repository
+#atom_data: kurucz_cd23_chianti_H_He.h5
+atom_data: /Users/marcwilliamson/Research/TARDIS/tardis-refdata/atom_data/kurucz_cd23_chianti_H_He.h5
+
+csvy_model: csvy_vfilter.csvy
+
+
+plasma:
+  #initial_t_inner: 10000 K
+  #initial_t_rad: 10000 K
+  disable_electron_scattering: no
+  ionization: lte
+  excitation: lte
+  # radiative_rates_type - currently supported are dilute-blackbody, detailed and blackbody
+  radiative_rates_type: dilute-blackbody
+  # line_interaction_type - currently supported are scatter, downbranch and macroatom
+  line_interaction_type: macroatom
+
+montecarlo:
+  seed: 23111963
+  no_of_packets: 4.0e+4
+  iterations: 20
+  # Number of threads used in OMP mode; uncomment if you want to control the
+  # OMP behaviour via the config; otherwise the maximum available number of
+  # threads is used or the number specified in the OMP_NUM_THREADS environment
+  # variable
+  # --------
+  #nthreads: 1
+
+  last_no_of_packets: 1.e+4
+  no_of_virtual_packets: 10
+
+  convergence_strategy:
+    type: damped
+    damping_constant: 1.0
+    threshold: 0.05
+    fraction: 0.8
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 1.0
+
+spectrum:
+  start: 500 angstrom
+  stop: 20000 angstrom
+  num: 10000

--- a/tardis/model/tests/data/csvy_vfilter.csvy
+++ b/tardis/model/tests/data/csvy_vfilter.csvy
@@ -1,0 +1,30 @@
+---
+name: csvy_vfilter
+model_density_time_0: 1 day
+model_isotope_time_0: 0 day
+description: Example csvy config file for TARDIS.
+tardis_model_config_version: v1.0
+datatype:
+  fields:
+    -  name: velocity
+       unit: km/s
+       desc: velocities of shell outer bounderies.
+    -  name: density
+       unit: g/cm^3
+       desc: density of shell.
+    -  name: H
+       desc: fractional H abundance
+    -  name: He
+       desc: fractional He abundance
+
+v_inner_boundary: 11000 km/s
+v_outer_boundary: 14500 km/s
+---
+velocity,density,H,He
+9000, 5e-10, 0.5, 0.5
+10500, 2.0e-10, 0.0, 1.0
+12000, 9e-11, 0.35, 0.65
+13000, 9e-12, 0.3, 0.7
+14000, 6e-12, 0.6, 0.4
+15000, 4e-12, 0.4, 0.6
+16000, 3e-12, 0.2, 0.8

--- a/tardis/model/tests/test_csvy_model.py
+++ b/tardis/model/tests/test_csvy_model.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import numpy.testing as npt
 import tardis
 import os
@@ -43,3 +44,14 @@ def test_compare_models(filename):
             npt.assert_array_almost_equal(csvy_model_val, config_model_val)
 
 
+def test_csvy_abundance():
+    csvypath = os.path.join(DATA_PATH, 'config_v_filter.yml')
+    config = Configuration.from_yaml(csvypath)
+    csvy_model = Radial1DModel.from_csvy(config)
+    csvy_abund = csvy_model.abundance
+
+    ref_abund = pd.DataFrame(np.array([[0.35,0.3, 0.6, 0.4],[0.65,0.7,0.4,0.6]]))
+    ref_abund.index.name = 'atomic_number'
+    ref_abund.index = np.array([1, 2])
+
+    assert csvy_abund.equals(ref_abund)


### PR DESCRIPTION
The csvy model abundance reader was including the first line of abundances, which should be ignored.  This was causing an indexing issue.  This issue is fixed, and a new test is added to specifically check for this type of bug.