### PR TITLE
Fix callbacks in run_tardis

### DIFF
--- a/tardis/base.py
+++ b/tardis/base.py
@@ -39,7 +39,7 @@ def run_tardis(config, atom_data=None, packet_source=None,
                                         packet_source=packet_source,
                                         atom_data=atom_data)
     for cb in simulation_callbacks:
-        simulation.add_callback(cb)
+        simulation.add_callback(*cb)
 
     simulation.run()
 

--- a/tardis/montecarlo/src/integrator.c
+++ b/tardis/montecarlo/src/integrator.c
@@ -169,7 +169,8 @@ _formal_integral(
   double R_max = storage->r_outer_i[size_shell - 1];
   double pp[N];
   double *exp_tau = calloc(size_tau, sizeof(double));
-#pragma omp parallel firstprivate(L, exp_tau)
+//#pragma omp parallel firstprivate(L, exp_tau)
+#pragma omp parallel 
     {
 
 #pragma omp master
@@ -336,8 +337,8 @@ _formal_integral(
           }
         }
       // Free everything allocated on heap
-      free(exp_tau);
       printf("\n");
     }
+      free(exp_tau);
   return L;
 }

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -384,7 +384,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
          The callback ID
         """
         cb_id = self._cb_next_id
-        self._callbacks[cb_id] = (cb_func, args)
+        self._callbacks[cb_id] = (cb_func, (self,)+args)
         self._cb_next_id += 1
         return cb_id
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
run_tardis allows users to specify a list of callbacks to be run at each iteration of the simulation.  The current version does not allow a user to specify any extra arguments or access any attributes of the simulation itself.
## Description
<!--- Describe your changes in detail -->
when run_tardis allocates callbacks, it now adds them using the *unpacking syntax to allow for arguments to be passed along with the callback function.
Callback assignment now sets the instance of the simulation as the first argument of the callback function.  This allows users to specify functions that can act on the simulation object itself.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The ability to use callbacks with the tardis model was severely limited.  Now callbacks can give live feedback on the simulation as it runs.
## How Has This Been Tested?
I ran through the test modules and none of the failed.  I also wrote a few functions to perform various simple tasks like printing the iteration number at each iteration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
