### PR TITLE
Create Zenodo JSON file

### DIFF
--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -43,16 +43,6 @@ jobs:
       inputs:
         secureFile: 'non_commit_contributors.txt'
 
-    - task: DownloadSecureFile@1
-      inputs: 
-        secureFile: 'id_azure_rsa'
-  
-    - task: InstallSSHKey@0
-      inputs:
-       knownHostsEntry: $(gh_host)
-       sshPublicKey: $(public_key)
-       sshKeySecureFile: 'id_azure_rsa'
-
     - bash: |
         echo "##vso[task.prependpath]$CONDA/bin"
         sudo chown -R $USER $CONDA
@@ -67,14 +57,16 @@ jobs:
         conda install -c conda-forge orcid --yes --no-update-deps
       displayName: "Install ORCID package "
 
-    - bash: |
-        source activate tardis
-        git clone git@github.com:tardis-sn/tardis_zenodo.git
-      displayName: "Clone tardis_zenodo repo"
+    #- bash: |
+    #    source activate tardis
+    #    git clone git@github.com:tardis-sn/tardis_zenodo.git
+    #  displayName: "Clone tardis_zenodo repo"
 
     - bash: |
         source activate tardis
+        mkdir tardis_zenodo
         cd tardis_zenodo
+        wget https://gist.github.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8
         cp $(zenodoSecretKey.secureFilePath) .
         cp $(authorOrder.secureFilePath) .
         cp $(nonCommitContributors.secureFilePath) .

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -62,7 +62,7 @@ jobs:
     - bash: |
         source activate zenodo
         mkdir tardis_zenodo; cd tardis_zenodo
-        wget https://gist.github.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8
+        wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/eb107bc1d4bc1f612d67841b6511da7c9920aa15/gather_data.ipynb
         cp $(zenodoSecretKey.secureFilePath) .
         cp $(authorOrder.secureFilePath) .
         cp $(nonCommitContributors.secureFilePath) .

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -7,7 +7,7 @@ trigger: none
 #pr: none
 schedules:
   - cron: "30 22 * * 0"
-    displayName: Weekly Sunday build
+    displayName: Weekly build
     branches:
       include:
         - master
@@ -75,8 +75,13 @@ jobs:
           source activate zenodo
           cd $(tardis.zenodo.home)
           jupyter nbconvert gather_data.ipynb --to html --allow-errors --execute --ExecutePreprocessor.timeout=6000
+        displayName: "Running notebook (allow errors)"
+
+      - bash: |
+          source activate zenodo
+          cd $(tardis.zenodo.home)
           jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
-        displayName: "Running notebook"
+        displayName: "Running notebook (not allow errors)"
 
       - task: PublishPipelineArtifact@1
         inputs:

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -44,14 +44,17 @@ jobs:
           secureFile: "non_commit_contributors.txt"
 
       - task: DownloadSecureFile@1
+        name: idAzureRSA
         inputs: 
+        displayName: "Download Azure keys"
           secureFile: 'id_azure_rsa'
 
       - task: InstallSSHKey@0
         inputs:
          knownHostsEntry: $(gh_host)
          sshPublicKey: $(public_key)
-         sshKeySecureFile: 'id_azure_rsa'
+         sshKeySecureFile: idAzureRSA
+        displayName: "Install SSH keys"
 
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -48,10 +48,6 @@ jobs:
         displayName: "Add CONDA to path"
 
       - bash: |
-          ls -r *
-        displayName: "Test step"
-
-      - bash: |
           conda create -n zenodo python=3.6 --yes
           source activate zenodo
           conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
@@ -64,8 +60,8 @@ jobs:
 
       - bash: |
           source activate zenodo
-          mkdir tardis_zenodo; cd tardis_zenodo
-          wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/eb107bc1d4bc1f612d67841b6511da7c9920aa15/gather_data.ipynb
+          cd ..; mkdir tardis_zenodo; cd tardis_zenodo
+          wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/ae0d4ef5421ef150f43ef5ad5c85f38c3e9b866f/gather_data.ipynb
           cp $(zenodoSecretKey.secureFilePath) .
           cp $(authorOrder.secureFilePath) .
           cp $(nonCommitContributors.secureFilePath) .

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -21,55 +21,57 @@ pool:
   vmImage: "ubuntu-latest"
 
 jobs:
