### PR TITLE
Re-applied Black formatting to tardis after excluding undesired directories

### DIFF
--- a/asv/benchmarks/benchmarks.py
+++ b/asv/benchmarks/benchmarks.py
@@ -6,17 +6,21 @@ from tardis.tests import montecarlo_test_wrappers as montecarlo
 
 LINE_SIZE = 10000000
 
+
 class TimeSuite:
     """
     An example benchmark that times the performance of various kinds
     of iterating over dictionaries in Python.
     """
+
     def setup(self):
         self.line = np.arange(LINE_SIZE, 1, -1).astype(np.float64)
 
     def time_binarysearch(self):
         for _ in range(LINE_SIZE):
-            montecarlo.binary_search_wrapper(self.line, np.random.random() * LINE_SIZE, 0, LINE_SIZE - 1)
+            montecarlo.binary_search_wrapper(
+                self.line, np.random.random() * LINE_SIZE, 0, LINE_SIZE - 1
+            )
 
     def time_compute_distance2outer(self):
         for _ in range(1000000):
@@ -25,7 +29,7 @@ class TimeSuite:
             montecarlo.compute_distance2outer_wrapper(0.3, 1.0, 1.0)
             montecarlo.compute_distance2outer_wrapper(0.3, -1.0, 1.0)
             montecarlo.compute_distance2outer_wrapper(0.5, 0.0, 1.0)
-    
+
     def time_compute_distance2inner(self):
         for _ in range(1000000):
             montecarlo.compute_distance2inner_wrapper(1.5, -1.0, 1.0)
@@ -34,8 +38,28 @@ class TimeSuite:
 
     def time_compute_distance2line(self):
         for _ in range(1000000):
-            montecarlo.compute_distance2line_wrapper(2.20866912e+15, -0.251699059004, 1.05581082105e+15, 1.06020910733e+15, 1693440.0, 5.90513983371e-07, 1.0602263591e+15, 1.06011723237e+15, 2)
-            montecarlo.compute_distance2line_wrapper(2.23434667994e+15, -0.291130548401, 1.05581082105e+15, 1.06733618121e+15, 1693440.0, 5.90513983371e-07, 1.06738407486e+15, 1.06732933961e+15, 3)
+            montecarlo.compute_distance2line_wrapper(
+                2.20866912e15,
+                -0.251699059004,
+                1.05581082105e15,
+                1.06020910733e15,
+                1693440.0,
+                5.90513983371e-07,
+                1.0602263591e15,
+                1.06011723237e15,
+                2,
+            )
+            montecarlo.compute_distance2line_wrapper(
+                2.23434667994e15,
+                -0.291130548401,
+                1.05581082105e15,
+                1.06733618121e15,
+                1693440.0,
+                5.90513983371e-07,
+                1.06738407486e15,
+                1.06732933961e15,
+                3,
+            )
 
     def time_compute_distance2electron(self):
         for _ in range(1000000):

--- a/docs/physics/plasma/plasma_plots/lte_ionization_balance.py
+++ b/docs/physics/plasma/plasma_plots/lte_ionization_balance.py
@@ -7,7 +7,7 @@ from tardis.io.atom_data import AtomData
 import numpy as np
 import pandas as pd
 
-#Making 2 Figures for ionization balance and level populations
+# Making 2 Figures for ionization balance and level populations
 
 plt.figure(1).clf()
 ax1 = plt.figure(1).add_subplot(111)
@@ -16,73 +16,87 @@ plt.figure(2).clf()
 ax2 = plt.figure(2).add_subplot(111)
 
 # expanding the tilde to the users directory
-#atom_fname = os.path.join(os.path.dirname(base.__file__), 'data', 'atom_data.h5')
+# atom_fname = os.path.join(os.path.dirname(base.__file__), 'data', 'atom_data.h5')
 
 # reading in the HDF5 File
 atom_data = AtomData.from_hdf(atom_fname)
 
-#The atom_data needs to be prepared to create indices. The Class needs to know which atomic numbers are needed for the
-#calculation and what line interaction is needed (for "downbranch" and "macroatom" the code creates special tables)
-atom_data.prepare_atom_data([14], 'scatter')
+# The atom_data needs to be prepared to create indices. The Class needs to know which atomic numbers are needed for the
+# calculation and what line interaction is needed (for "downbranch" and "macroatom" the code creates special tables)
+atom_data.prepare_atom_data([14], "scatter")
 
