### PR TITLE
Fixes for reference data pipeline

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -6,10 +6,11 @@ trigger: none
 pr: [ master ]
 
 variables:
-  PACKAGE_MANAGER: "mamba"
-  REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
-  REF_DATA_DIR: "$(Agent.BuildDirectory)/tardis-refdata"
-  SYSTEM_DEBUG: "false"
+  package.manager: "mamba"
+  build.dir: "$(Agent.BuildDirectory)"
+  ref.data.url: "https://github.com/tardis-sn/tardis-refdata.git"
+  ref.data.dir: "$(build.dir)/tardis-refdata"
+  system.debug: "false"
 
 jobs:
   - job: report
@@ -66,7 +67,7 @@ jobs:
 
       - task: PublishPipelineArtifact@1
         inputs:
-          targetPath: $REF_DATA_DIR/notebooks/ref_data_compare.html
+          targetPath: "$(ref.data.dir)/notebooks/ref_data_compare.html"
           artifact: "html_report"
           publishLocation: "pipeline"
         displayName: "Publishing artifact"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -36,7 +36,12 @@ jobs:
           source activate tardis
           GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
           cd $REF_DATA_DIR
+          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
+          git lfs pull --include="atom_data/chianti_He.h5" origin
+          git lfs pull --include="plasma_reference/" origin
           git lfs pull --include="unit_test_data.h5" origin
+          git lfs pull --include="packet_unittest.h5" origin
+          echo MD5: `md5sum unit_test_data.h5`
         displayName: "Fetch reference data"
 
       - bash: |
@@ -46,7 +51,7 @@ jobs:
 
       - bash: |
           source activate tardis
-          python setup.py test --args="--tardis-refdata=$REF_DATA_DIR --generate-reference"
+          pytest --tardis-refdata=$REF_DATA_DIR --generate-reference
         displayName: "Generate new reference data"
 
       - bash: |
@@ -56,6 +61,9 @@ jobs:
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
           cd $REF_DATA_DIR/notebooks
+        displayName: "Generating HTML report"
+
+      - bash: |
           jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
         displayName: "Generating HTML report"
 
@@ -64,3 +72,4 @@ jobs:
           targetPath: "$REF_DATA_DIR/notebooks/ref_data_compare.html"
           artifact: "html_report"
           publishLocation: "pipeline"
+        displayName: "Publishing artifact"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -77,3 +77,7 @@ jobs:
           publishLocation: "pipeline"
         displayName: "Publishing artifact"
         condition: succeededOrFailed()
+
+      - bash: ls -lR /tmp
+        displayName: "Check files in /tmp"
+        condition: succeededOrFailed()

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -32,18 +32,7 @@ jobs:
           conda install bokeh -c conda-forge --no-update-deps --yes
         displayName: "Install Bokeh in TARDIS environment"
 
-      - bash: |
-          GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
-          cd $REF_DATA_DIR
-          git fetch origin
-          git checkout origin/master
-          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
-          git lfs pull --include="atom_data/chianti_He.h5" origin
-          git lfs pull --include="plasma_reference/" origin
-          git lfs pull --include="unit_test_data.h5" origin
-          git lfs pull --include="packet_unittest.h5" origin
-          echo MD5: `md5sum atom_data/kurucz_cd23_chianti_H_He.h5`
-          echo MD5: `md5sum unit_test_data.h5`
+      - bash: sh ci-helpers/fetch_reference_data.sh
         displayName: "Fetch reference data"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -66,7 +66,7 @@ jobs:
 
       - task: PublishPipelineArtifact@1
         inputs:
-          targetPath: "$REF_DATA_DIR/notebooks/ref_data_compare.html"
+          targetPath: $REF_DATA_DIR/notebooks/ref_data_compare.html
           artifact: "html_report"
           publishLocation: "pipeline"
         displayName: "Publishing artifact"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -7,8 +7,9 @@ pr: [ master ]
 
 variables:
   PACKAGE_MANAGER: "mamba"
