### PR TITLE
[ADD] added notebook to show parallel computing using Dask

### DIFF
--- a/Parallel execution using Dask.ipynb
+++ b/Parallel execution using Dask.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " # `para` function would be used to show parallel running of TARDIS instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from tardis import run_tardis\n",
+    "from tardis.io.atom_data.util import download_atom_data\n",
+    "\n",
+    "def download_yml():\n",
+    "    os.system('wget https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/models/examples/tardis_example.yml')\n",
+    "\n",
+    "def para(dummy):\n",
+    "    # dummy variable used in order to make each function call unique\n",
+    "    _ = dummy\n",
+    "    files = os.listdir()\n",
+    "    if not 'tardis_example.yml' in files:\n",
+    "        download_yml()\n",
+    "    download_atom_data('kurucz_cd23_chianti_H_He')\n",
+    "    sim = run_tardis('tardis_example.yml')\n",
+    "    return"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Dask to execute parallel python functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running 1 instance on 4 workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Client</h3>\n",
+       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Scheduler: </b>tcp://127.0.0.1:33005</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://127.0.0.1:44021/status' target='_blank'>http://127.0.0.1:44021/status</a>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
+       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Workers: </b>4</li>\n",
+       "  <li><b>Cores: </b>8</li>\n",
+       "  <li><b>Memory: </b>8.22 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Client: 'tcp://127.0.0.1:33005' processes=4 threads=8, memory=8.22 GB>"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client = Client()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[<Future: pending, key: para-722b69320a4de80dffcec3961ea840b0>]\n",
+      "CPU times: user 28.6 s, sys: 12.4 s, total: 41 s\n",
+      "Wall time: 57.9 s\n",
+      "[None]\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = client.map(para, [0])\n",
+    "print(x)\n",
+    "%time result = client.gather(x)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Running 4 instances on 4 worker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<Client: 'tcp://127.0.0.1:33001' processes=4 threads=8, memory=8.22 GB>\n",
+      "[<Future: pending, key: para-722b69320a4de80dffcec3961ea840b0>, <Future: pending, key: para-565cce5c602947919d22239ef4817770>, <Future: pending, key: para-441307dd133e613d364e0b35932cb5b7>, <Future: pending, key: para-c9ccb043a8208372b62a08ff4e204e60>]\n",
+      "CPU times: user 24.3 s, sys: 5.79 s, total: 30.1 s\n",
+      "Wall time: 1min 12s\n",
+      "[None, None, None, None]\n"
+     ]
+    }
+   ],
+   "source": [
+    "client = Client()\n",
+    "print(client)\n",
+    "x = client.map(para, range(4))\n",
+    "print(x)\n",
+    "%time result = client.gather(x)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Using Dask we can run python codes in parallel or on multicore systems. This might
help to run TARDIS instances on super computer for higher computation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Usually TARDIS is run thousands of time to simulate supernovae. To reduce the time
taken to run those simulations we can use Dask.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This is tested on my laptop, with 4 cores and 8 GB ram. As you can see in the screenshot below that not much time is added even when 4 unique instances are run. I ran `run_tardis('tardis_example.yml')`

## Screenshots (if appropriate):
![Screenshot_2020-03-11 Parallel execution using Dask - Jupyter Notebook](https://user-images.githubusercontent.com/25999504/76356308-be96de00-633b-11ea-8ec6-bb8926827685.png)

## Note
This is only a proof of concept, don't merge it.