-#Initializing the NebularPlasma class using the from_abundance class method.
-#This classmethod is normally only needed to test individual plasma classes
-#Usually the plasma class just gets the number densities from the model class
+# Initializing the NebularPlasma class using the from_abundance class method.
+# This classmethod is normally only needed to test individual plasma classes
+# Usually the plasma class just gets the number densities from the model class
 assert True, (
-        'This script needs a proper rewrite and should use the new'
-        '"assemble_plasma" function.')
+    "This script needs a proper rewrite and should use the new"
+    '"assemble_plasma" function.'
+)
 # TODO: Uncomment and fix the next line
 # lte_plasma = assemble_plasma({'Si':1.0}, 1e-14*u.g/u.cm**3, atom_data, 10*u.day)
 lte_plasma = None
 lte_plasma.update_radiationfield([10000], [1.0])
 
-#Initializing a dataframe to store the ion populations  and level populations for the different temperatures
+# Initializing a dataframe to store the ion populations  and level populations for the different temperatures
 ion_number_densities = pd.DataFrame(index=lte_plasma.ion_populations.index)
-level_populations = pd.DataFrame(index=lte_plasma.level_populations.ix[14, 1].index)
+level_populations = pd.DataFrame(
+    index=lte_plasma.level_populations.ix[14, 1].index
+)
 t_rads = np.linspace(2000, 20000, 100)
 
-#Calculating the different ion populations and level populuatios for the given temperatures
+# Calculating the different ion populations and level populuatios for the given temperatures
 for t_rad in t_rads:
     lte_plasma.update_radiationfield([t_rad], ws=[1.0])
-    #getting total si number density
+    # getting total si number density
     si_number_density = lte_plasma.number_densities.get_value(14, 0)
-    #Normalizing the ion populations
+    # Normalizing the ion populations
     ion_density = lte_plasma.ion_populations / si_number_density
     ion_number_densities[t_rad] = ion_density
 
-    #normalizing the level_populations for Si II
-    current_level_population = lte_plasma.level_populations[0].ix[14, 1] / lte_plasma.ion_populations.get_value((14, 1), 0)
+    # normalizing the level_populations for Si II
+    current_level_population = lte_plasma.level_populations[0].ix[
+        14, 1
+    ] / lte_plasma.ion_populations.get_value((14, 1), 0)
 
-    #normalizing with statistical weight
+    # normalizing with statistical weight
     current_level_population /= atom_data.levels.ix[14, 1].g
 
     level_populations[t_rad] = current_level_population
 
-ion_colors = ['b', 'g', 'r', 'k']
+ion_colors = ["b", "g", "r", "k"]
 
 for ion_number in [0, 1, 2, 3]:
     current_ion_density = ion_number_densities.ix[14, ion_number]
-    ax1.plot(current_ion_density.index, current_ion_density.values, '%s-' % ion_colors[ion_number],
-             label='Si %s W=1.0' % tardis.util.base.int_to_roman(ion_number + 1).upper())
+    ax1.plot(
+        current_ion_density.index,
+        current_ion_density.values,
+        "%s-" % ion_colors[ion_number],
+        label="Si %s W=1.0"
+        % tardis.util.base.int_to_roman(ion_number + 1).upper(),
+    )
 
 
-#only plotting every 5th radiation temperature
+# only plotting every 5th radiation temperature
 t_rad_normalizer = colors.Normalize(vmin=2000, vmax=20000)
 t_rad_color_map = plt.cm.ScalarMappable(norm=t_rad_normalizer, cmap=plt.cm.jet)
 
 for t_rad in t_rads[::5]:
-    ax2.plot(level_populations[t_rad].index, level_populations[t_rad].values, color=t_rad_color_map.to_rgba(t_rad))
+    ax2.plot(
+        level_populations[t_rad].index,
+        level_populations[t_rad].values,
+        color=t_rad_color_map.to_rgba(t_rad),
+    )
     ax2.semilogy()
 
 t_rad_color_map.set_array(t_rads)
 cb = plt.figure(2).colorbar(t_rad_color_map)
 
-ax1.set_xlabel('T [K]')
-ax1.set_ylabel('Number Density Fraction')
+ax1.set_xlabel("T [K]")
+ax1.set_ylabel("Number Density Fraction")
 ax1.legend()
 