+  BUILD_DIR: $(Agent.BuildDirectory)
   REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
-  REF_DATA_DIR: "$(Agent.BuildDirectory)/tardis-refdata"
+  REF_DATA_DIR: "$BUILD_DIR/tardis-refdata"
   SYSTEM_DEBUG: "false"
 
 jobs:
@@ -47,7 +48,6 @@ jobs:
 
       - bash: |
           source activate tardis
-          ls -R $REF_DATA_DIR
           pytest tardis --tardis-refdata=$REF_DATA_DIR --generate-reference
         displayName: "Generate new reference data"
 
@@ -58,9 +58,11 @@ jobs:
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
           cd $REF_DATA_DIR/notebooks
-        displayName: "Set upstream repository"
+        displayName: "Set refdata upstream repository"
 
-      - bash: jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
+      - bash: |
+          source activate tardis
+          jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
         displayName: "Generating HTML report"
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -3,7 +3,7 @@
 
 # This pipeline runs manually
 trigger: none
-pr: master
+pr: [ master ]
 
 variables:
   SYSTEM_DEBUG: "false"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -47,7 +47,7 @@ jobs:
 
       - bash: |
           source activate tardis
-          pytest tardis --tardis-refdata="$REF_DATA_DIR" --generate-reference
+          python setup.py test --args="--tardis-refdata=$(ref.data.home) --generate-reference"
         displayName: "Generate new reference data"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -33,7 +33,7 @@ jobs:
 
       - bash: |
           source activate tardis
-          $PACKAGE_MANAGER install bokeh -c conda-forge --no-update-deps -y
+          $PACKAGE_MANAGER install bokeh=1.4 -c conda-forge --no-update-deps -y
         displayName: "Install Bokeh in TARDIS environment"
 
       - bash: sh ci-helpers/fetch_reference_data.sh

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -62,8 +62,15 @@ jobs:
       - bash: |
           source activate tardis
           cd $REF_DATA_DIR/notebooks
-          jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
+          jupyter nbconvert ref_data_compare.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
         displayName: "Generating HTML report"
+
+      - bash: |
+          source activate tardis
+          cd $REF_DATA_DIR/notebooks
+          jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
+        displayName: "Generating HTML report (failed)"
+        condition: failed()
 
       - task: PublishPipelineArtifact@1
         inputs:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -8,7 +8,7 @@ pr: [ master ]
 variables:
   PACKAGE_MANAGER: "mamba"
   REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
-  REF_DATA_DIR: "$HOME/tardis-refdata"
+  REF_DATA_DIR: "$(Agent.BuildDirectory)/tardis-refdata"
   SYSTEM_DEBUG: "false"
 
 jobs:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -33,9 +33,10 @@ jobs:
         displayName: "Install Bokeh in TARDIS environment"
 
       - bash: |
-          source activate tardis
-          GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
+          git clone $REF_DATA_URL $REF_DATA_DIR
           cd $REF_DATA_DIR
+          git fetch origin
+          git checkout origin/master
           git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
           git lfs pull --include="atom_data/chianti_He.h5" origin
           git lfs pull --include="plasma_reference/" origin

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -28,7 +28,7 @@ jobs:
 
       - bash: conda install mamba -c conda-forge -y
         displayName: "Install Mamba package manager"
-        condition: eq($(package.manager), 'mamba')
+        condition: eq( $(package.manager), 'mamba' )
 
       - bash: $PACKAGE_MANAGER env create -f tardis_env3.yml
         displayName: "Install TARDIS environment"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -28,7 +28,7 @@ jobs:
 
       - bash: conda install mamba -c conda-forge -y
         displayName: "Install Mamba package manager"