-- job: zenodo_json
-  displayName: Create Zenodo JSON file
-  steps:
+  - job: zenodo_json
+    displayName: Create Zenodo JSON file
+    steps:
+      - task: DownloadSecureFile@1
+        name: zenodoSecretKey
+        displayName: "Download Zenodo secret key"
+        inputs:
+          secureFile: "key_secret.json"
 
-    - task: DownloadSecureFile@1
-      name: zenodoSecretKey
-      displayName: 'Download Zenodo secret key'
-      inputs:
-        secureFile: 'key_secret.json'
+      - task: DownloadSecureFile@1
+        name: authorOrder
+        displayName: "Download author order file"
+        inputs:
+          secureFile: "author_order.txt"
 
-    - task: DownloadSecureFile@1
-      name: authorOrder
-      displayName: 'Download author order file'
-      inputs:
-        secureFile: 'author_order.txt'
+      - task: DownloadSecureFile@1
+        name: nonCommitContributors
+        displayName: "Download non commit contributors file"
+        inputs:
+          secureFile: "non_commit_contributors.txt"
 
-    - task: DownloadSecureFile@1
-      name: nonCommitContributors
-      displayName: 'Download non commit contributors file'
-      inputs:
-        secureFile: 'non_commit_contributors.txt'
+      - bash: |
+          echo "##vso[task.prependpath]$CONDA/bin"
+          sudo chown -R $USER $CONDA
+        displayName: "Add CONDA to path"
 
-    - bash: |
-        echo "##vso[task.prependpath]$CONDA/bin"
-        sudo chown -R $USER $CONDA
-      displayName: "Add CONDA to path"
+      - bash: |
+          ls -r *
+        displayName: "Test step"
 
-    - bash: |
-        conda create -n zenodo python=3.6 --yes
-        source activate zenodo
-        conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
-      displayName: "Create Zenodo env"
+      - bash: |
+          conda create -n zenodo python=3.6 --yes
+          source activate zenodo
+          conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
+        displayName: "Create Zenodo env"
 
-    #- bash: |
-    #    source activate zenodo
-    #    git clone git@github.com:tardis-sn/tardis_zenodo.git
-    #  displayName: "Clone tardis_zenodo repo"
+      #- bash: |
+      #    source activate zenodo
+      #    git clone git@github.com:tardis-sn/tardis_zenodo.git
+      #  displayName: "Clone tardis_zenodo repo"
 
-    - bash: |
-        source activate zenodo
-        mkdir tardis_zenodo; cd tardis_zenodo
-        wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/eb107bc1d4bc1f612d67841b6511da7c9920aa15/gather_data.ipynb
-        cp $(zenodoSecretKey.secureFilePath) .
-        cp $(authorOrder.secureFilePath) .
-        cp $(nonCommitContributors.secureFilePath) .
-        jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
-        cat .zenodo.json
-      displayName: "Running gather_data notebook"
-
+      - bash: |
+          source activate zenodo
+          mkdir tardis_zenodo; cd tardis_zenodo
+          wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/eb107bc1d4bc1f612d67841b6511da7c9920aa15/gather_data.ipynb
+          cp $(zenodoSecretKey.secureFilePath) .
+          cp $(authorOrder.secureFilePath) .
+          cp $(nonCommitContributors.secureFilePath) .
+          jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
+          cat .zenodo.json
+        displayName: "Running gather_data notebook"
 #- job: gh_release
 #  displayName: Upload GitHub release
 #  dependsOn: zenodo_json
@@ -78,25 +80,25 @@ jobs:
 #        echo "##vso[task.prependpath]$CONDA/bin"
 #        sudo chown -R $USER $CONDA
 #      displayName: "Add CONDA to path"
-#  
+#
 #    - bash: |
 #        sh ci-helpers/install_tardis_env.sh
 #      displayName: "Install TARDIS env"
-#  
+#
 #    - bash: |
 #        source activate tardis
 #        python setup.py install
 #      displayName: "Build & install TARDIS"
-#  
+#
 #    - bash: |
 #        source activate tardis
 #        echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
 #      displayName: "Get TARDIS version number"
-#  
+#
 #    - bash: |
 #        echo $(VERSION)
 #      displayName: "Recover TARDIS version number"
-#  
+#
 #    - task: GitHubRelease@1
 #      inputs:
 #        gitHubConnection: "wkerzendorf"

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -15,6 +15,7 @@ schedules:
 
 variables:
   system.debug: "true"
