### PR TITLE
add parser for si2_osc_kurucz data

### DIFF
--- a/scripts/parse_data_carsus/demo_parse_data_carsus.ipynb
+++ b/scripts/parse_data_carsus/demo_parse_data_carsus.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scripts.parse_data_carsus.main import read_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Predefined Values\n",
+    "filename = 'si2_osc_kurucz'\n",
+    "directory_path = '/Users/sashmish/Documents/personal/carsus/atomic/'\n",
+    "    \n",
+    "METADATA = r'^([\\w\\-\\.]+)\\s+!([\\w ]+)$'\n",
+    "PATTERN1 = r'^([\\w\\[\\]\\(\\)\\/]+)\\s+([\\w\\.]+)\\s+([+-]?[\\d\\.]+)\\s+([+-]?[\\d\\.]+)\\s+([+-]?[\\d\\.]+)\\s+([+-]?[\\dE\\.\\+\\-]+)\\s+([+-]?\\d+)\\s+([+-]?[\\dE\\.\\+\\-]+)\\s+([+-]?[\\dE\\.\\+\\-]+)\\s+([+-]?[\\dE\\.\\+\\-]+)'\n",
+    "PATTERN2 = r'^([\\w\\[\\]\\(\\)\\/]+)\\s*-([\\w\\[\\]\\(\\)\\/]+)\\s+([+-]?[\\dE\\.\\+\\-]+)\\s+([+-]?[\\dE\\.\\+\\-]+)\\s+([+-]?[\\dE\\.\\+\\-]+)\\s+(\\d+-\\s*\\d+)'\n",
+    "\n",
+    "columns_meta = ['Value', 'Name']\n",
+    "columns1 = ['level','g','E(cm^-1)','10^15 Hz','eV','Lam(A)','ID','ARAD','C4','C6']\n",
+    "columns2 = ['Transition1','Transition2','f','A','Lam(A)','i-j']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File found at path: /Users/sashmish/Documents/personal/carsus/atomic/SIL/II/16sep15/si2_osc_kurucz\n",
+      "         Value                     Name\n",
+      "1  17-Jun-2014              Format date\n",
+      "2  16-Sep-2015                     Date\n",
+      "3          157  Number of energy levels\n",
+      "4  131838.1400        Ionization energy\n",
+      "5          2.0  Screened nuclear charge\n",
+      "6         4196    Number of transitions\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parses out the metadata present in file\n",
+    "df = read_data(directory_path, filename, METADATA, columns_meta)\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File found at path: /Users/sashmish/Documents/personal/carsus/atomic/SIL/II/16sep15/si2_osc_kurucz\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>level</th>\n",
+       "      <th>g</th>\n",
+       "      <th>E(cm^-1)</th>\n",
+       "      <th>10^15 Hz</th>\n",
+       "      <th>eV</th>\n",
+       "      <th>Lam(A)</th>\n",
+       "      <th>ID</th>\n",
+       "      <th>ARAD</th>\n",
+       "      <th>C4</th>\n",
+       "      <th>C6</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3s2_3p_2Po[1/2]</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>3.95241</td>\n",
+       "      <td>16.346</td>\n",
+       "      <td>7.585E+02</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.000E+00</td>\n",
+       "      <td>-5.290E-17</td>\n",
+       "      <td>7.470E-33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3s2_3p_2Po[3/2]</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>287.240000</td>\n",
+       "      <td>3.94380</td>\n",
+       "      <td>16.310</td>\n",
+       "      <td>7.602E+02</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.000E+00</td>\n",
+       "      <td>-5.300E-17</td>\n",
+       "      <td>7.460E-33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3s_3p2_4Pe[1/2]</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>42824.290000</td>\n",
+       "      <td>2.66857</td>\n",
+       "      <td>11.036</td>\n",
+       "      <td>1.123E+03</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1.222E+04</td>\n",
+       "      <td>-5.340E-17</td>\n",
+       "      <td>7.490E-33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3s_3p2_4Pe[3/2]</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>42932.620000</td>\n",
+       "      <td>2.66532</td>\n",
+       "      <td>11.023</td>\n",
+       "      <td>1.125E+03</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2.110E+03</td>\n",
+       "      <td>-5.340E-17</td>\n",
+       "      <td>7.490E-33</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>3s_3p2_4Pe[5/2]</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>43107.910000</td>\n",
+       "      <td>2.66007</td>\n",
+       "      <td>11.001</td>\n",
+       "      <td>1.127E+03</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3.246E+03</td>\n",
+       "      <td>-5.350E-17</td>\n",
+       "      <td>7.490E-33</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             level    g      E(cm^-1) 10^15 Hz      eV     Lam(A) ID  \\\n",
+       "1  3s2_3p_2Po[1/2]  2.0      0.000000  3.95241  16.346  7.585E+02  1   \n",
+       "2  3s2_3p_2Po[3/2]  4.0    287.240000  3.94380  16.310  7.602E+02  2   \n",
+       "3  3s_3p2_4Pe[1/2]  2.0  42824.290000  2.66857  11.036  1.123E+03  3   \n",
+       "4  3s_3p2_4Pe[3/2]  4.0  42932.620000  2.66532  11.023  1.125E+03  4   \n",
+       "5  3s_3p2_4Pe[5/2]  6.0  43107.910000  2.66007  11.001  1.127E+03  5   \n",
+       "\n",
+       "        ARAD          C4         C6  \n",
+       "1  0.000E+00  -5.290E-17  7.470E-33  \n",
+       "2  0.000E+00  -5.300E-17  7.460E-33  \n",
+       "3  1.222E+04  -5.340E-17  7.490E-33  \n",
+       "4  2.110E+03  -5.340E-17  7.490E-33  \n",
+       "5  3.246E+03  -5.350E-17  7.490E-33  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Parses out the energy level data\n",
+    "df = read_data(directory_path, filename, PATTERN1, columns1)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File found at path: /Users/sashmish/Documents/personal/carsus/atomic/SIL/II/16sep15/si2_osc_kurucz\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Transition1</th>\n",
+       "      <th>Transition2</th>\n",
+       "      <th>f</th>\n",
+       "      <th>A</th>\n",
+       "      <th>Lam(A)</th>\n",
+       "      <th>i-j</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3s2_3p_2Po[1/2]</td>\n",
+       "      <td>3s_3p2_4Pe[1/2]</td>\n",
+       "      <td>5.741E-06</td>\n",
+       "      <td>7.023E+03</td>\n",
+       "      <td>2335.123</td>\n",
+       "      <td>1-   3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3s2_3p_2Po[1/2]</td>\n",
+       "      <td>3s_3p2_4Pe[3/2]</td>\n",
+       "      <td>3.564E-08</td>\n",
+       "      <td>2.191E+01</td>\n",
+       "      <td>2329.231</td>\n",
+       "      <td>1-   4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3s2_3p_2Po[1/2]</td>\n",
+       "      <td>3s_3p2_2De[3/2]</td>\n",
+       "      <td>7.638E-04</td>\n",
+       "      <td>7.793E+05</td>\n",
+       "      <td>1808.013</td>\n",
+       "      <td>1-   6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3s2_3p_2Po[1/2]</td>\n",
+       "      <td>3s2_4s_2Se[1/2]</td>\n",
+       "      <td>1.279E-01</td>\n",
+       "      <td>3.661E+08</td>\n",
+       "      <td>1526.707</td>\n",
+       "      <td>1-   8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>3s2_3p_2Po[1/2]</td>\n",
+       "      <td>3s_3p2_2Se[1/2]</td>\n",
+       "      <td>1.062E-01</td>\n",
+       "      <td>4.162E+08</td>\n",
+       "      <td>1304.370</td>\n",
+       "      <td>1-   9</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       Transition1      Transition2          f          A    Lam(A)     i-j\n",
+       "1  3s2_3p_2Po[1/2]  3s_3p2_4Pe[1/2]  5.741E-06  7.023E+03  2335.123  1-   3\n",
+       "2  3s2_3p_2Po[1/2]  3s_3p2_4Pe[3/2]  3.564E-08  2.191E+01  2329.231  1-   4\n",
+       "3  3s2_3p_2Po[1/2]  3s_3p2_2De[3/2]  7.638E-04  7.793E+05  1808.013  1-   6\n",
+       "4  3s2_3p_2Po[1/2]  3s2_4s_2Se[1/2]  1.279E-01  3.661E+08  1526.707  1-   8\n",
+       "5  3s2_3p_2Po[1/2]  3s_3p2_2Se[1/2]  1.062E-01  4.162E+08  1304.370  1-   9"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Parses out the Oscillator strengths for transitions in the energy level\n",
+    "df = read_data(directory_path, filename, PATTERN2, columns2)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scripts/parse_data_carsus/main.py
+++ b/scripts/parse_data_carsus/main.py
@@ -1,0 +1,96 @@
+import pandas as pd
+import re
+import os
+
+"""
+Python program to read the tabulated data present in si2_osc_kurucz file,
+parse them using regular expressions, and tabulate into dataframes.
+"""
+
+class ParameterException(Exception):
+    pass
+
+def find(name, path):
+    """
+    Helper function to iteratively find the required file in the directory.
+
+    Parameters
+    ----------
+    name : name of file.
+
+    path : absolute path of the directory.
+
+    Returns
+    -------
+    Absolute path of the file.
+    """
+    for root, dirs, files in os.walk(path):
+        if name in files:
+            return os.path.join(root, name)
+
+def extract_data(path):
+    """
+    Reads the data present in the file and return as a string.
+
+    Parameters
+    ----------
+    path : Absolute path to the file.
+    
+    Returns
+    -------
+    Filedata (in string format).
+    """
+    filedata = ""
+    with open(path, 'r') as f:
+        filedata += f.read()
+    return filedata
+
+def extract_tabular_data(pattern, string, columns, flags=0):
+    """
+    Extracts the tabulated data from the file according to the pattern.
+
+    Parameters
+    ----------
+    pattern : Regex pattern for matching.
+
+    string : string on which to match the expression.
+
+    columns : list of column names.
+
+    flags : (Optional) flags to be passed to matcher object.
+
+    Returns
+    -------
+    Pandas Dataframe containing the data.
+    """
+    df = pd.DataFrame(columns=columns)
+    matches = re.finditer(pattern, string, flags)
+
+    for matchNum, match in enumerate(matches, start=1):
+        for groupNum in range(0, len(match.groups())):
+            df.loc[matchNum, columns[groupNum]] = match.group(groupNum+1)
+    
+    return df
+
+def read_data(directory_path, filename, pattern, columns):
+    """
+    Driver function.
+    """
+    # Finds file and extracts data
+    file_path = find(filename, directory_path)
+    if file_path is None:
+        raise ParameterException('File not found at speified location.')
+    print('File found at path:', file_path)
+
+    filedata = extract_data(file_path)
+    
+    # Metadata parsing
+    df = extract_tabular_data(pattern, filedata, columns, re.MULTILINE)
+    return df
+    # Extraction of tabulated data
+    df1 = extract_tabular_data(PATTERN1, table1, columns1, re.MULTILINE)
+    df1.set_index("ID", inplace=True)
+    print(df1.head())
+
+    df2 = extract_tabular_data(PATTERN2, table2, columns2, re.MULTILINE)
+    print(df2.head())