-        condition: eq( $(package.manager), 'mamba' )
+        condition: eq(variables['package.manager'], 'mamba')
 
       - bash: $PACKAGE_MANAGER env create -f tardis_env3.yml
         displayName: "Install TARDIS environment"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -36,11 +36,12 @@ jobs:
           source activate tardis
           GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
           cd $REF_DATA_DIR
-          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
-          git lfs pull --include="atom_data/chianti_He.h5" origin
-          git lfs pull --include="plasma_reference/" origin
-          git lfs pull --include="unit_test_data.h5" origin
-          git lfs pull --include="packet_unittest.h5" origin
+          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5"
+          git lfs pull --include="atom_data/chianti_He.h5"
+          git lfs pull --include="plasma_reference/"
+          git lfs pull --include="unit_test_data.h5"
+          git lfs pull --include="packet_unittest.h5"
+          echo MD5: `atom_data/kurucz_cd23_chianti_H_He.h5`
           echo MD5: `md5sum unit_test_data.h5`
         displayName: "Fetch reference data"
 

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -51,7 +51,7 @@ jobs:
 
       - bash: |
           source activate tardis
-          pytest --tardis-refdata=$REF_DATA_DIR --generate-reference
+          pytest tardis --tardis-refdata=$REF_DATA_DIR --generate-reference
         displayName: "Generate new reference data"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -63,8 +63,7 @@ jobs:
           cd $REF_DATA_DIR/notebooks
         displayName: "Set upstream repository"
 
-      - bash: |
-          jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
+      - bash: jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
         displayName: "Generating HTML report"
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -56,11 +56,11 @@ jobs:
           git remote add upstream $REF_DATA_URL
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
-          cd $REF_DATA_DIR/notebooks
-        displayName: "Set refdata upstream repository"
+        displayName: "Set upstream repository"
 
       - bash: |
           source activate tardis
+          cd $REF_DATA_DIR/notebooks
           jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
         displayName: "Generating HTML report"
 

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -7,9 +7,8 @@ pr: [ master ]
 
 variables:
   PACKAGE_MANAGER: "mamba"
-  BUILD_DIR: $(Agent.BuildDirectory)
   REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
-  REF_DATA_DIR: "$BUILD_DIR/tardis-refdata"
+  REF_DATA_DIR: "$(Agent.BuildDirectory)/tardis-refdata"
   SYSTEM_DEBUG: "false"
 
 jobs:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -51,6 +51,13 @@ jobs:
 
       - bash: |
           source activate tardis
+          cd $REF_DATA_DIR
+          git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
+          git checkout upstream/pr/28
+        displayName: "Checkout"
+
+      - bash: |
+          source activate tardis
           cd $REF_DATA_DIR/notebooks
           jupyter nbconvert ref_data_compare.ipynb --to html --execute --ExecutePreprocessor.timeout=6000
         displayName: "Generating HTML report"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -47,7 +47,8 @@ jobs:
 
       - bash: |
           source activate tardis
-          python setup.py test --args="--tardis-refdata=$REF_DATA_DIR --generate-reference"
+          ls -R $REF_DATA_DIR
+          pytest tardis --tardis-refdata=$REF_DATA_DIR --generate-reference
         displayName: "Generate new reference data"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -7,9 +7,9 @@ pr: [ master ]
 
 variables:
   PACKAGE_MANAGER: "mamba"
-  SYSTEM_DEBUG: "false"
   REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
   REF_DATA_DIR: "$HOME/tardis-refdata"
+  SYSTEM_DEBUG: "false"
 
 jobs:
   - job: report
@@ -26,7 +26,7 @@ jobs:
         displayName: "Add conda to path"
 
       - bash: conda install mamba -c conda-forge -y
-        displayName: "Install mamba"
+        displayName: "Install Mamba package manager"
         condition: eq(variables['PACKAGE_MANAGER'], 'mamba')
 
       - bash: $PACKAGE_MANAGER env create -f tardis_env3.yml
