### PR TITLE
Numba replace intensity_black_body 

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -3,7 +3,6 @@ import os
 import re
 from collections import OrderedDict
 
-import numexpr as ne
 import numpy as np
 import pandas as pd
 import yaml
@@ -13,6 +12,7 @@ from pyne import nucname
 
 import tardis
 from tardis.io.util import get_internal_data_path
+from numba import jit
 
 k_B_cgs = constants.k_B.cgs.value
 c_cgs = constants.c.cgs.value
@@ -242,7 +242,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
     with open(fname, 'w') as f:
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
-
+@jit(nopython=True)
 def intensity_black_body(nu, T):
     """
     Calculate the intensity of a black-body according to the following formula
@@ -265,8 +265,8 @@ def intensity_black_body(nu, T):
     """
     beta_rad = 1 / (k_B_cgs * T)
     coefficient = 2 * h_cgs / c_cgs ** 2
-    intensity = ne.evaluate('coefficient * nu**3 / '
-                            '(exp(h_cgs * nu * beta_rad) -1 )')
+    intensity = coefficient * nu**3 / 
+                            (np.exp(h_cgs * nu * beta_rad) -1 )
     return intensity
 
 

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -265,8 +265,7 @@ def intensity_black_body(nu, T):
     """
     beta_rad = 1 / (k_B_cgs * T)
     coefficient = 2 * h_cgs / c_cgs ** 2
-    intensity = coefficient * nu**3 / 
-                            (np.exp(h_cgs * nu * beta_rad) -1 )
+    intensity = coefficient * nu**3 / (np.exp(h_cgs * nu * beta_rad) -1 )
     return intensity
 
 

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -2,7 +2,6 @@ import logging
 import os
 import re
 from collections import OrderedDict
-import numexpr as ne
 import numpy as np
 import pandas as pd
 import yaml
@@ -12,8 +11,7 @@ from pyne import nucname
 
 import tardis
 from tardis.io.util import get_internal_data_path
-from numba import njit,float64
-import numba as nb
+from numba import njit
 
 k_B_cgs = constants.k_B.cgs.value
 c_cgs = constants.c.cgs.value
@@ -270,6 +268,8 @@ def intensity_black_body(nu, T,):
     intensity = coefficient * nu**3 / (np.exp(h_cgs * nu * beta_rad) -1 )
 
     return intensity
+
+
 def species_tuple_to_string(species_tuple, roman_numerals=True):
     """
     Convert a species tuple to its corresponding string representation.

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -242,7 +242,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
 @njit(error_model='numpy')
-def intensity_black_body(nu, T,):
+def intensity_black_body(nu, T):
     
     """
     Calculate the intensity of a black-body according to the following formula

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 from collections import OrderedDict
-
+import numexpr as ne
 import numpy as np
 import pandas as pd
 import yaml
@@ -12,7 +12,8 @@ from pyne import nucname
 
 import tardis
 from tardis.io.util import get_internal_data_path
-from numba import jit
+from numba import njit,float64
+import numba as nb
 
 k_B_cgs = constants.k_B.cgs.value
 c_cgs = constants.c.cgs.value
@@ -242,33 +243,33 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
     with open(fname, 'w') as f:
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
-@jit
-def intensity_black_body(nu, T):
+@njit
+def intensity_black_body(nu, T,):
+    
     """
     Calculate the intensity of a black-body according to the following formula
 
     .. math::
-        I(\\nu, T) = \\frac{2h\\nu^3}{c^2}\frac{1}
-        {e^{h\\nu \\beta_\\textrm{rad}} - 1}
+	I(\\nu, T) = \\frac{2h\\nu^3}{c^2}\frac{1}
+	{e^{h\\nu \\beta_\\textrm{rad}} - 1}
 
     Parameters
     ----------
     nu: float
-        Frequency of light
+	Frequency of light
     T: float
-        Temperature in kelvin
+	Temperature in kelvin
 
     Returns
     -------
     Intensity: float
-        Returns the intensity of the black body
+	Returns the intensity of the black body
     """
-    beta_rad = 1 / (k_B_cgs * T)
-    coefficient = 2 * h_cgs / c_cgs ** 2
+    beta_rad = 1.0 / (k_B_cgs * T) 
+    coefficient = 2.0 * h_cgs / c_cgs ** 2
     intensity = coefficient * nu**3 / (np.exp(h_cgs * nu * beta_rad) -1 )
+
     return intensity
-
-
 def species_tuple_to_string(species_tuple, roman_numerals=True):
     """
     Convert a species tuple to its corresponding string representation.

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -242,7 +242,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
     with open(fname, 'w') as f:
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
-@jit(nopython=True)
+@jit
 def intensity_black_body(nu, T):
     """
     Calculate the intensity of a black-body according to the following formula

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -241,7 +241,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
     with open(fname, 'w') as f:
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
-@njit
+@njit(error_model='numpy')
 def intensity_black_body(nu, T,):
     
     """


### PR DESCRIPTION
## Description
Replace numexpr.evaluate with numba decorator in function intensity_black_body and added error handling

numexpr.evaluate has a error handling in witch it treats DivideByZero as numpy does. Numba doesn't do this by default, halting the program instead. Adding (error_model='numpy') converts the error value to a NaN as numpy does.

Although cProfiling on the function itself shows significant improvement, doing the same for the whole code to test performance improvement doesn't show improvement since it's a one-time call.


![image](https://user-images.githubusercontent.com/45364266/75274446-a2def400-57e1-11ea-96bb-db5f41e41658.png)




