### PR TITLE
Added numba version of black_body_intensity

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -3,7 +3,7 @@ import os
 import re
 from collections import OrderedDict
 
-import numexpr as ne
+from numba import njit
 import numpy as np
 import pandas as pd
 import yaml
@@ -243,21 +243,19 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
 
+@njit(parallel=True, error_model='numpy')
 def intensity_black_body(nu, T):
     """
     Calculate the intensity of a black-body according to the following formula
-
     .. math::
         I(\\nu, T) = \\frac{2h\\nu^3}{c^2}\frac{1}
         {e^{h\\nu \\beta_\\textrm{rad}} - 1}
-
     Parameters
     ----------
     nu: float
         Frequency of light
     T: float
         Temperature in kelvin
-
     Returns
     -------
     Intensity: float
@@ -265,8 +263,7 @@ def intensity_black_body(nu, T):
     """
     beta_rad = 1 / (k_B_cgs * T)
     coefficient = 2 * h_cgs / c_cgs ** 2
-    intensity = ne.evaluate('coefficient * nu**3 / '
-                            '(exp(h_cgs * nu * beta_rad) -1 )')
+    intensity = coefficient * nu ** 3 / (np.exp(h_cgs * nu * beta_rad) - 1)
     return intensity
 
 

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -243,7 +243,7 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
 
-@njit(parallel=True, error_model='numpy')
+@njit(fastmath=True, error_model='numpy')
 def intensity_black_body(nu, T):
     """
     Calculate the intensity of a black-body according to the following formula


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Black_body_intensity function modification

## Description
Modified black_body_intensity function to use numba instead of numexpr. Tried using two decorators from numba njit and vectorize. Came to conclusion that njit is best choice.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Easier to maintain. shows the same speed as previous version of the function, that used numexpr

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested runtime of four function variants (see screenshot section):  default, without any changes, v1  - pure numpy, v2 - vectorize decorator from numba, and v3 - jit decorator from numba
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Снимок экрана от 2020-03-01 23-13-54](https://user-images.githubusercontent.com/43323579/75633037-ca372600-5c12-11ea-8f8f-3a2c8fee7197.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