@@ -47,7 +47,7 @@ jobs:
 
       - bash: |
           source activate tardis
-          python setup.py test --args="--tardis-refdata=$(ref.data.home) --generate-reference"
+          python setup.py test --args="--tardis-refdata=$REF_DATA_DIR --generate-reference"
         displayName: "Generate new reference data"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -36,11 +36,11 @@ jobs:
           source activate tardis
           GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
           cd $REF_DATA_DIR
-          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5"
-          git lfs pull --include="atom_data/chianti_He.h5"
-          git lfs pull --include="plasma_reference/"
-          git lfs pull --include="unit_test_data.h5"
-          git lfs pull --include="packet_unittest.h5"
+          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
+          git lfs pull --include="atom_data/chianti_He.h5" origin
+          git lfs pull --include="plasma_reference/" origin
+          git lfs pull --include="unit_test_data.h5" origin
+          git lfs pull --include="packet_unittest.h5" origin
           echo MD5: `atom_data/kurucz_cd23_chianti_H_He.h5`
           echo MD5: `md5sum unit_test_data.h5`
         displayName: "Fetch reference data"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -13,6 +13,9 @@ jobs:
       vmImage: "ubuntu-latest"
 
     steps:
+      - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
+        displayName: "Force exit on error (bash)"
+
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"
           sudo chown -R $USER $CONDA
@@ -58,6 +61,5 @@ jobs:
           targetPath: "$REF_DATA_DIR/notebooks/ref_data_compare.html"
           artifact: "html_report"
           publishLocation: "pipeline"
-
 # Keep this line, is useful for testing without changing the notebook.
 # sed -i "s/ref2_hash='upstream\/pr\/24'/ref1_hash='c998f44', ref2_hash='master'/g" ref_data_compare.ipynb

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -1,16 +1,11 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
+# This pipeline runs manually
 trigger: none
-pr: none
+pr: master
 
 variables:
-  system.debug: "true"
-  ref.data.home: "$(Agent.BuildDirectory)/tardis-refdata"
-  ref.data.github.url: "https://github.com/tardis-sn/tardis-refdata.git"
-  tardis.build.dir: $(Build.Repository.LocalPath)
+  SYSTEM_DEBUG: "false"
+  REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
+  REF_DATA_DIR: "$HOME/tardis-refdata"
 
 jobs:
   - job: report
@@ -21,21 +16,20 @@ jobs:
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"
           sudo chown -R $USER $CONDA
-        displayName: "Add CONDA to path"
+        displayName: "Add conda to path"
 
-      - bash: |
-          sh ci-helpers/install_tardis_env.sh
-        displayName: "Install TARDIS env"
+      - bash: conda env create -f tardis_env3.yml
+        displayName: "Install TARDIS environment"
 
       - bash: |
           source activate tardis
           conda install bokeh -c conda-forge --no-update-deps --yes
-        displayName: "Install Bokeh"
+        displayName: "Install Bokeh in TARDIS environment"
 
       - bash: |
           source activate tardis
-          GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/tardis-sn/tardis-refdata.git $(ref.data.home)
-          cd $(ref.data.home)
+          GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
+          cd $REF_DATA_DIR
           git lfs pull --include="unit_test_data.h5" origin
         displayName: "Fetch reference data"
 
@@ -46,30 +40,24 @@ jobs:
 
       - bash: |
           source activate tardis
-          python setup.py test --args="--tardis-refdata=$(ref.data.home) --generate-reference"
+          python setup.py test --args="--tardis-refdata=$REF_DATA_DIR --generate-reference"
         displayName: "Generate new reference data"
 
       - bash: |
           source activate tardis
-          cd $(ref.data.home)
-          git remote add upstream https://github.com/tardis-sn/tardis-refdata.git
+          cd $REF_DATA_DIR
+          git remote add upstream $REF_DATA_URL
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
-          cd notebooks
+          cd $REF_DATA_DIR/notebooks
           jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