-ax2.set_xlabel('Level Number for Si II')
-ax2.set_ylabel('Number Density Fraction')
-cb.set_label('T [K]')
+ax2.set_xlabel("Level Number for Si II")
+ax2.set_ylabel("Number Density Fraction")
+cb.set_label("T [K]")
 
 plt.show()

--- a/docs/physics/plasma/plasma_plots/nebular_ionization_balance.py
+++ b/docs/physics/plasma/plasma_plots/nebular_ionization_balance.py
@@ -9,7 +9,7 @@ from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 
-#Making 2 Figures for ionization balance and level populations
+# Making 2 Figures for ionization balance and level populations
 
 plt.figure(1).clf()
 ax1 = plt.figure(1).add_subplot(111)
@@ -18,97 +18,125 @@ plt.figure(2).clf()
 ax2 = plt.figure(2).add_subplot(111)
 
 # expanding the tilde to the users directory
-atom_fname = os.path.expanduser('~/.tardis/si_kurucz.h5')
+atom_fname = os.path.expanduser("~/.tardis/si_kurucz.h5")
 
 # reading in the HDF5 File
 atom_data = base.AtomData.from_hdf(atom_fname)
 
-#The atom_data needs to be prepared to create indices. The Class needs to know which atomic numbers are needed for the
-#calculation and what line interaction is needed (for "downbranch" and "macroatom" the code creates special tables)
-atom_data.prepare_atom_data([14], 'scatter')
+# The atom_data needs to be prepared to create indices. The Class needs to know which atomic numbers are needed for the
+# calculation and what line interaction is needed (for "downbranch" and "macroatom" the code creates special tables)
+atom_data.prepare_atom_data([14], "scatter")
 
-#Initializing the NebularPlasma class using the from_abundance class method.
-#This classmethod is normally only needed to test individual plasma classes
-#Usually the plasma class just gets the number densities from the model class
-nebular_plasma = plasma.NebularPlasma.from_abundance(10000, 0.5, {'Si': 1}, 1e-13, atom_data, 10.)
+# Initializing the NebularPlasma class using the from_abundance class method.
+# This classmethod is normally only needed to test individual plasma classes
+# Usually the plasma class just gets the number densities from the model class
+nebular_plasma = plasma.NebularPlasma.from_abundance(
+    10000, 0.5, {"Si": 1}, 1e-13, atom_data, 10.0
+)
 
 
-#Initializing a dataframe to store the ion populations  and level populations for the different temperatures
+# Initializing a dataframe to store the ion populations  and level populations for the different temperatures
 ion_number_densities = pd.DataFrame(index=nebular_plasma.ion_populations.index)
-level_populations = pd.DataFrame(index=nebular_plasma.level_populations.ix[14, 1].index)
+level_populations = pd.DataFrame(
+    index=nebular_plasma.level_populations.ix[14, 1].index
+)
 t_rads = np.linspace(2000, 20000, 100)
 
-#Calculating the different ion populations and level populuatios for the given temperatures
+# Calculating the different ion populations and level populuatios for the given temperatures
 for t_rad in t_rads:
     nebular_plasma.update_radiationfield(t_rad, w=1.0)
-    #getting total si number density
+    # getting total si number density
     si_number_density = nebular_plasma.number_density.get_value(14)
-    #Normalizing the ion populations
+    # Normalizing the ion populations
     ion_density = nebular_plasma.ion_populations / si_number_density
     ion_number_densities[t_rad] = ion_density
 
-    #normalizing the level_populations for Si II
-    current_level_population = nebular_plasma.level_populations.ix[14, 1] / nebular_plasma.ion_populations.ix[14, 1]
-    #normalizing with statistical weight
+    # normalizing the level_populations for Si II
+    current_level_population = (
+        nebular_plasma.level_populations.ix[14, 1]
+        / nebular_plasma.ion_populations.ix[14, 1]
+    )
+    # normalizing with statistical weight
     current_level_population /= atom_data.levels.ix[14, 1].g
 
     level_populations[t_rad] = current_level_population
 
-ion_colors = ['b', 'g', 'r', 'k']
+ion_colors = ["b", "g", "r", "k"]
 
 for ion_number in [0, 1, 2, 3]:
     current_ion_density = ion_number_densities.ix[14, ion_number]
