### PR TITLE
Fix file paths at `diff` step in release pipeline

### DIFF
--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -99,9 +99,6 @@ jobs:
           publishLocation: "pipeline"
         condition: succeededOrFailed()
 
-      - bash: ls -r *
-        displayName: "Check file location"
-        condition: succeededOrFailed()
 #
 #  - job: gh_release
 #    displayName: Upload GitHub release

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -4,8 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: 
-  - master
+pr: none
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly build
@@ -99,44 +98,42 @@ jobs:
           publishLocation: "pipeline"
         condition: succeededOrFailed()
 
-#
-#  - job: gh_release
-#    displayName: Upload GitHub release
-#    dependsOn: zenodo_json
-#    steps:
-#      - bash: |
-#          echo "##vso[task.prependpath]$CONDA/bin"
-#          sudo chown -R $USER $CONDA
-#        displayName: "Add CONDA to path"
-#
-#      - bash: |
-#          sh ci-helpers/install_tardis_env.sh
-#        displayName: "Install TARDIS env"
-#
-#      - bash: |
-#          source activate tardis
-#          python setup.py install
-#        displayName: "Build & install TARDIS"
-#
-#      - bash: |
-#          source activate tardis
-#          echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
-#        displayName: "Get TARDIS version number"
-#
-#      - bash: |
-#          echo $(VERSION)
-#        displayName: "Recover TARDIS version number"
-#
-#      - task: GitHubRelease@1
-#        inputs:
-#          gitHubConnection: "wkerzendorf"
-#          repositoryName: "$(Build.Repository.Name)"
-#          action: "create"
-#          target: "$(Build.SourceVersion)"
-#          tagSource: "userSpecifiedTag"
-#          tag: "v$(VERSION)"
-#          title: "TARDIS v$(VERSION)"
-#          isPreRelease: false
-#          changeLogCompareToRelease: "lastFullRelease"
-#          changeLogType: "commitBased"
-#
+  - job: gh_release
+    displayName: Upload GitHub release
+    dependsOn: zenodo_json
+    steps:
+      - bash: |
+          echo "##vso[task.prependpath]$CONDA/bin"
+          sudo chown -R $USER $CONDA
+        displayName: "Add CONDA to path"
+
+      - bash: |
+          sh ci-helpers/install_tardis_env.sh
+        displayName: "Install TARDIS env"
+
+      - bash: |
+          source activate tardis
+          python setup.py install
+        displayName: "Build & install TARDIS"
+
+      - bash: |
+          source activate tardis
+          echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
+        displayName: "Get TARDIS version number"
+
+      - bash: |
+          echo $(VERSION)
+        displayName: "Recover TARDIS version number"
+
+      - task: GitHubRelease@1
+        inputs:
+          gitHubConnection: "wkerzendorf"
+          repositoryName: "$(Build.Repository.Name)"
+          action: "create"
+          target: "$(Build.SourceVersion)"
+          tagSource: "userSpecifiedTag"
+          tag: "v$(VERSION)"
+          title: "TARDIS v$(VERSION)"
+          isPreRelease: false
+          changeLogCompareToRelease: "lastFullRelease"
+          changeLogType: "commitBased"

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -16,7 +16,6 @@ schedules:
 
 variables:
   system.debug: "true"
-  tardis.repo.home: "$(Agent.BuildDirectory)/tardis"
   tardis.zenodo.home: "$(Agent.BuildDirectory)/tardis_zenodo"
   tardis.build.dir: $(Build.Repository.LocalPath)
 
@@ -83,7 +82,7 @@ jobs:
 
       # This step should fail if there are changes in .zenodo.json
       - bash: |
-          diff $(tardis.zenodo.json)/.zenodo.json $(tardis.repo.home)/.zenodo.json
+          diff $(tardis.zenodo.json)/.zenodo.json .zenodo.json
         displayName: "Look for changes in JSON"
 
       - task: PublishPipelineArtifact@1
@@ -100,7 +99,7 @@ jobs:
           publishLocation: "pipeline"
         condition: succeededOrFailed()
 
-      - bash: ls -r 
+      - bash: ls -r *
         displayName: "Check file location"
         condition: succeededOrFailed()
 #

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: none
+pr: release-pipeline-fix-2
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly build

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -81,7 +81,7 @@ jobs:
 
       # This step should fail if there are changes in .zenodo.json
       - bash: |
-          diff $(tardis.zenodo.json)/.zenodo.json $(tardis.build.dir)/.zenodo.json
+          diff $(tardis.zenodo.json)/.zenodo.json $(Agent.BuildDirectory)/.zenodo.json
         displayName: "Look for changes in JSON"
 
       - task: PublishPipelineArtifact@1
@@ -97,43 +97,44 @@ jobs:
           artifact: "report"
           publishLocation: "pipeline"
         condition: succeededOrFailed()
