### PR TITLE
Enable the Dask framework for parallel execution for TARDIS

### DIFF
--- a/run_tardis_with_dask.py
+++ b/run_tardis_with_dask.py
@@ -1,0 +1,14 @@
+from tardis import run_tardis
+from tardis.io.atom_data.util import download_atom_data
+from dask.distributed import Client
+
+# the data is automatically downloaded
+download_atom_data('kurucz_cd23_chianti_H_He')
+
+if __name__ == "__main__":
+    client = Client()
+    x = client.map(run_tardis, 'run_tardis_with_dask_config.yml')
+    import pdb;
+
+    pdb.set_trace()
+    x.result()

--- a/run_tardis_with_dask_config.yml
+++ b/run_tardis_with_dask_config.yml
@@ -1,0 +1,57 @@
+# Example YAML configuration for TARDIS
+tardis_config_version: v1.0
+
+supernova:
+  luminosity_requested: 9.44 log_lsun
+  time_explosion: 13 day
+
+atom_data: kurucz_cd23_chianti_H_He.h5
+
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 1.1e4 km/s
+      stop: 20000 km/s
+      num: 20
+    density:
+      type: branch85_w7
+
+  abundances:
+    type: uniform
+    O: 0.19
+    Mg: 0.03
+    Si: 0.52
+    S: 0.19
+    Ar: 0.04
+    Ca: 0.03
+
+plasma:
+  disable_electron_scattering: no
+  ionization: lte
+  excitation: lte
+  radiative_rates_type: dilute-blackbody
+  line_interaction_type: macroatom
+
+montecarlo:
+  seed: 23111963
+  no_of_packets: 4.0e+4
+  iterations: 20
+  nthreads: 1
+
+  last_no_of_packets: 1.e+5
+  no_of_virtual_packets: 10
+
+  convergence_strategy:
+    type: damped
+    damping_constant: 1.0
+    threshold: 0.05
+    fraction: 0.8
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 1.0
+
+spectrum:
+  start: 500 angstrom
+  stop: 20000 angstrom
+  num: 10000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is my first attempt at the objective task 'Enable the Dask framework for parallel execution for TARDIS' 
I created a file `run_tardis_with_dask` to test running `run_tardis()` in parallel. But a type error occurred on running `x.result()` where init was missing 12 positional arguments.
I used python debugger to find out that the problem was with `x.result()`. On reading the dask source code I found that once dask completes a task, `result()` function ultimately `yields` the result where a new object of all classes with `HDFWriterMixin` as parent is formed.
At first I deduced that dask was trying to create a Simulation object without passing the 12 required parameters, so I passed them as kwargs and args myself in the class. But then I realised that it was trying to create a new object of all classes with `HDFWriterMixin` as parent and each of their kwargs and args cannot be passed this way. 
Hence, I think my approach is wrong and I am trying to find another way.
Please review my code and help me with it.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
