### PR TITLE
Cmfgen2tardis.py fix

### DIFF
--- a/tardis/scripts/cmfgen2tardis.py
+++ b/tardis/scripts/cmfgen2tardis.py
@@ -4,10 +4,10 @@ import argparse
 import numpy as np
 import pandas as pd
 
-from tardis.atomic import AtomData
+from tardis.io.atom_data import AtomData
 
 
-atomic_dataset = AtomData.from_hdf5()
+atomic_dataset = AtomData.from_hdf()
 
 
 def get_atomic_number(element):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The import path and the function name is wrong 
## Description
<!--- Describe your changes in detail -->
`tardis/scripts/cmfgen2tardis.py`:
   - Updated import path 
   - corrected `from_hdf5()` to `from_hdf()`
## Motivation and Context
This file can't run if import statements and functions names are wrong
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