+  tardis.zenodo.home: "$(Agent.BuildDirectory)/tardis_zenodo"
   tardis.build.dir: $(Build.Repository.LocalPath)
 
 pool:
@@ -55,19 +56,25 @@ jobs:
 
       #- bash: |
       #    source activate zenodo
-      #    git clone git@github.com:tardis-sn/tardis_zenodo.git
+      #    git clone git@github.com:tardis-sn/tardis_zenodo.git $(tardis.zenodo.home)
       #  displayName: "Clone tardis_zenodo repo"
 
       - bash: |
           source activate zenodo
           cd ..; mkdir tardis_zenodo
-          cd tardis_zenodo; pwd
+          cd $(tardis.zenodo.home)
           wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/ae0d4ef5421ef150f43ef5ad5c85f38c3e9b866f/gather_data.ipynb
           cp $(zenodoSecretKey.secureFilePath) .
           cp $(authorOrder.secureFilePath) .
           cp $(nonCommitContributors.secureFilePath) .
           jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
-        displayName: "Running gather_data notebook"
+        displayName: "Running notebook"
+
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: "$(tardis.zenodo.home)/.zenodo.json"
+          artifact: "report"
+          publishLocation: "pipeline"
 #- job: gh_release
 #  displayName: Upload GitHub release
 #  dependsOn: zenodo_json

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -95,11 +95,6 @@ jobs:
           artifact: "report"
           publishLocation: "pipeline"
         condition: succeededOrFailed()
-
-      #- bash: |
-      #    git clone git@github.com:tardis-sn/tardis_zenodo.git temp
-      #  condition: succeededOrFailed()
-      #  displayName: "Test step"
         
 #- job: gh_release
 #  displayName: Upload GitHub release

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: none
+#pr: none
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly Sunday build

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -76,6 +76,13 @@ jobs:
           targetPath: "$(tardis.zenodo.home)/.zenodo.json"
           artifact: "zenodo_json"
           publishLocation: "pipeline"
+
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: "$(tardis.zenodo.home)/gather_data.html"
+          artifact: "report"
+          publishLocation: "pipeline"
+        condition: succeededOrFailed()
 #- job: gh_release
 #  displayName: Upload GitHub release
 #  dependsOn: zenodo_json

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -60,7 +60,9 @@ jobs:
 
       - bash: |
           source activate zenodo
-          cd ..; mkdir tardis_zenodo; cd tardis_zenodo
+          cd ..; mkdir tardis_zenodo; 
+          ls -r * 
+          cd tardis_zenodo
           wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/ae0d4ef5421ef150f43ef5ad5c85f38c3e9b866f/gather_data.ipynb
           cp $(zenodoSecretKey.secureFilePath) .
           cp $(authorOrder.secureFilePath) .

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -44,7 +44,6 @@ jobs:
           secureFile: "non_commit_contributors.txt"
 
       - task: DownloadSecureFile@1
-        name: idAzureRSA
         inputs: 
           secureFile: "id_azure_rsa"
         displayName: "Download Azure keys"
@@ -53,7 +52,7 @@ jobs:
         inputs:
          knownHostsEntry: $(gh_host)
          sshPublicKey: $(public_key)
-         sshKeySecureFile: idAzureRSA
+         sshKeySecureFile: "id_azure_rsa"
         displayName: "Install SSH keys"
 
       - bash: |

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -73,7 +73,7 @@ jobs:
       - task: PublishPipelineArtifact@1
         inputs:
           targetPath: "$(tardis.zenodo.home)/.zenodo.json"
-          artifact: "report"
+          artifact: "zenodo_json"
           publishLocation: "pipeline"
 #- job: gh_release
 #  displayName: Upload GitHub release

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -60,9 +60,14 @@ jobs:
     #  displayName: "Clone tardis_zenodo repo"
 
     - bash: |
+        echo $(zenodoSecretKey.secureFilePath)
+        echo $(authorOrder.secureFilePath)
+        echo $(nonCommitContributors.secureFilePath)
+      displayName: "Test step"
+
+    - bash: |
         source activate zenodo
-        mkdir tardis_zenodo
-        cd tardis_zenodo
+        mkdir tardis_zenodo; cd tardis_zenodo
         wget https://gist.github.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8
         cp $(zenodoSecretKey.secureFilePath) .
         cp $(authorOrder.secureFilePath) .

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -49,28 +49,30 @@ jobs:
       displayName: "Add CONDA to path"
 
     - bash: |
