### PR TITLE
addressing the issue caused by relative file path

### DIFF
--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -66,8 +66,7 @@ def assemble_plasma(config, model, atom_data=None):
             if os.path.isabs(config.atom_data):
                 atom_data_fname = config.atom_data
             else:
-                atom_data_fname = os.path.join(config.config_dirname,
-                                               config.atom_data)
+                raise IOError('Atom data path is not absolute')
         else:
             raise ValueError('No atom_data option found in the configuration.')
 

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -66,7 +66,8 @@ def assemble_plasma(config, model, atom_data=None):
             if os.path.isabs(config.atom_data):
                 atom_data_fname = config.atom_data
             else:
-                raise IOError('Atom data path is not absolute')
+                atom_data_fname = os.path.join(os.getcwd(),
+                                               config.atom_data)
         else:
             raise ValueError('No atom_data option found in the configuration.')
 


### PR DESCRIPTION
Addressing issue #962 . As relative filepath to tardis refadata causes problems, making the user to use only absolute filepath to tardis-refdata seems to solve the problem