### PR TITLE
Split release pipeline

### DIFF
--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -15,123 +15,14 @@ schedules:
 
 variables:
   system.debug: "true"
-  tardis.zenodo.home: "$(Agent.BuildDirectory)/tardis_zenodo"
-  tardis.zenodo.access: $(epassaro_pat)
   tardis.build.dir: $(Build.Repository.LocalPath)
 
 pool:
   vmImage: "ubuntu-latest"
 
 jobs:
-  - job: zenodo_json
-    displayName: Create Zenodo JSON file
-    steps:
-
-      - task: DownloadSecureFile@1
-        inputs: 
-          secureFile: 'id_azure_rsa'
-
-      - task: InstallSSHKey@0
-        inputs:
-         knownHostsEntry: $(gh_host)
-         sshPublicKey: $(public_key)
-         sshKeySecureFile: 'id_azure_rsa'
-
-      - task: DownloadSecureFile@1
-        name: zenodoSecretKey
-        displayName: "Download Zenodo secret key"
-        inputs:
-          secureFile: "key_secret.json"
-
-      - task: DownloadSecureFile@1
-        name: authorOrder
-        displayName: "Download author order file"
-        inputs:
-          secureFile: "author_order.txt"
-
-      - task: DownloadSecureFile@1
-        name: nonCommitContributors
-        displayName: "Download non commit contributors file"
-        inputs:
-          secureFile: "non_commit_contributors.txt"
-
-      - bash: |
-          echo "##vso[task.prependpath]$CONDA/bin"
-          sudo chown -R $USER $CONDA
-        displayName: "Add CONDA to path"
-
-      - bash: |
-          conda create -n zenodo python=3.6 --yes
-          source activate zenodo
-          conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
-        displayName: "Create Zenodo env"
-
-      - bash: |
-          cd ..
-          git clone https://$(tardis.zenodo.access)@github.com/tardis-sn/tardis_zenodo.git
-        displayName: "Clone tardis_zenodo repo"
-
-      - bash: |
-          cp $(zenodoSecretKey.secureFilePath) $(tardis.zenodo.home)
-          cp $(authorOrder.secureFilePath) $(tardis.zenodo.home)
-          cp $(nonCommitContributors.secureFilePath) $(tardis.zenodo.home)
-        displayName: "Recovering secrets"
-
-      - bash: |
-          source activate zenodo
-          cd $(tardis.zenodo.home)
-          jupyter nbconvert gather_data.ipynb --to html --allow-errors --execute --ExecutePreprocessor.timeout=6000
-        displayName: "Running notebook (allow errors)"
-
-      - bash: |
-          source activate zenodo
-          cd $(tardis.zenodo.home)
-          jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
-        displayName: "Running notebook (not allow errors)"
-
-      # This step should fail if there are changes in .zenodo.json
-      #- bash: |
-      #    diff $(tardis.zenodo.home)/.zenodo.json .zenodo.json
-      #  displayName: "Look for changes in JSON"
-
-      - bash: |
-          set -e
-
-          cd ..
-          git clone git@github.com:tardis-sn/tardis.git out
-          cd out
-          
-          git config --local user.name "Azure Pipelines"
-          git config --local user.email "azuredevops@microsoft.com"
-          cp $(tardis.zenodo.home)/.zenodo.json .zenodo.json
-          git add .zenodo.json
-
-          if git diff --staged --quiet; then
-             echo "Exiting with no changes"
-             exit 0
-          else
-            git commit -m "Update zenodo.json"
-            git push origin master
-          fi  
-        displayName: "Push zenodo.json to master branch"
-
-      - task: PublishPipelineArtifact@1
-        inputs:
-          targetPath: "$(tardis.zenodo.home)/.zenodo.json"
-          artifact: "zenodo_json"
-          publishLocation: "pipeline"
-        condition: succeededOrFailed()
-
-      - task: PublishPipelineArtifact@1
-        inputs:
-          targetPath: "$(tardis.zenodo.home)/gather_data.html"
-          artifact: "report"
-          publishLocation: "pipeline"
-        condition: succeededOrFailed()
-
   - job: gh_release
     displayName: Upload GitHub release
-    dependsOn: zenodo_json
     steps:
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"

--- a/azure-pipelines/update-zenodo-json.yml
+++ b/azure-pipelines/update-zenodo-json.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-pr: none
+#pr: none
 schedules:
   - cron: "30 22 * * 5"
     displayName: Weekly update

--- a/azure-pipelines/update-zenodo-json.yml
+++ b/azure-pipelines/update-zenodo-json.yml
@@ -110,7 +110,7 @@ jobs:
              echo "Exiting with no changes"
              exit 0
           else
-            git commit -m "Update zenodo.json"
+            git commit -m "Update zenodo.json [skip ci]"
             git push origin master
           fi  
         displayName: "Push zenodo.json to master branch"

--- a/azure-pipelines/update-zenodo-json.yml
+++ b/azure-pipelines/update-zenodo-json.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger: none
-#pr: none
+pr: none
 schedules:
   - cron: "30 22 * * 5"
     displayName: Weekly update
@@ -26,16 +26,15 @@ jobs:
   - job: zenodo_json
     displayName: Create Zenodo JSON file
     steps:
-
       - task: DownloadSecureFile@1
-        inputs: 
-          secureFile: 'id_azure_rsa'
+        inputs:
+          secureFile: "id_azure_rsa"
 
       - task: InstallSSHKey@0
         inputs:
-         knownHostsEntry: $(gh_host)
-         sshPublicKey: $(public_key)
-         sshKeySecureFile: 'id_azure_rsa'
+          knownHostsEntry: $(gh_host)
+          sshPublicKey: $(public_key)
+          sshKeySecureFile: "id_azure_rsa"
 
       - task: DownloadSecureFile@1
         name: zenodoSecretKey
@@ -100,7 +99,7 @@ jobs:
           cd ..
           git clone git@github.com:tardis-sn/tardis.git out
           cd out
-          
+
           git config --local user.name "Azure Pipelines"
           git config --local user.email "azuredevops@microsoft.com"
           cp $(tardis.zenodo.home)/.zenodo.json .zenodo.json
@@ -112,7 +111,7 @@ jobs:
           else
             git commit -m "Update zenodo.json [skip ci]"
             git push origin master
-          fi  
+          fi
         displayName: "Push zenodo.json to master branch"
 
       - task: PublishPipelineArtifact@1

--- a/update-zenodo-json.yml
+++ b/update-zenodo-json.yml
@@ -1,0 +1,130 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger: none
+pr: none
+schedules:
+  - cron: "30 22 * * 5"
+    displayName: Weekly update
+    branches:
+      include:
+        - master
+    always: true
+
+variables:
+  system.debug: "true"
+  tardis.zenodo.home: "$(Agent.BuildDirectory)/tardis_zenodo"
+  tardis.zenodo.access: $(epassaro_pat)
+  tardis.build.dir: $(Build.Repository.LocalPath)
+
+pool:
+  vmImage: "ubuntu-latest"
+
+jobs:
+  - job: zenodo_json
+    displayName: Create Zenodo JSON file
+    steps:
+
+      - task: DownloadSecureFile@1
+        inputs: 
+          secureFile: 'id_azure_rsa'
+
+      - task: InstallSSHKey@0
+        inputs:
+         knownHostsEntry: $(gh_host)
+         sshPublicKey: $(public_key)
+         sshKeySecureFile: 'id_azure_rsa'
+
+      - task: DownloadSecureFile@1
+        name: zenodoSecretKey
+        displayName: "Download Zenodo secret key"
+        inputs:
+          secureFile: "key_secret.json"
+
+      - task: DownloadSecureFile@1
+        name: authorOrder
+        displayName: "Download author order file"
+        inputs:
+          secureFile: "author_order.txt"
+
+      - task: DownloadSecureFile@1
+        name: nonCommitContributors
+        displayName: "Download non commit contributors file"
+        inputs:
+          secureFile: "non_commit_contributors.txt"
+
+      - bash: |
+          echo "##vso[task.prependpath]$CONDA/bin"
+          sudo chown -R $USER $CONDA
+        displayName: "Add CONDA to path"
+
+      - bash: |
+          conda create -n zenodo python=3.6 --yes
+          source activate zenodo
+          conda install jupyter nbconvert numpy pandas orcid -c conda-forge --yes
+        displayName: "Create Zenodo env"
+
+      - bash: |
+          cd ..
+          git clone https://$(tardis.zenodo.access)@github.com/tardis-sn/tardis_zenodo.git
+        displayName: "Clone tardis_zenodo repo"
+
+      - bash: |
+          cp $(zenodoSecretKey.secureFilePath) $(tardis.zenodo.home)
+          cp $(authorOrder.secureFilePath) $(tardis.zenodo.home)
+          cp $(nonCommitContributors.secureFilePath) $(tardis.zenodo.home)
+        displayName: "Recovering secrets"
+
+      - bash: |
+          source activate zenodo
+          cd $(tardis.zenodo.home)
+          jupyter nbconvert gather_data.ipynb --to html --allow-errors --execute --ExecutePreprocessor.timeout=6000
+        displayName: "Running notebook (allow errors)"
+
+      - bash: |
+          source activate zenodo
+          cd $(tardis.zenodo.home)
+          jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
+        displayName: "Running notebook (not allow errors)"
+
+      # This step should fail if there are changes in .zenodo.json
+      #- bash: |
+      #    diff $(tardis.zenodo.home)/.zenodo.json .zenodo.json
+      #  displayName: "Look for changes in JSON"
+
+      - bash: |
+          set -e
+
+          cd ..
+          git clone git@github.com:tardis-sn/tardis.git out
+          cd out
+          
+          git config --local user.name "Azure Pipelines"
+          git config --local user.email "azuredevops@microsoft.com"
+          cp $(tardis.zenodo.home)/.zenodo.json .zenodo.json
+          git add .zenodo.json
+
+          if git diff --staged --quiet; then
+             echo "Exiting with no changes"
+             exit 0
+          else
+            git commit -m "Update zenodo.json"
+            git push origin master
+          fi  
+        displayName: "Push zenodo.json to master branch"
+
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: "$(tardis.zenodo.home)/.zenodo.json"
+          artifact: "zenodo_json"
+          publishLocation: "pipeline"
+        condition: succeededOrFailed()
+
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: "$(tardis.zenodo.home)/gather_data.html"
+          artifact: "report"
+          publishLocation: "pipeline"
+        condition: succeededOrFailed()


### PR DESCRIPTION
Split the release pipeline in two pipelines:

1. One that updates `zenodo.json` weekly (if necessary).
2. One that makes the TARDIS release weekly.

Advantages:

- It's clearer and easier to mantain two small pipelines than a large one.
- Both pipelines are independent. So we will have a new TARDIS release every Sunday, no matter if there's any problem when generating the JSON file (incomplete or duplicated author names).

Currently these pipelines are scheduled to run on Friday and Sunday respectively.