-        sh ci-helpers/install_tardis_env.sh
-      displayName: "Install TARDIS env"
+        conda create -n zenodo python=3.6
+        source activate zenodo
+        conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
+      displayName: "Create Zenodo env"
     
     - bash: |
-        source activate tardis
+        source activate zenodo
         conda install -c conda-forge orcid --yes --no-update-deps
       displayName: "Install ORCID package "
 
     #- bash: |
-    #    source activate tardis
+    #    source activate zenodo
     #    git clone git@github.com:tardis-sn/tardis_zenodo.git
     #  displayName: "Clone tardis_zenodo repo"
 
     - bash: |
-        source activate tardis
+        source activate zenodo
         mkdir tardis_zenodo
         cd tardis_zenodo
         wget https://gist.github.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8
         cp $(zenodoSecretKey.secureFilePath) .
         cp $(authorOrder.secureFilePath) .
         cp $(nonCommitContributors.secureFilePath) .
-        jupyter nbconvert gather_data.ipynb --execute --ExecutePreprocessor.timeout=6000
+        jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
         cat .zenodo.json
       displayName: "Running gather_data notebook"
 

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -60,15 +60,13 @@ jobs:
 
       - bash: |
           source activate zenodo
-          cd ..; mkdir tardis_zenodo; 
-          ls -r * 
-          cd tardis_zenodo
+          cd ..; mkdir tardis_zenodo
+          cd tardis_zenodo; pwd
           wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/ae0d4ef5421ef150f43ef5ad5c85f38c3e9b866f/gather_data.ipynb
           cp $(zenodoSecretKey.secureFilePath) .
           cp $(authorOrder.secureFilePath) .
           cp $(nonCommitContributors.secureFilePath) .
           jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
-          cat .zenodo.json
         displayName: "Running gather_data notebook"
 #- job: gh_release
 #  displayName: Upload GitHub release

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -43,6 +43,16 @@ jobs:
         inputs:
           secureFile: "non_commit_contributors.txt"
 
+      - task: DownloadSecureFile@1
+        inputs: 
+          secureFile: 'id_azure_rsa'
+
+      - task: InstallSSHKey@0
+        inputs:
+         knownHostsEntry: $(gh_host)
+         sshPublicKey: $(public_key)
+         sshKeySecureFile: 'id_azure_rsa'
+
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"
           sudo chown -R $USER $CONDA
@@ -95,6 +105,12 @@ jobs:
           artifact: "report"
           publishLocation: "pipeline"
         condition: succeededOrFailed()
+
+      - bash: |
+          git clone git@github.com:tardis-sn/tardis_zenodo.git temp
+        condition: succeededOrFailed()
+        displayName: "Test step"
+        
 #- job: gh_release
 #  displayName: Upload GitHub release
 #  dependsOn: zenodo_json

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -22,6 +22,7 @@ pool:
 
 jobs:
 - job: zenodo_json
+  displayName: Create Zenodo JSON file
   steps:
 
     - task: DownloadSecureFile@1
@@ -41,6 +42,16 @@ jobs:
       displayName: 'Download non commit contributors file'
       inputs:
         secureFile: 'non_commit_contributors.txt'
+
+    - task: DownloadSecureFile@1
+      inputs: 
+        secureFile: 'id_azure_rsa'
+  
+    - task: InstallSSHKey@0
+      inputs:
+       knownHostsEntry: $(gh_host)
+       sshPublicKey: $(public_key)
+       sshKeySecureFile: 'id_azure_rsa'
 
     - bash: |
         echo "##vso[task.prependpath]$CONDA/bin"
@@ -72,6 +83,7 @@ jobs:
       displayName: "Running gather_data notebook"
 
 #- job: gh_release
+#  displayName: Upload GitHub release
 #  dependsOn: zenodo_json
 #  steps:
 #    - bash: |

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -49,15 +49,10 @@ jobs:
       displayName: "Add CONDA to path"
 
     - bash: |
-        conda create -n zenodo python=3.6
+        conda create -n zenodo python=3.6 --yes
         source activate zenodo
         conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
       displayName: "Create Zenodo env"
