### PR TITLE
Fix broken pipelines

### DIFF
--- a/azure-pipelines/simple_test_framework.yml
+++ b/azure-pipelines/simple_test_framework.yml
@@ -61,7 +61,7 @@ jobs:
         pip install git+https://github.com/tonybaloney/pytest-azurepipelines.git
         export QT_API=pyqt
         pytest tardis --tardis-refdata=$(ref.data.home) --cov=tardis --cov-report=xml --cov-report=html
-        export QT_API=pyqt
+
     displayName: 'TARDIS test'
   - script: |
       bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Pipelines are passing :heavy_check_mark: despite tests are failing.

This happens because the last step of the task:

```
  - bash: |
        source activate tardis
        conda install -y pytest-cov
        pip install git+https://github.com/tonybaloney/pytest-azurepipelines.git
        export QT_API=pyqt
        pytest tardis --tardis-refdata=$(ref.data.home) --cov=tardis --cov-report=xml --cov-report=html
        export QT_API=pyqt
    displayName: 'TARDIS test'
``` 

gives an exit code `0`. 

Removing that duplicated line solves the issue. The pipeline will fail now but that's correct.