### PR TITLE
Use numba instead of numexpr in tardis.util.base.intensity_black_body

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -3,13 +3,15 @@ import os
 import re
 from collections import OrderedDict
 
-import numexpr as ne
+# import numexpr as ne
 import numpy as np
 import pandas as pd
 import yaml
 from tardis import constants
 from astropy import units as u
 from pyne import nucname
+
+from numba import njit
 
 import tardis
 from tardis.io.util import get_internal_data_path
@@ -243,6 +245,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
 
+@njit
 def intensity_black_body(nu, T):
     """
     Calculate the intensity of a black-body according to the following formula
@@ -263,10 +266,9 @@ def intensity_black_body(nu, T):
     Intensity: float
         Returns the intensity of the black body
     """
-    beta_rad = 1 / (k_B_cgs * T)
-    coefficient = 2 * h_cgs / c_cgs ** 2
-    intensity = ne.evaluate('coefficient * nu**3 / '
-                            '(exp(h_cgs * nu * beta_rad) -1 )')
+    beta_rad = 1.0 / (k_B_cgs * T)
+    coefficient = 2.0 * h_cgs / c_cgs ** 2
+    intensity = coefficient * nu**3 / (np.exp(h_cgs * nu * beta_rad) - 1)
     return intensity
 
 


### PR DESCRIPTION
`intensity_black_body` in `tardis.util.base` has been modified to use numba instead of numexpr

A simple profile done in IPython terminal, with `intensity_black_body_old` representing the numexpr version
```python
In [1]: %timeit intensity_black_body(np.random.rand()*100, 100*np.random.rand())                                                                     
2.23 µs ± 90.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [2]: %timeit intensity_black_body_old(np.random.rand()*100, 100*np.random.rand())                                                                 
34.4 µs ± 130 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Numpy is used to generate random numbers above so that we can get results over random numbers and do not obtain profiling results specific to given `nu` and `T`.

About 15x speed up is observed for repeated execution. However as numba does just in time compilation, it will be slower on the first call of the function, therefore if this function is not supposed to be called repeatedly, it would not be wise to optimise using numba.