-    
-    - bash: |
-        source activate zenodo
-        conda install -c conda-forge orcid --yes --no-update-deps
-      displayName: "Install ORCID package "
 
     #- bash: |
     #    source activate zenodo

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -43,18 +43,6 @@ jobs:
         inputs:
           secureFile: "non_commit_contributors.txt"
 
-      - task: DownloadSecureFile@1
-        inputs: 
-          secureFile: "id_azure_rsa"
-        displayName: "Download Azure keys"
-
-      - task: InstallSSHKey@0
-        inputs:
-         knownHostsEntry: $(gh_host)
-         sshPublicKey: $(public_key)
-         sshKeySecureFile: "id_azure_rsa"
-        displayName: "Install SSH keys"
-
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"
           sudo chown -R $USER $CONDA
@@ -108,10 +96,10 @@ jobs:
           publishLocation: "pipeline"
         condition: succeededOrFailed()
 
-      - bash: |
-          git clone git@github.com:tardis-sn/tardis_zenodo.git temp
-        condition: succeededOrFailed()
-        displayName: "Test step"
+      #- bash: |
+      #    git clone git@github.com:tardis-sn/tardis_zenodo.git temp
+      #  condition: succeededOrFailed()
+      #  displayName: "Test step"
         
 #- job: gh_release
 #  displayName: Upload GitHub release

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -54,55 +54,58 @@ jobs:
     - bash: |
         source activate tardis
         conda install -c conda-forge orcid --yes --no-update-deps
-      displayName: "Install TARDIS env"
+      displayName: "Install ORCID Python package "
 
-    #- bash: |
-    #    source activate tardis
-    #    git clone https://github.com/tardis-sn/tardis_zenodo.git
-    #  displayName: "Clone tardis_zenodo repo"
-
-    - bash: |
-        mkdir tardis_zenodo
-        cp $(zenodoSecretKey) .
-        cp $(authorOrder) .
-        cp $(nonCommitContributors) .
-      displayName: "Copying secure files"
-
-- job: gh_release
-  dependsOn: zenodo_json
-  steps:
-    - bash: |
-        echo "##vso[task.prependpath]$CONDA/bin"
-        sudo chown -R $USER $CONDA
-      displayName: "Add CONDA to path"
-  
-    - bash: |
-        sh ci-helpers/install_tardis_env.sh
-      displayName: "Install TARDIS env"
-  
     - bash: |
         source activate tardis
-        python setup.py install
-      displayName: "Build & install TARDIS"
-  
+        git clone https://github.com/tardis-sn/tardis_zenodo.git
+      displayName: "Clone tardis_zenodo repo"
+
     - bash: |
         source activate tardis
-        echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
-      displayName: "Get TARDIS version number"
-  
-    - bash: |
-        echo $(VERSION)
-      displayName: "Recover TARDIS version number"
-  
-    - task: GitHubRelease@1
-      inputs:
-        gitHubConnection: "wkerzendorf"
-        repositoryName: "$(Build.Repository.Name)"
-        action: "create"
-        target: "$(Build.SourceVersion)"
-        tagSource: "userSpecifiedTag"
-        tag: "$(VERSION)"
-        title: "TARDIS v$(VERSION)"
-        isPreRelease: true
-        changeLogCompareToRelease: "lastFullRelease"
-        changeLogType: "commitBased"
+        cd tardis_zenodo
+        cp $(zenodoSecretKey.secureFilePath) .
+        cp $(authorOrder.secureFilePath) .
+        cp $(nonCommitContributors.secureFilePath) .
+        jupyter nbconvert gather_data.ipynb --execute --ExecutePreprocessor.timeout=6000
+        cat .zenodo.json
+      displayName: "Running gather_data notebook"
+
+#- job: gh_release
+#  dependsOn: zenodo_json
+#  steps:
+#    - bash: |
+#        echo "##vso[task.prependpath]$CONDA/bin"
+#        sudo chown -R $USER $CONDA
+#      displayName: "Add CONDA to path"
+#  
+#    - bash: |
+#        sh ci-helpers/install_tardis_env.sh
+#      displayName: "Install TARDIS env"
+#  
+#    - bash: |
+#        source activate tardis
+#        python setup.py install
+#      displayName: "Build & install TARDIS"
+#  
+#    - bash: |
+#        source activate tardis
+#        echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
+#      displayName: "Get TARDIS version number"
+#  
+#    - bash: |
+#        echo $(VERSION)
+#      displayName: "Recover TARDIS version number"
+#  
+#    - task: GitHubRelease@1
+#      inputs:
+#        gitHubConnection: "wkerzendorf"
+#        repositoryName: "$(Build.Repository.Name)"
+#        action: "create"
+#        target: "$(Build.SourceVersion)"
+#        tagSource: "userSpecifiedTag"
+#        tag: "$(VERSION)"
+#        title: "TARDIS v$(VERSION)"
+#        isPreRelease: true
+#        changeLogCompareToRelease: "lastFullRelease"
+#        changeLogType: "commitBased"

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -60,12 +60,6 @@ jobs:
     #  displayName: "Clone tardis_zenodo repo"
 
     - bash: |
