### PR TITLE
Added virtual packet start and end wavelength configuration

### DIFF
--- a/tardis/io/schemas/spectrum.yml
+++ b/tardis/io/schemas/spectrum.yml
@@ -50,3 +50,11 @@ properties:
         default: False
         description: If True bias v-packet emission based on the electron
             scattering optical depth
+      spawn_wavelength_start:
+        type: quantity
+        default: 0 angstrom
+        description: Sets the starting wavelength for virtual packet spawning.
+      spawn_wavelength_end:
+        type: quantity
+        default: inf angstrom
+        description: Sets the end wavelength for virtual packet spawning.

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -141,8 +141,8 @@ def trace_vpacket_volley(r_packet, vpacket_collection, numba_model,
         [description]
     """
     
-    if ((r_packet.nu < vpacket_collection.spectrum_frequency[0]) or 
-        (r_packet.nu > vpacket_collection.spectrum_frequency[-1])):
+    if ((r_packet.nu < config.spectrum.virtual.spawn_wavelength_start) or 
+        (r_packet.nu > config.spectrum.virtual.spawn_wavelength_end)):
         
         return
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a virtual pack start and end wavelength configuration to spectrum.yml
Default values range from 0 to infinity Angstroms

## Motivation and Context
Numba versus C virtual photons not matching at extreme wavelengths- this config options allows the user to set the range of virtual photon wavelengths

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned/requested two reviewers for this pull request.
