### PR TITLE
Added more file types to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__
 */cython_version.py
 htmlcov
 .coverage
+.ipynb_checkpoints/
 
 
 # IDE Specific files
@@ -40,11 +41,13 @@ local.properties
 
 # Sphinx
 _build
+docs/api
 
 
 # Packages/installer info
 *.egg
 *.egg-info
+.eggs/
 dist
 build
 eggs


### PR DESCRIPTION
There are several filetypes that should go in `.gitignore` to prevent the developer mistakenly committing undesired files - so I've added following, which I encountered:
1. `.ipynb_checkpoints/` - It gets generated when any notebook present in repository is executed locally.
2. `.eggs/` - The dir which contain all `.egg` files and a README.txt (describing what it is purpose of it) - though `.egg` files are already ignored but not this readme file, so I ignored the entire dir
3. `docs/api` - It contains API docs which get auto-generated each time when building docs - they are around 64 files which need not to be committed as the docs pipeline automatically generates them on each build.