-        echo $(zenodoSecretKey.secureFilePath)
-        echo $(authorOrder.secureFilePath)
-        echo $(nonCommitContributors.secureFilePath)
-      displayName: "Test step"
-
-    - bash: |
         source activate zenodo
         mkdir tardis_zenodo; cd tardis_zenodo
         wget https://gist.github.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -63,10 +63,11 @@ jobs:
           source activate zenodo
           cd ..; mkdir tardis_zenodo
           cd $(tardis.zenodo.home)
-          wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/ae0d4ef5421ef150f43ef5ad5c85f38c3e9b866f/gather_data.ipynb
+          wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/d71ca46ca1816f6f46c768314c2da59ed017861e/gather_data.ipynb
           cp $(zenodoSecretKey.secureFilePath) .
           cp $(authorOrder.secureFilePath) .
           cp $(nonCommitContributors.secureFilePath) .
+          jupyter nbconvert gather_data.ipynb --to html --allow-errors --execute --ExecutePreprocessor.timeout=6000
           jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
         displayName: "Running notebook"
 

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -46,8 +46,8 @@ jobs:
       - task: DownloadSecureFile@1
         name: idAzureRSA
         inputs: 
+          secureFile: "id_azure_rsa"
         displayName: "Download Azure keys"
-          secureFile: 'id_azure_rsa'
 
       - task: InstallSSHKey@0
         inputs:

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -54,11 +54,11 @@ jobs:
     - bash: |
         source activate tardis
         conda install -c conda-forge orcid --yes --no-update-deps
-      displayName: "Install ORCID Python package "
+      displayName: "Install ORCID package "
 
     - bash: |
         source activate tardis
-        git clone https://github.com/tardis-sn/tardis_zenodo.git
+        git clone git@github.com:tardis-sn/tardis_zenodo.git
       displayName: "Clone tardis_zenodo repo"
 
     - bash: |

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -60,13 +60,20 @@ jobs:
       #  displayName: "Clone tardis_zenodo repo"
 
       - bash: |
-          source activate zenodo
           cd ..; mkdir tardis_zenodo
           cd $(tardis.zenodo.home)
           wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/d71ca46ca1816f6f46c768314c2da59ed017861e/gather_data.ipynb
-          cp $(zenodoSecretKey.secureFilePath) .
-          cp $(authorOrder.secureFilePath) .
-          cp $(nonCommitContributors.secureFilePath) .
+        displayName: "Downloading notebook (workaround)"
+
+      - bash: |
+          cp $(zenodoSecretKey.secureFilePath) $(tardis.zenodo.home)
+          cp $(authorOrder.secureFilePath) $(tardis.zenodo.home)
+          cp $(nonCommitContributors.secureFilePath) $(tardis.zenodo.home)
+        displayName: "Recovering secrets"
+
+      - bash: |
+          source activate zenodo
+          cd $(tardis.zenodo.home)
           jupyter nbconvert gather_data.ipynb --to html --allow-errors --execute --ExecutePreprocessor.timeout=6000
           jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
         displayName: "Running notebook"

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -20,39 +20,89 @@ variables:
 pool:
   vmImage: "ubuntu-latest"
 
-steps:
-  - bash: |
-      echo "##vso[task.prependpath]$CONDA/bin"
-      sudo chown -R $USER $CONDA
-    displayName: "Add CONDA to path"
+jobs:
+- job: zenodo_json
+  steps:
 
-  - bash: |
-      sh ci-helpers/install_tardis_env.sh
-    displayName: "Install TARDIS env"
+    - task: DownloadSecureFile@1
+      name: zenodoSecretKey
+      displayName: 'Download Zenodo secret key'
+      inputs:
+        secureFile: 'key_secret.json'
 
