### PR TITLE
Modify intensity_black_body using numba

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -3,7 +3,6 @@ import os
 import re
 from collections import OrderedDict
 
-import numexpr as ne
 import numpy as np
 import pandas as pd
 import yaml
@@ -13,6 +12,7 @@ from pyne import nucname
 
 import tardis
 from tardis.io.util import get_internal_data_path
+from numba import jit
 
 k_B_cgs = constants.k_B.cgs.value
 c_cgs = constants.c.cgs.value
@@ -242,7 +242,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
     with open(fname, 'w') as f:
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
-
+@jit(nopython=True, error_model='numpy')
 def intensity_black_body(nu, T):
     """
     Calculate the intensity of a black-body according to the following formula
@@ -265,8 +265,7 @@ def intensity_black_body(nu, T):
     """
     beta_rad = 1 / (k_B_cgs * T)
     coefficient = 2 * h_cgs / c_cgs ** 2
-    intensity = ne.evaluate('coefficient * nu**3 / '
-                            '(exp(h_cgs * nu * beta_rad) -1 )')
+    intensity = coefficient * nu**3 / (np.exp(h_cgs * nu * beta_rad) -1 )
     return intensity
 
 


### PR DESCRIPTION
## Description
Modify function intensity_black_body to be compiled with numba

Added <code>@jit</code>. decorator to <code>intensity_black_body</code> using <code>nopyhon=True</code> and <code>error_model='numpy'</code> as arguments. The first one is set to run the function without the involvement of the Python interpreter, while the latter is set to handle division by zero by returning a <code>NaN</code>, an implicit feature of <code>numexpr.evaluate</code>. The <code>numexpr</code> import was removed, as no other function calls it

## Motivation and Context
Improve performance using the numba library

## How Has This Been Tested?
Used <code>cProfile</code> to test the entire code. Contrary to what was intended, the results show an increase in time, given that numba's performance boost relies on calling the decorated function multiple times, which is not the case with <code>intensity_black_body</code>

## Screenshots (if appropriate):
![results](https://user-images.githubusercontent.com/60028580/75499985-72968180-59aa-11ea-8cce-793a1648e65f.jpeg)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
