### PR TITLE
Fix for vboundary tests

### DIFF
--- a/tardis/plasma/setup_package.py
+++ b/tardis/plasma/setup_package.py
@@ -4,7 +4,7 @@ from astropy_helpers.distutils_helpers import get_distutils_option
 import numpy as np
 
 def get_package_data():
-    return {'tardis.plasma.tests':['data/*.dat', 'data/*.yml', 'data/*.h5', 'data/*.dot', 'data/*.tex']}
+    return {'tardis.plasma.tests':['data/*.dat', 'data/*.txt', 'data/*.yml', 'data/*.h5', 'data/*.dot', 'data/*.tex']}
 
 if get_distutils_option('with_openmp', ['build', 'install', 'develop']) is not None:
     compile_args = ['-fopenmp', '-W', '-Wall', '-Wmissing-prototypes', '-std=c99']


### PR DESCRIPTION
This PR fixes the `vboundary` tests failing under Ubuntu 18.04 and its derivatives.