-  - bash: |
-      source activate tardis
-      python setup.py install
-    displayName: "Build & install TARDIS"
+    - task: DownloadSecureFile@1
+      name: authorOrder
+      displayName: 'Download author order file'
+      inputs:
+        secureFile: 'author_order.txt'
 
-  - bash: |
-      source activate tardis
-      echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
-    displayName: "Get TARDIS version number"
+    - task: DownloadSecureFile@1
+      name: nonCommitContributors
+      displayName: 'Download non commit contributors file'
+      inputs:
+        secureFile: 'non_commit_contributors.txt'
 
-  - bash: |
-      echo $(VERSION)
-    displayName: "Recover TARDIS version number"
+    - bash: |
+        echo "##vso[task.prependpath]$CONDA/bin"
+        sudo chown -R $USER $CONDA
+      displayName: "Add CONDA to path"
 
-  - task: GitHubRelease@1
-    inputs:
-      gitHubConnection: "wkerzendorf"
-      repositoryName: "$(Build.Repository.Name)"
-      action: "create"
-      target: "$(Build.SourceVersion)"
-      tagSource: "userSpecifiedTag"
-      tag: "v$(VERSION)"
-      title: "TARDIS v$(VERSION)"
-      isPreRelease: false
-      changeLogCompareToRelease: "lastFullRelease"
-      changeLogType: "commitBased"
+    - bash: |
+        sh ci-helpers/install_tardis_env.sh
+      displayName: "Install TARDIS env"
+    
+    - bash: |
+        source activate tardis
+        conda install -c conda-forge orcid --yes --no-update-deps
+      displayName: "Install TARDIS env"
+
+    #- bash: |
+    #    source activate tardis
+    #    git clone https://github.com/tardis-sn/tardis_zenodo.git
+    #  displayName: "Clone tardis_zenodo repo"
+
+    - bash: |
+        mkdir tardis_zenodo
+        cp $(zenodoSecretKey) .
+        cp $(authorOrder) .
+        cp $(nonCommitContributors) .
+      displayName: "Copying secure files"
+
+- job: gh_release
+  dependsOn: zenodo_json
+  steps:
+    - bash: |
+        echo "##vso[task.prependpath]$CONDA/bin"
+        sudo chown -R $USER $CONDA
+      displayName: "Add CONDA to path"
+  
+    - bash: |
+        sh ci-helpers/install_tardis_env.sh
+      displayName: "Install TARDIS env"
+  
+    - bash: |
+        source activate tardis
+        python setup.py install
+      displayName: "Build & install TARDIS"
+  
+    - bash: |
+        source activate tardis
+        echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
+      displayName: "Get TARDIS version number"
+  
+    - bash: |
+        echo $(VERSION)
+      displayName: "Recover TARDIS version number"
+  
+    - task: GitHubRelease@1
+      inputs:
+        gitHubConnection: "wkerzendorf"
+        repositoryName: "$(Build.Repository.Name)"
+        action: "create"
+        target: "$(Build.SourceVersion)"
+        tagSource: "userSpecifiedTag"
+        tag: "$(VERSION)"
+        title: "TARDIS v$(VERSION)"
+        isPreRelease: true
+        changeLogCompareToRelease: "lastFullRelease"
+        changeLogType: "commitBased"


### PR DESCRIPTION
**Last update: 13/2/2020**

- The pipeline consist of two jobs: one creates `.zenodo.json` file by running a notebook, and the other upload a new GitHub release. The Zenodo webhook automatically makes a release in their site using `.zenodo.json` from `master` as author list.

- At the moment the second job is commented and not executed. Once un-commented, the second job will run only if the first job is succesful (see the parameter: `dependsOn: zenodo_json`).

- The first job is incomplete. To complete we need: 

  a) Fetch the `gather_data.ipynb` notebook from `tardis_zenodo` private repo. We are using a copy of the notebook stored in Gist and downloaded via `wget` as a temporary workaround.

  b) Push the generated `.zenodo.json` to the `master` branch.

- During the first job the `gather_data.ipynb` notebook is executed twice:
  
  1. The first run is with `--allow-errors` flag and renders the notebook with errors/exceptions. The rendered notebook is saved as an Azure Artifact. This step usually never fails and is useful to debug errors very quickly.

  2. The second run is done without the flag. If there's any error/exception the entire pipeline will fail.