-        displayName: "Generating report"
+        displayName: "Generating HTML report"
 
       - task: PublishPipelineArtifact@1
         inputs:
-          targetPath: "$(ref.data.home)/notebooks/ref_data_compare.html"
-          artifact: "report"
+          targetPath: "$REF_DATA_DIR/notebooks/ref_data_compare.html"
+          artifact: "html_report"
           publishLocation: "pipeline"
-
-      - bash: |
-          ls -lR /tmp
-          echo
-        condition: succeededOrFailed()
-        displayName: "Check files in /tmp"
 
 # Keep this line, is useful for testing without changing the notebook.
 # sed -i "s/ref2_hash='upstream\/pr\/24'/ref1_hash='c998f44', ref2_hash='master'/g" ref_data_compare.ipynb

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -42,7 +42,7 @@ jobs:
 
       - bash: |
           source activate tardis
-          pytest tardis --tardis-refdata=$REF_DATA_DIR --generate-reference
+          pytest tardis --tardis-refdata="$REF_DATA_DIR" --generate-reference
         displayName: "Generate new reference data"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -6,6 +6,7 @@ trigger: none
 pr: [ master ]
 
 variables:
+  PACKAGE_MANAGER: "mamba"
   SYSTEM_DEBUG: "false"
   REF_DATA_URL: "https://github.com/tardis-sn/tardis-refdata.git"
   REF_DATA_DIR: "$HOME/tardis-refdata"
@@ -24,12 +25,16 @@ jobs:
           sudo chown -R $USER $CONDA
         displayName: "Add conda to path"
 
-      - bash: conda env create -f tardis_env3.yml
+      - bash: conda install mamba -c conda-forge -y
+        displayName: "Install mamba"
+        condition: eq(variables['PACKAGE_MANAGER'], 'mamba')
+
+      - bash: $PACKAGE_MANAGER env create -f tardis_env3.yml
         displayName: "Install TARDIS environment"
 
       - bash: |
           source activate tardis
-          conda install bokeh -c conda-forge --no-update-deps --yes
+          $PACKAGE_MANAGER install bokeh -c conda-forge --no-update-deps -y
         displayName: "Install Bokeh in TARDIS environment"
 
       - bash: sh ci-helpers/fetch_reference_data.sh

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -41,15 +41,6 @@ jobs:
 
       - bash: |
           source activate tardis
-          cd $REF_DATA_DIR
-          git remote rename origin upstream
-          git fetch upstream
-          git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
-          git checkout upstream/master
-        displayName: "Rename remote"
-
-      - bash: |
-          source activate tardis
           python setup.py build_ext --inplace
         displayName: "Build & install TARDIS"
 

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -33,7 +33,7 @@ jobs:
         displayName: "Install Bokeh in TARDIS environment"
 
       - bash: |
-          git clone $REF_DATA_URL $REF_DATA_DIR
+          GIT_LFS_SKIP_SMUDGE=1 git clone $REF_DATA_URL $REF_DATA_DIR
           cd $REF_DATA_DIR
           git fetch origin
           git checkout origin/master
@@ -42,7 +42,7 @@ jobs:
           git lfs pull --include="plasma_reference/" origin
           git lfs pull --include="unit_test_data.h5" origin
           git lfs pull --include="packet_unittest.h5" origin
-          echo MD5: `atom_data/kurucz_cd23_chianti_H_He.h5`
+          echo MD5: `md5sum atom_data/kurucz_cd23_chianti_H_He.h5`
           echo MD5: `md5sum unit_test_data.h5`
         displayName: "Fetch reference data"
 

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -21,9 +21,7 @@ jobs:
       - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
         displayName: "Force exit on error (bash)"
 