-
-  - job: gh_release
-    displayName: Upload GitHub release
-    dependsOn: zenodo_json
-    steps:
-      - bash: |
-          echo "##vso[task.prependpath]$CONDA/bin"
-          sudo chown -R $USER $CONDA
-        displayName: "Add CONDA to path"
-
-      - bash: |
-          sh ci-helpers/install_tardis_env.sh
-        displayName: "Install TARDIS env"
-
-      - bash: |
-          source activate tardis
-          python setup.py install
-        displayName: "Build & install TARDIS"
-
-      - bash: |
-          source activate tardis
-          echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
-        displayName: "Get TARDIS version number"
-
-      - bash: |
-          echo $(VERSION)
-        displayName: "Recover TARDIS version number"
-
-      - task: GitHubRelease@1
-        inputs:
-          gitHubConnection: "wkerzendorf"
-          repositoryName: "$(Build.Repository.Name)"
-          action: "create"
-          target: "$(Build.SourceVersion)"
-          tagSource: "userSpecifiedTag"
-          tag: "v$(VERSION)"
-          title: "TARDIS v$(VERSION)"
-          isPreRelease: false
-          changeLogCompareToRelease: "lastFullRelease"
-          changeLogType: "commitBased"
+#
+#  - job: gh_release
+#    displayName: Upload GitHub release
+#    dependsOn: zenodo_json
+#    steps:
+#      - bash: |
+#          echo "##vso[task.prependpath]$CONDA/bin"
+#          sudo chown -R $USER $CONDA
+#        displayName: "Add CONDA to path"
+#
+#      - bash: |
+#          sh ci-helpers/install_tardis_env.sh
+#        displayName: "Install TARDIS env"
+#
+#      - bash: |
+#          source activate tardis
+#          python setup.py install
+#        displayName: "Build & install TARDIS"
+#
+#      - bash: |
+#          source activate tardis
+#          echo "##vso[task.setvariable variable=version]$(python -c 'import tardis; print(tardis.__version__)')"
+#        displayName: "Get TARDIS version number"
+#
+#      - bash: |
+#          echo $(VERSION)
+#        displayName: "Recover TARDIS version number"
+#
+#      - task: GitHubRelease@1
+#        inputs:
+#          gitHubConnection: "wkerzendorf"
+#          repositoryName: "$(Build.Repository.Name)"
+#          action: "create"
+#          target: "$(Build.SourceVersion)"
+#          tagSource: "userSpecifiedTag"
+#          tag: "v$(VERSION)"
+#          title: "TARDIS v$(VERSION)"
+#          isPreRelease: false
+#          changeLogCompareToRelease: "lastFullRelease"
+#          changeLogType: "commitBased"
+#

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -4,7 +4,8 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: release-pipeline-fix-2
+pr: 
+  - release-pipeline-fix-2
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly build

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -81,7 +81,7 @@ jobs:
 
       # This step should fail if there are changes in .zenodo.json
       - bash: |
-          diff $(tardis.zenodo.json)/.zenodo.json $(Agent.BuildDirectory)/.zenodo.json
+          diff $(tardis.zenodo.json)/.zenodo.json $(Agent.BuildDirectory)/tardis/.zenodo.json
         displayName: "Look for changes in JSON"
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -16,6 +16,7 @@ schedules:
 
 variables:
   system.debug: "true"
+  tardis.repo.home: "$(Agent.BuildDirectory)/tardis"
   tardis.zenodo.home: "$(Agent.BuildDirectory)/tardis_zenodo"
   tardis.build.dir: $(Build.Repository.LocalPath)
 
@@ -82,7 +83,7 @@ jobs:
 
       # This step should fail if there are changes in .zenodo.json
       - bash: |
-          diff $(tardis.zenodo.json)/.zenodo.json $(Agent.BuildDirectory)/tardis/.zenodo.json
+          diff $(tardis.zenodo.json)/.zenodo.json $(tardis.repo.home)/.zenodo.json
         displayName: "Look for changes in JSON"
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -99,6 +99,10 @@ jobs:
           artifact: "report"
           publishLocation: "pipeline"
         condition: succeededOrFailed()
+
+      - bash: ls -r 
+        displayName: "Check file location"
+        condition: succeededOrFailed()
 #
 #  - job: gh_release
 #    displayName: Upload GitHub release

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -82,7 +82,7 @@ jobs:
 
       # This step should fail if there are changes in .zenodo.json
       - bash: |
-          diff $(tardis.zenodo.json)/.zenodo.json .zenodo.json
+          diff $(tardis.zenodo.home)/.zenodo.json .zenodo.json
         displayName: "Look for changes in JSON"
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -5,7 +5,7 @@
 
 trigger: none
 pr: 
-  - release-pipeline-fix-2
+  - master
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Release pipeline is failing because changes made in PR #1040 introduced an incorrect path of both JSON files, then the `diff` command fails.

<!--- Describe your changes in detail -->

This bug is already fixed, and the pipeline is working as expected (see [build log](https://dev.azure.com/tardis-sn/TARDIS/_build/results?buildId=1080&view=logs&j=2cd66027-7103-5c41-b66e-ddcc8aac08a0&t=3818c840-b2b1-581c-0588-c76cbb3ce33d)). Now the pipeline fails because one author [modified his ORCID information](https://github.com/tardis-sn/tardis/commit/20de586ba791dd465fddb8149cceb11ca1b02a9d), then the `diff` step stops the build process. But this is ok!.

The new JSON (with updated ORCID data) is updated as an artifact in the failed pipeline build log, and we need to push it to the `master` branch and re-run the pipeline (see #1046). Then the pipeline must pass.

_This should be our workflow until somone splits this pipeline in two parts and we are capable of pushing files from Azure to TARDIS main repository._

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
