### PR TITLE
add extension of Dataframe to support units

### DIFF
--- a/tardis/model/tests/test_udata.py
+++ b/tardis/model/tests/test_udata.py
@@ -1,0 +1,39 @@
+import os
+import pandas as pd
+import pytest
+import astropy.units as u
+from ..udata import UDataFrame
+
+
+@pytest.fixture(scope="module")
+def units_series():
+    return pd.Series([u.meter, None, u.kg, None, u.Ohm])
+
+@pytest.fixture(scope="module")
+def units_list():
+    return [u.meter, None, u.kg, None, u.Ohm]
+
+@pytest.fixture(scope="module")
+def sample_data():
+    return pd.DataFrame(data = pd.np.random.randint(0, 50, (10, 5)),
+                        columns=['A','B','C','D','E'])
+
+@pytest.fixture(scope="module")
+def sample_udata(sample_data, units_list):
+    return UDataFrame(sample_data, units=units_list)
+
+def test_creation_utable(sample_udata, units_list, units_series):
+    for i in range(len(units_series)):
+        assert sample_udata.units[i] == units_series[i]
+        assert sample_udata.units[i] == units_list[i]
+
+    assert sample_udata.get_unit('A') == u.meter
+    with pytest.raises(ValueError):
+        sample_udata.get_unit('F')
+    
+    sample_udata.set_unit('B', u.second)
+    assert sample_udata.get_unit('B') == u.second
+
+def test_copy(sample_udata):
+    new_data = sample_udata.copy()
+    assert new_data.units.equals(sample_udata.units)

--- a/tardis/model/udata.py
+++ b/tardis/model/udata.py
@@ -1,0 +1,116 @@
+import numpy as np
+
+from pandas import DataFrame, Series
+
+from astropy.units import Unit
+
+class UDataFrame(DataFrame):
+    """
+    An extension of the `~pandas.Dataframe`, which stores the units of
+    the columns as well and preserve during basic operations.
+
+    Parameters
+    ----------
+    data : The actual data to be stored in dataframe
+
+    units : pandas.Series of either astropy.units or None
+            It stores the units corresponding to the columns of the data
+    
+    Examples
+    --------
+    >>> from tardis.model.udata import Udataframe
+    >>> from pandas import DataFrame, Series
+    >>> udata = UDataFrame(data=DataFrame(data = pd.np.random.randint(0, 50, (10, 5)),
+                           columns=['A','B','C','D','E'],
+                           units=Series([u.meter, None, u.kg, None, u.Ohm])
+    """
+
+    _metadata = ['units']
+
+    @property
+    def _constructor(self):
+        return UDataFrame
+
+    def __init__(self, data, units, **kwargs):
+        units = Series(kwargs.pop("units", None))
+        super().__init__(**kwargs)
+        self.units = units
+
+    def _verify_len_unit(self):
+        """
+        Verify if all the columns have an entry in the
+        Series of units.
+        """
+        return True if len(self.columns) == len(self.units) else False
+
+    def _verify_type_units(self):
+        """
+        Verify if all elements of units are either of type
+        `~astropy.units.Unit` or None
+        """
+        return True if all(type(self.units) is Unit or None) else False 
+
+    @property
+    def units(self):
+        return self._units
+
+    @units.setter
+    def units(self, u):
+        if self._verify_len_unit and self._verify_type_units:
+            if type(u) is Series:
+                self._units = u
+            elif type(u) is list:
+                self._units = Series(u)
+            else:
+                raise TypeError("Units must be either a pandas.Series or a list")
+        else:
+            raise ValueError("The units must be of same length as that of data,",
+                             " and elements must be either of type astropy.units.Unit or None")
+
+    def get_unit(self, column_name):
+        """
+        Function to get unit of a column
+
+        Parameters
+        ----------
+        column_name : str
+               Column Name
+        
+        Returns
+        -------
+        `~astropy.units.Unit` or None
+        """
+        if column_name not in self.columns:
+            raise ValueError("Invalid column name")
+        
+        i = list(self.columns).index(column_name)
+        return self.units[i]
+
+    def set_unit(self, column_name, unit_name):
+        """
+        Function to set unit of a column
+
+        Parameters
+        ----------
+        column_name : str
+               Column Name
+        unit_name : `~astropy.units.Unit` or None
+                    Unit to be set to the column
+        """
+        if column_name not in self.columns:
+            raise ValueError("Invalid column name")
+        
+        i = list(self.columns).index(column_name)
+        self.units[i] = unit_name
+
+    def copy(self):
+        """
+        Creates a copy of the original dataframe
+
+        Returns
+        -------
+        `~tardis.model.udata.UDataFrame
+        """
+        cp = UDataFrame(self)
+        cp.units = self.units
+        return cp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This acts as the intro project for the GSoC idea for **Quantity-ify TARDIS**. This creates an extension of `pandas.DataFrame` that supports the handling of column units.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All testing has been done using `pytest`.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