-      - bash: |
-          echo "##vso[task.prependpath]$CONDA/bin"
-          sudo chown -R $USER $CONDA
+      - bash: echo "##vso[task.prependpath]$CONDA/bin"
         displayName: "Add conda to path"
 
       - bash: conda install mamba -c conda-forge -y

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -78,3 +78,4 @@ jobs:
           artifact: "html_report"
           publishLocation: "pipeline"
         displayName: "Publishing artifact"
+        condition: succeededOrFailed()

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -69,7 +69,7 @@ jobs:
           source activate tardis
           cd $REF_DATA_DIR/notebooks
           jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000
-        displayName: "Generating HTML report (failed)"
+        displayName: "Generating (failed) HTML report"
         condition: failed()
 
       - task: PublishPipelineArtifact@1

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -34,8 +34,10 @@ jobs:
 
       - bash: |
           source activate tardis
-          git clone https://github.com/tardis-sn/tardis-refdata.git $(ref.data.home)
-        displayName: "Fetch ALL reference data"
+          GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/tardis-sn/tardis-refdata.git $(ref.data.home)
+          cd $(ref.data.home)
+          git lfs pull --include="unit_test_data.h5" origin
+        displayName: "Fetch reference data"
 
       - bash: |
           source activate tardis

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -40,6 +40,13 @@ jobs:
         displayName: "Fetch reference data"
 
       - bash: |
+          cd $REF_DATA_DIR
+          git remote rename origin upstream
+          git fetch upstream
+          git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
+        displayName: "Rename remote"
+
+      - bash: |
           source activate tardis
           python setup.py build_ext --inplace
         displayName: "Build & install TARDIS"
@@ -48,14 +55,6 @@ jobs:
           source activate tardis
           pytest tardis --tardis-refdata=$REF_DATA_DIR --generate-reference
         displayName: "Generate new reference data"
-
-      - bash: |
-          source activate tardis
-          cd $REF_DATA_DIR
-          git remote add upstream $REF_DATA_URL
-          git fetch upstream
-          git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
-        displayName: "Set upstream repository"
 
       - bash: |
           source activate tardis

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -28,7 +28,7 @@ jobs:
 
       - bash: conda install mamba -c conda-forge -y
         displayName: "Install Mamba package manager"
-        condition: eq(variables['PACKAGE_MANAGER'], 'mamba')
+        condition: eq($(package.manager), 'mamba')
 
       - bash: $PACKAGE_MANAGER env create -f tardis_env3.yml
         displayName: "Install TARDIS environment"

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -54,6 +54,7 @@ jobs:
           cd $REF_DATA_DIR
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
           git checkout upstream/pr/28
+          git lfs pull --include="unit_test_data.h5" upstream
         displayName: "Checkout"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -61,7 +61,7 @@ jobs:
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
           cd $REF_DATA_DIR/notebooks
-        displayName: "Generating HTML report"
+        displayName: "Set upstream repository"
 
       - bash: |
           jupyter nbconvert ref_data_compare.ipynb --to html --execute --allow-errors --ExecutePreprocessor.timeout=6000

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -40,10 +40,12 @@ jobs:
         displayName: "Fetch reference data"
 
       - bash: |
+          source activate tardis
           cd $REF_DATA_DIR
           git remote rename origin upstream
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
+          git checkout upstream/master
         displayName: "Rename remote"
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -1,3 +1,6 @@
+# Keep this line, is useful for testing without changing the notebook.
+# sed -i "s/ref2_hash='upstream\/pr\/24'/ref1_hash='c998f44', ref2_hash='master'/g" ref_data_compare.ipynb
+
 # This pipeline runs manually
 trigger: none
 pr: master
@@ -61,5 +64,3 @@ jobs:
           targetPath: "$REF_DATA_DIR/notebooks/ref_data_compare.html"
           artifact: "html_report"
           publishLocation: "pipeline"
-# Keep this line, is useful for testing without changing the notebook.
-# sed -i "s/ref2_hash='upstream\/pr\/24'/ref1_hash='c998f44', ref2_hash='master'/g" ref_data_compare.ipynb

