### PR TITLE
renamed capmanager class functions to its new ones

### DIFF
--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -120,8 +120,8 @@ class TestIntegration(object):
         # We now do a run with prepared config and get the simulation object.
         self.result = Simulation.from_config(tardis_config,
                                              atom_data=self.atom_data)
+        capmanager.suspend_global_capture(True)
 
-        capmanager.suspendcapture(True)
         # If current test run is just for collecting reference data, store the
         # output model to HDF file, save it at specified path. Skip all tests.
         # Else simply perform the run and move further for performing
@@ -139,7 +139,7 @@ class TestIntegration(object):
             pytest.skip("Reference data saved at {0}".format(
                 data_path['reference_path']
             ))
-        capmanager.resumecapture()
+        capmanager.resume_global_capture()
 
         # Get the reference data through the fixture.
         self.reference = reference


### PR DESCRIPTION
From pytest version 3.3.0+, the capmanager.suspendcapture and capmanager.resumecapture were renamed to capmanager.suspend_global_capture and capmanager.resume_global_capture, respectively.
The pytest version used here is 4.