### PR TITLE
Quantity-ify TARDIS first objective

### DIFF
--- a/scripts/datatable.py
+++ b/scripts/datatable.py
@@ -1,0 +1,75 @@
+"""
+=====================
+TARDIS data_table module
+=====================
+created on Mar 1, 2020
+
+"""
+
+import numpy as np
+import pandas as pd
+
+class DataTable:
+
+    """ Class that can be used to keep track of units associated with the
+    column attributes. Also it can be used to preserve this unit's data 
+    while copying in another object of same class.
+    
+    Class Members
+        ----------
+        data : dataframe
+            It is dataframe that actually stores the information
+            in tabular form
+            
+        units : array
+            It contains the units where index of units coincides with
+            index of column attribute
+            
+        attribute_unit : dictionary
+            Dictionary having key attribute name and unit as value 
+    
+    Example to use
+         ----------
+         df = pd.DataFrame( 
+                data = pd.np.random.randint(0, 100, (10, 5)) , 
+                columns = list('ABCED') )
+         dt1 = DataTable(df,['m', 's', 't', 'm/s', 'kg'])
+         
+         
+    Example to copy
+         ----------
+         dt2 = DataTable (dt1.data , dt1.units)
+         
+         """
+    
+     
+    def __init__(self, data, units):
+        if( len(list( data.columns )) == len(units) ):
+            self.data = data
+            self.units = units
+            columns = list( self.data.columns )
+            self.unit = {}
+            for i in range( len(units) ):
+                a = columns[i]
+                self.unit[a] = units[i]
+        else:
+            print("Invalid Input")
+            print(" The dimension of units and number of attributes didn't match.")
+    
+    
+    def get_unit(self,attr):
+        
+        """
+        Return unit of a particular attribute.
+
+        Parameters
+        ----------
+
+        attr: string or int
+            name of the attribute
+            
+        Returns: string
+            unit of the attribute
+        """
+        return self.unit[attr]    
+  


### PR DESCRIPTION
## Description
This PR creates a class DataTable which is capable of storing units of attributes and provide capability to pass these to another object of same class.

## Motivation and Context
Pandas DataFrame isn't capable to store the units of the attributes. The other issue is that this information about units of attributes gets further vanished when we try to copy one dataframe into another. 

##Implementation
I have tried to solve this problem by encapsulating the dataframe and units of attributes into a single class. Using this class we can not even store the units of attributes but also pass them into another object of same class by just passing the class members of first object to other.

## How Has This Been Tested?
I have tested the code by importing the library. I have also added short example about how to use the class in comments of the class.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
