### PR TITLE
Pin numpy to v1.18

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3
   - pip
-  - numpy=1.18
+  - numpy=1.17
   - scipy=1.5
   - pandas=1.0
   - astropy=3

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python=3
   - pip
-  - numpy=1.19.0
+  - numpy=1.18
   - scipy=1.5
   - pandas=1.0
   - astropy=3


### PR DESCRIPTION
## Description
NumPy 1.19.0 macOS test fails when running on CI trigger, but not with PR trigger. Pinning to 1.18.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned/requested two reviewers for this pull request.
