### PR TITLE
Fix for packet source unit test

### DIFF
--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -12,10 +12,19 @@ from tardis.montecarlo.packet_source import BlackBodySimpleSource
 def data_path():
     return os.path.join(tardis.__path__[0], 'montecarlo', 'tests', 'data')
 
+@pytest.fixture
+def packet_unittest_fpath(tardis_ref_path):
+    return os.path.abspath(os.path.join(
+        tardis_ref_path, 'packet_unittest.h5'))
 
-def test_bb_packet_sampling(tardis_ref_data):
+def test_bb_packet_sampling(tardis_ref_data, packet_unittest_fpath):
     bb = BlackBodySimpleSource(2508)
     #ref_df = pd.read_hdf('test_bb_sampling.h5')
+    if pytest.config.getvalue("--generate-reference"):
+            ref_bb = pd.read_hdf(packet_unittest_fpath, key='/blackbody')
+            ref_bb.to_hdf(tardis_ref_data, key='/packet_unittest/blackbody', 
+                            mode='a')
+
     ref_df = tardis_ref_data['/packet_unittest/blackbody']
     nus = bb.create_blackbody_packet_nus(10000, 100)
     mus = bb.create_zero_limb_darkening_packet_mus(100)

--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -13,15 +13,15 @@ def data_path():
     return os.path.join(tardis.__path__[0], 'montecarlo', 'tests', 'data')
 
 @pytest.fixture
-def packet_unittest_fpath(tardis_ref_path):
+def packet_unit_test_fpath(tardis_ref_path):
     return os.path.abspath(os.path.join(
         tardis_ref_path, 'packet_unittest.h5'))
 
-def test_bb_packet_sampling(tardis_ref_data, packet_unittest_fpath):
+def test_bb_packet_sampling(tardis_ref_data, packet_unit_test_fpath):
     bb = BlackBodySimpleSource(2508)
     #ref_df = pd.read_hdf('test_bb_sampling.h5')
     if pytest.config.getvalue("--generate-reference"):
-            ref_bb = pd.read_hdf(packet_unittest_fpath, key='/blackbody')
+            ref_bb = pd.read_hdf(packet_unit_test_fpath, key='/blackbody')
             ref_bb.to_hdf(tardis_ref_data, key='/packet_unittest/blackbody', 
                             mode='a')
 


### PR DESCRIPTION
The problem: after running tests with `--generate-reference` flag the `/packet_unittest` group from the HDF5 five is missing.

Solution: `packet_unittest` data is stored in a separated HDF5 file (see https://github.com/tardis-sn/tardis-refdata/pull/25) and then stored in `unit_test_data.h5` when `--generate-reference` is called.