### PR TITLE
Fix the encoding error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ elif os.path.exists('LONG_DESCRIPTION.rst'):
         LONG_DESCRIPTION = f.read()
 
 elif len(glob.glob(readme_glob)) > 0:
-    with open(glob.glob(readme_glob)[0]) as f:
+    with open(glob.glob(readme_glob)[0], encoding='utf-8') as f:
         LONG_DESCRIPTION = f.read()
 
 else:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed a potential error in setup.py, which may raises UnicodeDecodeError because  the docstring in the module has a Unicode character and our unpickler doesn't specify any encoding (thus defaulting to ascii).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
os: ubuntu::latest (DockerHub)

After built a new docker container for tardis and followed the Installation guide to create a development environment, I met this question as follow:

```Python
(tardis) root@8c64da05046f:/usr/depot/tardis# python setup.py develop
Traceback (most recent call last):
  File "setup.py", line 58, in <module>
    LONG_DESCRIPTION = f.read()
  File "/usr/local/bin/miniconda3/envs/tardis/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3223: ordinal not in range(128)
```

The problem is that the docstring in the module has a Unicode character and our unpickler doesn't specify any encoding (thus defaulting to ascii).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running `python setup.py test` gave no errors.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
