### PR TITLE
Add note for linux and macos (issue #1125)

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ simple TARDIS calculations.
 .. notes::
         
     TARDIS is only compatbile with Python >3.6
-    TARDIS only supports Linux and MacOs
+    TARDIS only supports Linux and MacOs.
     We strongly recommend to install TARDIS within an Anaconda environment and
     to always use the lastest github development version.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,12 +13,10 @@ simple TARDIS calculations.
 
 .. _requirements_label:
 
-
-.. warning::
-
+.. notes::
+        
     TARDIS is only compatbile with Python >3.6
-
-.. note::
+    TARDIS only supports Linux and MacOs
     We strongly recommend to install TARDIS within an Anaconda environment and
     to always use the lastest github development version.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,12 +13,11 @@ simple TARDIS calculations.
 
 .. _requirements_label:
 
-.. notes::
+.. note::
         
-    TARDIS is only compatbile with Python >3.6
-    TARDIS only supports Linux and MacOs.
-    We strongly recommend to install TARDIS within an Anaconda environment and
-    to always use the lastest github development version.
+    - TARDIS is only compatbile with Python >3.6
+    - TARDIS only supports Linux and MacOs.
+    - We strongly recommend to install TARDIS within an Anaconda environment and to always use the lastest github development version.
 
 Requirements
 ============


### PR DESCRIPTION
TARDIS only works on MacOs and Linux distributions and we need to let the users know.
## How Has This Been Tested?
`python setup.py build_docs`  works!

## Screenshot
![Screenshot from 2020-06-17 12-36-53](https://user-images.githubusercontent.com/45364266/84918903-9c79ce00-b097-11ea-9a2f-b9c82392ac86.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have updated the documentation accordingly.
