### PR TITLE
fix warnings in quickstart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ distribute-*.tar.gz
 
 # Mac OSX
 .DS_Store
+
+# Jupyter checkpoints
+.ipynb_checkpoints

--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -216,6 +216,9 @@ class AtomData(object):
         # Convert energy to CGS
         levels.loc[:, "energy"] = Quantity(levels["energy"].values, 'eV').cgs
 
+        # Sort the dataframe before indexing to improve performance
+        lines.sort_index(inplace=True)
+
         # Create a new columns with wavelengths in the CGS units
         lines.loc[:, 'wavelength_cm'] = Quantity(
                 lines['wavelength'], 'angstrom').cgs

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 
 import requests
 import yaml
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 
 from tardis import constants
 from astropy import units as u


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the warnings in the quickstart of tardis.
- `tqdm` does not throw a `TqdmExperimentalWarning` when ran on the notebook.
- Improve the performance of dataframe slicing using presorting.

`pyne.data` warning is due to memory issue ([under discussion](https://groups.google.com/forum/#!msg/pyne-dev/rWpV2ZqU8kQ/pbSnn2d2CgAJ))
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
