### PR TITLE
Montecarlo/fix omp integrator

### DIFF
--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -169,7 +169,8 @@ _formal_integral(
   double R_max = storage->r_outer_i[size_shell - 1];
   double pp[N];
   double *exp_tau = calloc(size_tau, sizeof(double));
-#pragma omp parallel firstprivate(L, exp_tau)
+//#pragma omp parallel firstprivate(L, exp_tau)
+#pragma omp parallel 
     {
 
 #pragma omp master
@@ -336,8 +337,8 @@ _formal_integral(
           }
         }
       // Free everything allocated on heap
-      free(exp_tau);
       printf("\n");
     }
+      free(exp_tau);
   return L;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed computing the integrated spectrum when running in parallel.
Fix for https://github.com/tardis-sn/tardis/issues/1019
## Description
<!--- Describe your changes in detail -->
Removed the firstprivate declaration at the first omp parallel pragma, as there was no need to copy the pointers for L and exp_tau to each thread.  I then moved the free call on exp_tau outside of the parallel segment so that the memory allocation and deallocation are done outside of the parallel block.
## Motivation and Context
Computing the integrated spectrum on models with nthreads>1 caused a double free error.

## How Has This Been Tested?
Ran two identical models, one with 32 threads and another with a single thread and compared the output integrated spectra.  The largest error between them was 3.3%, which seems to be within a reasonable range for the monte carlo.  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