--- a/scripts/parse_data_carsus/test.py
+++ b/scripts/parse_data_carsus/test.py
@@ -1,0 +1,27 @@
+import pytest
+from scripts.parse_data_carsus.main import read_data, ParameterException
+
+# Predefined Data
+filename = 'si2_osc_kurucz'
+directory_path = '/Users/sashmish/Documents/personal/carsus/atomic/'
+    
+METADATA = r'^([\w\-\.]+)\s+!([\w ]+)$'
+PATTERN1 = r'^([\w\[\]\(\)\/]+)\s+([\w\.]+)\s+([+-]?[\d\.]+)\s+([+-]?[\d\.]+)\s+([+-]?[\d\.]+)\s+([+-]?[\dE\.\+\-]+)\s+([+-]?\d+)\s+([+-]?[\dE\.\+\-]+)\s+([+-]?[\dE\.\+\-]+)\s+([+-]?[\dE\.\+\-]+)'
+PATTERN2 = r'^([\w\[\]\(\)\/]+)\s*-([\w\[\]\(\)\/]+)\s+([+-]?[\dE\.\+\-]+)\s+([+-]?[\dE\.\+\-]+)\s+([+-]?[\dE\.\+\-]+)\s+(\d+-\s*\d+)'
+
+columns_meta = ['Value', 'Name']
+columns1 = ['level','g','E(cm^-1)','10^15 Hz','eV','Lam(A)','ID','ARAD','C4','C6']
+columns2 = ['Transition1','Transition2','f','A','Lam(A)','i-j']
+    
+@pytest.mark.parametrize("pattern, columns", [(PATTERN1, columns1), (PATTERN2, columns2)])
+def test_table(pattern, columns):
+    df = read_data(directory_path, filename, pattern, columns)
+    assert all(df.columns == columns)
+
+def test_metadata():
+    df = read_data(directory_path, filename, METADATA, columns_meta)
+    assert all(df.columns == columns_meta)
+
+def test_incorrect_filename():
+    with pytest.raises(ParameterException):
+        read_data(directory_path, 'si2_osc_kurucz1', METADATA, columns_meta)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This acts as the intro project for the GSoC idea for `carsus_atomic_data`. This creates required regular expressions for the `si2_osc_kurucz` data and parses into different data frames.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All testing has been done using `pytest`
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
