### PR TITLE
Solve pending issues of the release pipeline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ The following bibtex entries are needed for the references.
     }
 
 
-    @misc{kerzendorf_wolfgang_2019_2590539,
+    @software{kerzendorf_wolfgang_2019_2590539,
       author       = {Kerzendorf, Wolfgang and
                       Nöbauer, Ulrich and
                       Sim, Stuart and

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -95,9 +95,12 @@ jobs:
       #  displayName: "Look for changes in JSON"
 
       - bash: |
-          REPO=`git config remote.origin.url`
-          SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+          set -e
 
+          cd ..
+          git clone git@github.com:tardis-sn/tardis.git out
+          cd out
+          
           git config --local user.name "Azure Pipelines"
           git config --local user.email "azuredevops@microsoft.com"
           cp $(tardis.zenodo.home)/.zenodo.json .zenodo.json
@@ -108,9 +111,8 @@ jobs:
              exit 0
           else
             git commit -m "Update zenodo.json"
-            git push $SSH_REPO master
-          fi
-
+            git push origin master
+          fi  
         displayName: "Push zenodo.json to master branch"
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -16,6 +16,7 @@ schedules:
 variables:
   system.debug: "true"
   tardis.zenodo.home: "$(Agent.BuildDirectory)/tardis_zenodo"
+  tardis.zenodo.access: $(epassaro_pat)
   tardis.build.dir: $(Build.Repository.LocalPath)
 
 pool:
@@ -67,7 +68,7 @@ jobs:
 
       - bash: |
           cd ..
-          git clone git@github.com:tardis-sn/tardis_zenodo.git
+          git clone https://$(tardis.zenodo.access)@github.com/tardis-sn/tardis_zenodo.git
         displayName: "Clone tardis_zenodo repo"
 
       - bash: |

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -100,7 +100,8 @@ jobs:
 
           git config --local user.name "Azure Pipelines"
           git config --local user.email "azuredevops@microsoft.com"
-          git add zenodo.json
+          cp $(tardis.zenodo.home)/.zenodo.json .zenodo.json
+          git add .zenodo.json
 
           if git diff --staged --quiet; then
              echo "Exiting with no changes"

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: none
+pr: [ master ]
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly build
@@ -25,6 +25,17 @@ jobs:
   - job: zenodo_json
     displayName: Create Zenodo JSON file
     steps:
+
+      - task: DownloadSecureFile@1
+        inputs: 
+          secureFile: 'id_azure_rsa'
+
+      - task: InstallSSHKey@0
+        inputs:
+         knownHostsEntry: $(gh_host)
+         sshPublicKey: $(public_key)
+         sshKeySecureFile: 'id_azure_rsa'
+
       - task: DownloadSecureFile@1
         name: zenodoSecretKey
         displayName: "Download Zenodo secret key"
@@ -54,12 +65,10 @@ jobs:
           conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
         displayName: "Create Zenodo env"
 
-      # Actually this is a workaround. We need to grab this from `tardis_zenodo` private repo.
       - bash: |
-          cd ..; mkdir tardis_zenodo
-          cd $(tardis.zenodo.home)
-          wget https://gist.githubusercontent.com/epassaro/12364cd3b33e4b2923ff1861d80ef6d8/raw/d71ca46ca1816f6f46c768314c2da59ed017861e/gather_data.ipynb
-        displayName: "Downloading notebook (workaround)"
+          cd ..
+          git clone git@github.com:tardis-sn/tardis_zenodo.git
+        displayName: "Clone tardis_zenodo repo"
 
       - bash: |
           cp $(zenodoSecretKey.secureFilePath) $(tardis.zenodo.home)

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -90,9 +90,27 @@ jobs:
         displayName: "Running notebook (not allow errors)"
 
       # This step should fail if there are changes in .zenodo.json
+      #- bash: |
+      #    diff $(tardis.zenodo.home)/.zenodo.json .zenodo.json
+      #  displayName: "Look for changes in JSON"
+
       - bash: |
-          diff $(tardis.zenodo.home)/.zenodo.json .zenodo.json
-        displayName: "Look for changes in JSON"
+          REPO=`git config remote.origin.url`
+          SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
+
+          git config --local user.name "Azure Pipelines"
+          git config --local user.email "azuredevops@microsoft.com"
+          git add zenodo.json
+
+          if git diff --staged --quiet; then
+             echo "Exiting with no changes"
+             exit 0
+          else
+            git commit -m "Update zenodo.json"
+            git push $SSH_REPO master
+          fi
+
+        displayName: "Push zenodo.json to master branch"
 
       - task: PublishPipelineArtifact@1
         inputs:

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: [ master ]
+pr: none
 schedules:
   - cron: "30 22 * * 0"
     displayName: Weekly build

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -78,7 +78,7 @@ The following bibtex entries are needed for the references.
     }
 
 
-    @misc{kerzendorf_wolfgang_2019_2590539,
+    @software{kerzendorf_wolfgang_2019_2590539,
       author       = {Kerzendorf, Wolfgang and
                       Nöbauer, Ulrich and
                       Sim, Stuart and


### PR DESCRIPTION
**Changes:**

- [x] Clone `tardis_zenodo` from private repo and remove the workaround.
- [x] Automatic push new `zenodo.json` to `master` branch.
- [x] Deactivate PR `master` trigger before merge.

**Next steps:**

1. Split the pipeline in two: one that creates the `zenodo.json` file and other  that makes the release.
2. Auto-update citation in `docs/credits.rst` and `README.rst`.