### PR TITLE
Fix how virtual_packet properties are saved in hdf

### DIFF
--- a/tardis/data/vpacket_config.yml
+++ b/tardis/data/vpacket_config.yml
@@ -1,1 +1,0 @@
-vpacket_logging: false

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -283,6 +283,10 @@ class HDFWriterMixin(object):
 
     @property
     def full_hdf_properties(self):
+        # If tardis was compiled --with-vpacket-logging, add vpacket properties
+        if hasattr(self, "virt_logging") and self.virt_logging == 1:
+            self.hdf_properties.extend(self.vpacket_hdf_properties)
+
         return self.optional_hdf_properties + self.hdf_properties
 
     @staticmethod

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -1,9 +1,6 @@
-from tardis import __path__ as TARDIS_PATH
 import os
 import logging
 import warnings
-
-import yaml
 
 from astropy import units as u
 from tardis import constants as const
@@ -19,7 +16,7 @@ from tardis.montecarlo.formal_integral import FormalIntegrator
 import numpy as np
 
 logger = logging.getLogger(__name__)
-TARDIS_PATH = TARDIS_PATH[0]
+
 
 class MontecarloRunner(HDFWriterMixin):
     """
@@ -36,14 +33,11 @@ class MontecarloRunner(HDFWriterMixin):
                       'packet_luminosity', 'spectrum',
                       'spectrum_virtual', 'spectrum_reabsorbed']
 
-    vpacket_config_file_path = os.path.join(TARDIS_PATH, 'data', 'vpacket_config.yml')
-    with open(vpacket_config_file_path) as fh:
-        vpacket_logging_config = yaml.load(fh, Loader=yaml.CLoader)
-        
-    if vpacket_logging_config['vpacket_logging']:
-        hdf_properties.extend(['virt_packet_last_interaction_in_nu', 'virt_packet_last_line_interaction_in_id',
-                                'virt_packet_last_line_interaction_out_id', 'virt_packet_nus',
-                                'virt_packet_energies'])
+    vpacket_hdf_properties = ["virt_packet_last_interaction_in_nu",
+                              "virt_packet_last_interaction_type",
+                              "virt_packet_last_line_interaction_in_id",
+                              "virt_packet_last_line_interaction_out_id",
+                              "virt_packet_nus", "virt_packet_energies"]
 
     hdf_name = 'runner'
     w_estimator_constant = ((const.c ** 2 / (2 * const.h)) *

--- a/tardis/montecarlo/setup_package.py
+++ b/tardis/montecarlo/setup_package.py
@@ -1,15 +1,11 @@
 #setting the right include
-from tardis import __path__ as TARDIS_PATH
 from setuptools import Extension
 import os
 from astropy_helpers.distutils_helpers import get_distutils_option
 from Cython.Build import cythonize
 
-import yaml
-
 from glob import glob
 
-TARDIS_PATH = TARDIS_PATH[0]
 
 if get_distutils_option('with_openmp', ['build', 'install', 'develop']) is not None:
     compile_args = ['-fopenmp', '-W', '-Wall', '-Wmissing-prototypes', '-std=c99']
@@ -21,14 +17,8 @@ else:
     define_macros = []
 
 
-vpacket_config_file_path = os.path.join(TARDIS_PATH, 'data', 'vpacket_config.yml')
 if get_distutils_option('with_vpacket_logging', ['build', 'install', 'develop']) is not None:
     define_macros.append(('WITH_VPACKET_LOGGING', None))
-    vpacket_config = {'vpacket_logging': True}
-else:
-    vpacket_config = {'vpacket_logging': False}
-
-yaml.dump(vpacket_config, open(vpacket_config_file_path, "w"), default_flow_style=False)
 
 def get_extensions():
     sources = ['tardis/montecarlo/montecarlo.pyx']


### PR DESCRIPTION
This PR makes sure that vpacket logging status is determined at run-time, thus removes any need of saving to a config file.

## Description
<!--- Describe your changes in detail -->
- Removes all `vpacket_logging.yml` config file creation code implemented in #967
- Uses `runner.virt_logging` to check if vpacket logging is enabled or not within hdf

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1246 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Saved simulation to hdf file with vpacket-logging enabled, all `vpacket_hdf_properties` get saved.
- Saved simulation to hdf file with vpacket-logging disabled, none of the `vpacket_hdf_properties` get saved.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