--- a/ci-helpers/fetch_reference_data.sh
+++ b/ci-helpers/fetch_reference_data.sh
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
 git lfs install --skip-smudge
 
-if test -e $REF_DATA_HOME; then
-    echo "Ref data available"
-else
-    echo git clone $REF_DATA_GITHUB_URL $REF_DATA_HOME
-    git clone $REF_DATA_GITHUB_URL $REF_DATA_HOME
+if test -e $REF_DATA_DIR; then
+    echo "Reference data available"
 
-cd $REF_DATA_HOME
-# Use the following to get the ref-data from the master;
-git fetch origin
-git checkout origin/master
-# Use the following to get the ref-data from a specific pull request
-#git fetch origin pull/20/head:update-ref
-#git checkout update-ref
-git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
-git lfs pull --include="atom_data/chianti_He.h5" origin
-git lfs pull --include="plasma_reference/" origin
-git lfs pull --include="unit_test_data.h5" origin
-echo MD5 `md5sum unit_test_data.h5`; fi
-cd $TARDIS_BUILD_DIR
+else
+    git clone $REF_DATA_URL $REF_DATA_DIR
+    cd $REF_DATA_DIR
+
+    # Use the following to get the ref-data from the master;
+    git fetch origin
+    git checkout origin/master
+
+    # Use the following to get the ref-data from a specific pull request
+    # git fetch origin pull/20/head:update-ref
+    # git checkout update-ref
+
+    git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
+    git lfs pull --include="atom_data/chianti_He.h5" origin
+    git lfs pull --include="plasma_reference/" origin
+    git lfs pull --include="unit_test_data.h5" origin
+    git lfs pull --include="packet_unittest.h5" origin
+
+    echo MD5: `md5sum unit_test_data.h5`
+    echo MD5: `md5sum atom_data/kurucz_cd23_chianti_H_He.h5`
+
+fi
+
+exit 0

--- a/ci-helpers/fetch_reference_data.sh
+++ b/ci-helpers/fetch_reference_data.sh
@@ -5,22 +5,22 @@ if test -e $REF_DATA_DIR; then
     echo "Reference data available"
 
 else
-    git clone $REF_DATA_URL $REF_DATA_DIR
+    git clone $REF_DATA_URL $REF_DATA_DIR -o upstream
     cd $REF_DATA_DIR
 
     # Use the following to get the ref-data from the master;
-    git fetch origin
-    git checkout origin/master
+    git fetch upstream
+    git checkout upstream/master
 
     # Use the following to get the ref-data from a specific pull request
-    # git fetch origin pull/20/head:update-ref
+    # git fetch upstream pull/20/head:update-ref
     # git checkout update-ref
 
-    git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" origin
-    git lfs pull --include="atom_data/chianti_He.h5" origin
-    git lfs pull --include="plasma_reference/" origin
-    git lfs pull --include="unit_test_data.h5" origin
-    git lfs pull --include="packet_unittest.h5" origin
+    git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5" upstream
+    git lfs pull --include="atom_data/chianti_He.h5" upstream
+    git lfs pull --include="plasma_reference/" upstream
+    git lfs pull --include="unit_test_data.h5" upstream
+    git lfs pull --include="packet_unittest.h5" upstream
 
     echo MD5: `md5sum unit_test_data.h5`
     echo MD5: `md5sum atom_data/kurucz_cd23_chianti_H_He.h5`


### PR DESCRIPTION
## Motivation

## Description
- [x] Use already existing `ci-helpers/fetch_reference_data.sh` script to save LFS bandwith. 
- [x] Small changes to `ci-helpers/fetch_reference_data.sh` script.
- [x] Add bash exit step on failure.
- [x] Add a variable to choose between `mamba` and `conda` package managers.


## How Has This Been Tested?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned/requested two reviewers for this pull request.
