### PR TITLE
Add skip condition if QT_API is no set (issue #1101)

### DIFF
--- a/tardis/gui/interface.py
+++ b/tardis/gui/interface.py
@@ -63,3 +63,4 @@ if __name__=='__main__':
     atomfile = sys.argv[2]
     mdl = run_tardis(yamlfile, atomfile)
     show(mdl) 
+

--- a/tardis/gui/interface.py
+++ b/tardis/gui/interface.py
@@ -9,8 +9,8 @@ else:
         ' export QT_API=pyqt \n\n For more information refer to user guide.')
 import sys
 try:
-    from IPython.lib.guisupport import get_app_qt4, start_event_loop_qt4
-    from IPython.lib.guisupport import is_event_loop_running_qt4
+    from IPython.lib.guisupport import get_app_qt5, start_event_loop_qt5
+    from IPython.lib.guisupport import is_event_loop_running_qt5
     importFailed = False 
 except ImportError:
     importFailed = True
@@ -36,7 +36,7 @@ def show(model):
     if importFailed:
         app = QtWidgets.QApplication([])
     else:
-        app = get_app_qt4()
+        app = get_app_qt5()
 
     tablemodel = SimpleTableModel
     win = Tardis(tablemodel)
@@ -45,13 +45,13 @@ def show(model):
     if importFailed:
         app.exec_()
     else:
-        start_event_loop_qt4(app)
+        start_event_loop_qt5(app)
 
         #If the IPython console is being used, this will evaluate to true.
         #In that case the window created will be garbage collected unless a 
         #reference to it is maintained after this function exits. So the win is
         #returned.
-        if is_event_loop_running_qt4(app):
+        if is_event_loop_running_qt5(app):
             return win
 
 if __name__=='__main__':

--- a/tardis/gui/tests/test_gui.py
+++ b/tardis/gui/tests/test_gui.py
@@ -3,7 +3,8 @@ import pytest
 from tardis.io.config_reader import Configuration
 from tardis.simulation import Simulation
 import astropy.units as u
-import tardis.gui as gui
+from tardis.gui.widgets import Tardis 
+from tardis.gui.datahandler import SimpleTableModel
 from PyQt5 import QtWidgets
 
 

--- a/tardis/gui/tests/test_gui.py
+++ b/tardis/gui/tests/test_gui.py
@@ -3,9 +3,7 @@ import pytest
 from tardis.io.config_reader import Configuration
 from tardis.simulation import Simulation
 import astropy.units as u
-from tardis.gui import interface
-from tardis.gui.widgets import Tardis 
-from tardis.gui.datahandler import SimpleTableModel
+import tardis.gui as gui
 from PyQt5 import QtWidgets
 
 
@@ -39,11 +37,12 @@ def simulation_one_loop(
     simulation.run()
 
     return simulation
-
+    
+@pytest.mark.skipif('QT_API' not in os.environ, reason="enviroment variable QT_API is not set")
 def test_gui(simulation_one_loop):
     simulation = simulation_one_loop
     app = QtWidgets.QApplication([])
-    tablemodel = SimpleTableModel
-    win = Tardis(tablemodel)
+    tablemodel =gui.datahandler.SimpleTableModel
+    win = gui.widgets.Tardis(tablemodel)
     win.show_model(simulation)
     app.quit()

--- a/tardis/gui/tests/test_gui.py
+++ b/tardis/gui/tests/test_gui.py
@@ -42,7 +42,7 @@ def simulation_one_loop(
 def test_gui(simulation_one_loop):
     simulation = simulation_one_loop
     app = QtWidgets.QApplication([])
-    tablemodel =gui.datahandler.SimpleTableModel
-    win = gui.widgets.Tardis(tablemodel)
+    tablemodel = SimpleTableModel
+    win = Tardis(tablemodel)
     win.show_model(simulation)
     app.quit()

--- a/tardis/gui/widgets.py
+++ b/tardis/gui/widgets.py
@@ -14,8 +14,8 @@ else:
 import matplotlib
 from matplotlib.figure import *
 import matplotlib.gridspec as gridspec
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4 import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qt5 import NavigationToolbar2QT as NavigationToolbar
 from matplotlib import colors
 from matplotlib.patches import Circle
 import matplotlib.pylab as plt
@@ -1066,13 +1066,13 @@ class Tardis(QtWidgets.QMainWindow):
         """
 
         #assumes that qt has already been initialized by starting IPython
-        #with the flag "--pylab=qt"
+        #with the flag "--pylab=qt"gut
         # app = QtCore.QCoreApplication.instance()
         # if app is None:
         #     app = QtGui.QApplication([])
         # try:
-        #     from IPython.lib.guisupport import start_event_loop_qt4
-        #     start_event_loop_qt4(app)
+        #     from IPython.lib.guisupport import start_event_loop_qt5
+        #     start_event_loop_qt5(app)
         # except ImportError:
         #     app.exec_()
 


### PR DESCRIPTION
`pytest tardis` fails on import of gui interface and widgets if QT_API variable is not set

## Description
 The issue appears on import (and I still don't how skipimport would work but I'll revisit at some point). I changed the call so that the import wouldn't check inside the module until needed for the test by importing the whole module. Following this some of the objects inside the function have to be called more explicitly.

I added the skipif decorator from pytest. The test now skips when the variable QT_API is not defined, but I'm not sure how the `pytest tardis` should proceed when the variable is defined. When I define QT_API either way on my master branch the test still skips, which I suppose is the expected behaviour because I didn't modify anything there. 

On a different commit I modified the functions interface and widgets to change how the Iphyton library calls specific functions, as can be seen this changes a qt4 to a qt5 and is purely for consistency, given that the functions are the same.

## Motivation and Context
Adresses #1101 

## How Has This Been Tested?
Run `pytest tardis` and the test now skips when QT_API is not declared.
Run again for the Iphyton calls change.
Giving( to save as reference)
263 passed, 1119 skipped, 1 xfailed in 24.38 seconds

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


All input is appreciated.