### PR TITLE
Case insensitive reading of csv element and isotope names

### DIFF
--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -502,7 +502,7 @@ def read_csv_isotope_abundances(
     )
 
     for element_symbol_string in df.index[skip_columns:]:
-        if element_symbol_string.title() in nucname.name_zz:
+        if element_symbol_string in nucname.name_zz:
             z = nucname.name_zz[element_symbol_string]
             abundance.loc[z, :] = df.loc[element_symbol_string].tolist()
         else:
@@ -533,7 +533,7 @@ def parse_csv_abundances(csvy_data):
     """
 
     abundance_col_names = [
-        name.title()
+        name
         for name in csvy_data.columns
         if nucname.iselement(name) or nucname.isnuclide(name)
     ]

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -502,7 +502,7 @@ def read_csv_isotope_abundances(
     )
 
     for element_symbol_string in df.index[skip_columns:]:
-        if element_symbol_string in nucname.name_zz:
+        if element_symbol_string.title() in nucname.name_zz:
             z = nucname.name_zz[element_symbol_string]
             abundance.loc[z, :] = df.loc[element_symbol_string].tolist()
         else:
@@ -533,7 +533,7 @@ def parse_csv_abundances(csvy_data):
     """
 
     abundance_col_names = [
-        name
+        name.title()
         for name in csvy_data.columns
         if nucname.iselement(name) or nucname.isnuclide(name)
     ]

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -178,8 +178,8 @@ def read_uniform_abundances(abundances_section, no_of_shells):
         if element_symbol_string == "type":
             continue
         try:
-            if element_symbol_string in nucname.name_zz:
-                z = nucname.name_zz[element_symbol_string]
+            if element_symbol_string.title() in nucname.name_zz:
+                z = nucname.name_zz[element_symbol_string.title()]
                 abundance.loc[z] = float(
                     abundances_section[element_symbol_string]
                 )
@@ -502,8 +502,8 @@ def read_csv_isotope_abundances(
     )
 
     for element_symbol_string in df.index[skip_columns:]:
-        if element_symbol_string in nucname.name_zz:
-            z = nucname.name_zz[element_symbol_string]
+        if element_symbol_string.title() in nucname.name_zz:
+            z = nucname.name_zz[element_symbol_string.title()]
             abundance.loc[z, :] = df.loc[element_symbol_string].tolist()
         else:
             z = nucname.znum(element_symbol_string)
@@ -533,7 +533,7 @@ def parse_csv_abundances(csvy_data):
     """
 
     abundance_col_names = [
-        name
+        name.title()
         for name in csvy_data.columns
         if nucname.iselement(name) or nucname.isnuclide(name)
     ]

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -160,6 +160,10 @@ def read_uniform_abundances(abundances_section, no_of_shells):
     -------
     abundance: ~pandas.DataFrame
     isotope_abundance: ~pandas.DataFrame
+
+    WARNING : current implementation is case insensitive, 
+    this will bring problems when we include molecules in 
+    the model. e.g. CO will be read as Co.
     """
     abundance = pd.DataFrame(
         columns=np.arange(no_of_shells),

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -533,7 +533,7 @@ def parse_csv_abundances(csvy_data):
     """
 
     abundance_col_names = [
-        name.title()
+        name
         for name in csvy_data.columns
         if nucname.iselement(name) or nucname.isnuclide(name)
     ]
@@ -555,8 +555,8 @@ def parse_csv_abundances(csvy_data):
     )
 
     for element_symbol_string in df.index[0:]:
-        if element_symbol_string in nucname.name_zz:
-            z = nucname.name_zz[element_symbol_string]
+        if element_symbol_string.title() in nucname.name_zz:
+            z = nucname.name_zz[element_symbol_string.title()]
             abundance.loc[z, :] = df.loc[element_symbol_string].tolist()
         else:
             z = nucname.znum(element_symbol_string)


### PR DESCRIPTION
Add case insensivity to functions  `parse_csv_abundances` and `read_uniform_abundances` when reading abundances from csv files.
## Description
Added `.title()` when passing the strings to the function `nucmane.name_zz()`  and a a warning in the docstirings for when we add molecules to the model
## Motivation and Context
Currently functions  `parse_csv_abundances` and `read_uniform_abundances` in `tardios/io/model_reader.py` use the function `nucmane.name_zz()` from pyne which is case sensitive, unlike similar functions like `funcname.znum()`. This can be a problem when checking csvy files because they may not be properly capitalized and the program would return an empty dataframe of abundances.
We have to be careful when we add modelecules to the program because this case insensivity will not recognize between CO and Co 




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned/requested two reviewers for this pull request.