-    ax1.plot(current_ion_density.index, current_ion_density.values, '%s-' % ion_colors[ion_number],
-             label='Si %s W=1.0' % tardis.util.base.int_to_roman(ion_number + 1).upper())
+    ax1.plot(
+        current_ion_density.index,
+        current_ion_density.values,
+        "%s-" % ion_colors[ion_number],
+        label="Si %s W=1.0"
+        % tardis.util.base.int_to_roman(ion_number + 1).upper(),
+    )
 
 
-#only plotting every 5th radiation temperature
+# only plotting every 5th radiation temperature
 t_rad_normalizer = colors.Normalize(vmin=2000, vmax=20000)
 t_rad_color_map = plt.cm.ScalarMappable(norm=t_rad_normalizer, cmap=plt.cm.jet)
 
 for t_rad in t_rads[::5]:
-    ax2.plot(level_populations[t_rad].index, level_populations[t_rad].values, color=t_rad_color_map.to_rgba(t_rad))
+    ax2.plot(
+        level_populations[t_rad].index,
+        level_populations[t_rad].values,
+        color=t_rad_color_map.to_rgba(t_rad),
+    )
     ax2.semilogy()
 
-#Calculating the different ion populations for the given temperatures with W=0.5
+# Calculating the different ion populations for the given temperatures with W=0.5
 ion_number_densities = pd.DataFrame(index=nebular_plasma.ion_populations.index)
 for t_rad in t_rads:
     nebular_plasma.update_radiationfield(t_rad, w=0.5)
-    #getting total si number density
+    # getting total si number density
     si_number_density = nebular_plasma.number_density.get_value(14)
-    #Normalizing the ion populations
+    # Normalizing the ion populations
     ion_density = nebular_plasma.ion_populations / si_number_density
     ion_number_densities[t_rad] = ion_density
 
-    #normalizing the level_populations for Si II
-    current_level_population = nebular_plasma.level_populations.ix[14, 1] / nebular_plasma.ion_populations.ix[14, 1]
-    #normalizing with statistical weight
+    # normalizing the level_populations for Si II
+    current_level_population = (
+        nebular_plasma.level_populations.ix[14, 1]
+        / nebular_plasma.ion_populations.ix[14, 1]
+    )
+    # normalizing with statistical weight
     current_level_population /= atom_data.levels.ix[14, 1].g
 
     level_populations[t_rad] = current_level_population
 
-#Plotting the ion fractions
+# Plotting the ion fractions
 
 for ion_number in [0, 1, 2, 3]:
     print("w=0.5")
     current_ion_density = ion_number_densities.ix[14, ion_number]
-    ax1.plot(current_ion_density.index, current_ion_density.values, '%s--' % ion_colors[ion_number],
-             label='Si %s W=0.5' % tardis.util.base.int_to_roman(ion_number + 1).upper())
+    ax1.plot(
+        current_ion_density.index,
+        current_ion_density.values,
+        "%s--" % ion_colors[ion_number],
+        label="Si %s W=0.5"
+        % tardis.util.base.int_to_roman(ion_number + 1).upper(),
+    )
 
 for t_rad in t_rads[::5]:
-    ax2.plot(level_populations[t_rad].index, level_populations[t_rad].values, color=t_rad_color_map.to_rgba(t_rad),
-             linestyle='--')
+    ax2.plot(
+        level_populations[t_rad].index,
+        level_populations[t_rad].values,
+        color=t_rad_color_map.to_rgba(t_rad),
+        linestyle="--",
+    )
     ax2.semilogy()
 
 t_rad_color_map.set_array(t_rads)
 cb = plt.figure(2).colorbar(t_rad_color_map)
 
-ax1.set_xlabel('T [K]')
-ax1.set_ylabel('Number Density Fraction')
+ax1.set_xlabel("T [K]")
+ax1.set_ylabel("Number Density Fraction")
 ax1.legend()
 
-ax2.set_xlabel('Level Number for Si II')
-ax2.set_ylabel('Number Density Fraction')
-cb.set_label('T [K]')
+ax2.set_xlabel("Level Number for Si II")
+ax2.set_ylabel("Number Density Fraction")
+cb.set_label("T [K]")
 
 plt.show()

--- a/docs/physics/pyplot/plot_mu_in_out_packet.py
+++ b/docs/physics/pyplot/plot_mu_in_out_packet.py
@@ -1,12 +1,13 @@
 from pylab import *
 from astropy import units as u, constants as const
