### PR TITLE
Set manual trigger on file (compare refdata)

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -3,6 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
+trigger: none
+pr: none
+
 variables:
   system.debug: "true"
   ref.data.home: "$(Agent.BuildDirectory)/tardis-refdata"


### PR DESCRIPTION
Azure allows to set up pipeline triggers through the web-gui or explicitly in the YAML file. The web-gui settings always override the YAML configuration, but this configuration is not visible for developers without access to the Azure dashboard.

Making the configuration explicit in the YAML file is way more clean and clear.
