### PR TITLE
addressed issue caused by relative file path.

### DIFF
--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -66,8 +66,7 @@ def assemble_plasma(config, model, atom_data=None):
             if os.path.isabs(config.atom_data):
                 atom_data_fname = config.atom_data
             else:
-                atom_data_fname = os.path.join(config.config_dirname,
-                                               config.atom_data)
+                raise IOError('Atom data path is not absolute')
         else:
             raise ValueError('No atom_data option found in the configuration.')
 

--- a/tardis/tests/integration_tests/test_integration.py
+++ b/tardis/tests/integration_tests/test_integration.py
@@ -120,8 +120,8 @@ class TestIntegration(object):
         # We now do a run with prepared config and get the simulation object.
         self.result = Simulation.from_config(tardis_config,
                                              atom_data=self.atom_data)
+        capmanager.suspend_global_capture(True)
 
-        capmanager.suspendcapture(True)
         # If current test run is just for collecting reference data, store the
         # output model to HDF file, save it at specified path. Skip all tests.
         # Else simply perform the run and move further for performing
@@ -139,7 +139,7 @@ class TestIntegration(object):
             pytest.skip("Reference data saved at {0}".format(
                 data_path['reference_path']
             ))
-        capmanager.resumecapture()
+        capmanager.resume_global_capture()
 
         # Get the reference data through the fixture.
         self.reference = reference


### PR DESCRIPTION
Addressing issue #962 . As relative filepath to tardis-refdata cause problems, making the user to add in only the absolute filepath to tardis-refdata seems to solve this issue.