### PR TITLE
Remove decode method

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -166,12 +166,12 @@ class AtomData(object):
             atom_data = cls(**dataframes)
 
             try:
-                atom_data.uuid1 = store.root._v_attrs["uuid1"].decode("ascii")
+                atom_data.uuid1 = store.root._v_attrs["uuid1"]
             except KeyError:
                 atom_data.uuid1 = None
 
             try:
-                atom_data.md5 = store.root._v_attrs["md5"].decode("ascii")
+                atom_data.md5 = store.root._v_attrs["md5"]
             except KeyError:
                 atom_data.md5 = None
 
@@ -179,8 +179,6 @@ class AtomData(object):
                 atom_data.version = store.root._v_attrs["database_version"]
             except KeyError:
                 atom_data.version = None
-
-            # ToDo: strore data sources as attributes in carsus
 
             logger.info(
                 "Read Atom Data with UUID={0} and MD5={1}.".format(

--- a/tardis/tests/fixtures/atom_data.py
+++ b/tardis/tests/fixtures/atom_data.py
@@ -5,7 +5,7 @@ import pytest
 
 from tardis.io.atom_data.base import AtomData
 
-DEFAULT_ATOM_DATA_UUID = "864f1753714343c41f99cb065710cace"
+DEFAULT_ATOM_DATA_UUID = b"864f1753714343c41f99cb065710cace"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description

- Remove `.decode("ascii")` method when reading atom data attributes. 
- In `tardis/tests/fixtures/atom_data.py` changed `DEFAULT_ATOM_DATA_UUID` to bytestring.

## Motivation and Context
It's not strictly necessary to encode strings before storing them inside the HDF5 metadata (unicode is default in Python 3). Carsus is currently signing atomic files **without** ASCII encoding, so we must prevent TARDIS from trying to decode these strings, otherwise will fail.

For older atomic files made with previous versions of Carsus (for example atomic data in `tardis-refdata`) the MD5 and UUID is stored as bytestrings.

> If we decide not to merge this PR, then we should re-add `.encode('ascii')` method in Carsus signing function.

## How Has This Been Tested?
```
 pytest tardis/io/tests --tardis-refdata=$HOME/Desktop/tardis-sn/tardis-refdata --remote-data
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