+
 x, y = x, y = mgrid[1:1000, 1:1000]
-mu_in = x / 500. - 1
-mu_out = y / 500. - 1
+mu_in = x / 500.0 - 1
+mu_out = y / 500.0 - 1
 v = 1.1e4 * u.km / u.s
-doppler_fac = (1-mu_in * v/const.c)/(1-mu_out * v/const.c)
-xlabel('$\mu_{\\rm in}$')
-ylabel('$\mu_{\\rm out}$')
-imshow(np.rot90(doppler_fac), extent=[-1, 1, -1, 1], cmap='bwr')
+doppler_fac = (1 - mu_in * v / const.c) / (1 - mu_out * v / const.c)
+xlabel("$\mu_{\\rm in}$")
+ylabel("$\mu_{\\rm out}$")
+imshow(np.rot90(doppler_fac), extent=[-1, 1, -1, 1], cmap="bwr")
 colorbar()
 show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,9 @@ exclude = '''
     | model         # Temporary - to remove later
     | montecarlo    # Temporary
   )/
+  | ah_bootstrap.py
+  | ez_setup.py
+  | setup.py
+  | docs/conf.py
 )
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,24 @@
 [tool.black]
 line-length = 80
 target-version = ['py36']
+exclude = '''
+(
+  /(
+      \.eggs         # all directories in the root of the project
+    | \.git
+    | \.hg
+    | \.mypy_cache
+    | \.nox
+    | \.tox
+    | \.venv
+    | \.svn
+    | _build
+    | buck-out
+    | build
+    | dist
+    | astropy_helpers
+    | model         # Temporary - to remove later
+    | montecarlo    # Temporary
+  )/
+)
+'''

--- a/tardis/plasma/properties/general.py
+++ b/tardis/plasma/properties/general.py
@@ -50,7 +50,9 @@ class GElectron(ProcessingPlasmaProperty):
 
     outputs = ("g_electron",)
     latex_name = ("g_{\\textrm{electron}}",)
-    latex_formula = (r"\Big(\dfrac{2\pi m_{e}/\beta_{\textrm{rad}}}{h^2}\Big)^{3/2}",)
+    latex_formula = (
+        r"\Big(\dfrac{2\pi m_{e}/\beta_{\textrm{rad}}}{h^2}\Big)^{3/2}",
+    )
 
     def calculate(self, beta_rad):
         return (

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -146,7 +146,9 @@ def assemble_plasma(config, model, atom_data=None):
         )
         property_kwargs[JBluesDetailed] = {"w_epsilon": config.plasma.w_epsilon}
     else:
-        raise ValueError(f"radiative_rates_type type unknown - {config.plasma.radiative_rates_type}")
+        raise ValueError(
+            f"radiative_rates_type type unknown - {config.plasma.radiative_rates_type}"
+        )
 
     if config.plasma.excitation == "lte":
         plasma_modules += lte_excitation_properties

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -51,7 +51,7 @@ dependencies:
   - sphinx_rtd_theme
   - recommonmark
 
-  #Test/Coverage requirements
+  # Test/Coverage requirements
   - git-lfs
   - pytest=5
   - pytest-html
@@ -59,6 +59,9 @@ dependencies:
   - coverage
   - requests
   - docopt
+
+  # Code quality
+  - black
 
   - pip:
       # Documentation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR aims to exclude undesired directories from black formatting. When running black, there are still 10 files which were formatted blacked (which were not covered earlier run, because it was run not on root of project but inside `tardis/`).

A brief summary of changes in each file are:
- `pyproject.toml` - Added directories to exclude from black (including `astropy_helpers` which was being formatted by black)
- `tardis_env3.yml` - Added black as a code quality dependency, so that it is already installed in a new tardis environment
- 10 files formatted by black are distributed as follows:
  - `tardis/plasma/` - 2 files - they are actually one line changes, made by us @wkerzendorf when editing strings - those strings were quite long, so black line-breaked them as expected :white_check_mark: 
  - `docs/` - There are 4 python files inside it
  - `asv/` - 1 file
  - `ah_bootstrap.py`, `setup.py`, `ez_setup.py` are remaining 3 at root directory.

## Motivation and Context
Related #1201 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
They're only formatting changes so ideally they shouldn't break the code. And if test pipeline pass, they are good to merge.
