### PR TITLE
Track Packet Last Interaction R

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -26,6 +26,7 @@ class MontecarloRunner(HDFWriterMixin):
     hdf_properties = ['output_nu', 'output_energy', 'nu_bar_estimator',
                       'j_estimator', 'montecarlo_virtual_luminosity',
                       'last_interaction_in_nu',
+                      'last_interaction_in_r',
                       'last_interaction_type',
                       'last_line_interaction_in_id',
                       'last_line_interaction_out_id',
@@ -34,6 +35,7 @@ class MontecarloRunner(HDFWriterMixin):
                       'spectrum_virtual', 'spectrum_reabsorbed']
 
     vpacket_hdf_properties = ["virt_packet_last_interaction_in_nu",
+                              "virt_packet_last_interaction_in_r",
                               "virt_packet_last_interaction_type",
                               "virt_packet_last_line_interaction_in_id",
                               "virt_packet_last_line_interaction_out_id",
@@ -126,6 +128,7 @@ class MontecarloRunner(HDFWriterMixin):
         self.last_interaction_type = -1 * np.ones(
                 no_of_packets, dtype=np.int64)
         self.last_interaction_in_nu = np.zeros(no_of_packets, dtype=np.float64)
+        self.last_interaction_in_r = np.zeros(no_of_packets, dtype=np.float64)
 
         self._montecarlo_virtual_luminosity = u.Quantity(
                 np.zeros_like(self.spectrum_frequency.value),

--- a/tardis/montecarlo/montecarlo.pyx
+++ b/tardis/montecarlo/montecarlo.pyx
@@ -47,6 +47,7 @@ cdef extern from "src/cmontecarlo.h":
         double *output_nus
         double *output_energies
         double *last_interaction_in_nu
+        double *last_interaction_in_r
         int_type_t *last_line_interaction_in_id
         int_type_t *last_line_interaction_out_id
         int_type_t *last_line_interaction_shell_id
@@ -104,6 +105,7 @@ cdef extern from "src/cmontecarlo.h":
         double *virt_packet_nus
         double *virt_packet_energies
         double *virt_packet_last_interaction_in_nu
+        double *virt_packet_last_interaction_in_r
         int_type_t *virt_packet_last_interaction_type
         int_type_t *virt_packet_last_line_interaction_in_id
         int_type_t *virt_packet_last_line_interaction_out_id
@@ -239,6 +241,8 @@ cdef initialize_storage_model(model, plasma, runner, storage_model_t *storage):
         runner.last_interaction_type)
     storage.last_interaction_in_nu = <double*> PyArray_DATA(
         runner.last_interaction_in_nu)
+    storage.last_interaction_in_r = <double*> PyArray_DATA(
+        runner.last_interaction_in_r)
 
     storage.js = <double*> PyArray_DATA(runner.j_estimator)
     storage.nubars = <double*> PyArray_DATA(runner.nu_bar_estimator)
@@ -318,6 +322,7 @@ def montecarlo_radial1d(model, plasma, runner, int_type_t virtual_packet_flag=0,
         runner.virt_packet_nus = c_array_to_numpy(storage.virt_packet_nus, np.NPY_DOUBLE, storage.virt_packet_count)
         runner.virt_packet_energies = c_array_to_numpy(storage.virt_packet_energies, np.NPY_DOUBLE, storage.virt_packet_count)
         runner.virt_packet_last_interaction_in_nu = c_array_to_numpy(storage.virt_packet_last_interaction_in_nu, np.NPY_DOUBLE, storage.virt_packet_count)
+        runner.virt_packet_last_interaction_in_r = c_array_to_numpy(storage.virt_packet_last_interaction_in_r, np.NPY_DOUBLE, storage.virt_packet_count)
         runner.virt_packet_last_interaction_type = c_array_to_numpy(storage.virt_packet_last_interaction_type, np.NPY_INT64, storage.virt_packet_count)
         runner.virt_packet_last_line_interaction_in_id = c_array_to_numpy(storage.virt_packet_last_line_interaction_in_id, np.NPY_INT64,
                                                                           storage.virt_packet_count)
@@ -327,6 +332,7 @@ def montecarlo_radial1d(model, plasma, runner, int_type_t virtual_packet_flag=0,
         runner.virt_packet_nus = np.zeros(0)
         runner.virt_packet_energies = np.zeros(0)
         runner.virt_packet_last_interaction_in_nu = np.zeros(0)
+        runner.virt_packet_last_interaction_in_r = np.zeros(0)
         runner.virt_packet_last_interaction_type = np.zeros(0)
         runner.virt_packet_last_line_interaction_in_id = np.zeros(0)
         runner.virt_packet_last_line_interaction_out_id = np.zeros(0)

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -719,7 +719,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
                       storage->virt_packet_nus = safe_realloc(storage->virt_packet_nus, sizeof(double) * storage->virt_array_size);
                       storage->virt_packet_energies = safe_realloc(storage->virt_packet_energies, sizeof(double) * storage->virt_array_size);
                       storage->virt_packet_last_interaction_in_nu = safe_realloc(storage->virt_packet_last_interaction_in_nu, sizeof(double) * storage->virt_array_size);
-		      storage->virt_packet_last_interaction_in_r = safe_realloc(storage->virt_packet_last_interaction_in_r, sizeof(double) * storage->virt_array_size);
+		              storage->virt_packet_last_interaction_in_r = safe_realloc(storage->virt_packet_last_interaction_in_r, sizeof(double) * storage->virt_array_size);
                       storage->virt_packet_last_interaction_type = safe_realloc(storage->virt_packet_last_interaction_type, sizeof(int64_t) * storage->virt_array_size);
                       storage->virt_packet_last_line_interaction_in_id = safe_realloc(storage->virt_packet_last_line_interaction_in_id, sizeof(int64_t) * storage->virt_array_size);
                       storage->virt_packet_last_line_interaction_out_id = safe_realloc(storage->virt_packet_last_line_interaction_out_id, sizeof(int64_t) * storage->virt_array_size);
@@ -727,7 +727,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
                   storage->virt_packet_nus[storage->virt_packet_count] = rpacket_get_nu(&virt_packet);
                   storage->virt_packet_energies[storage->virt_packet_count] = rpacket_get_energy(&virt_packet) * weight;
                   storage->virt_packet_last_interaction_in_nu[storage->virt_packet_count] = storage->last_interaction_in_nu[rpacket_get_id (packet)];
-		  storage->virt_packet_last_interaction_in_r[storage->virt_packet_count] = storage->last_interaction_in_r[rpacket_get_id (packet)];
+		          storage->virt_packet_last_interaction_in_r[storage->virt_packet_count] = storage->last_interaction_in_r[rpacket_get_id (packet)];
                   storage->virt_packet_last_interaction_type[storage->virt_packet_count] = storage->last_interaction_type[rpacket_get_id (packet)];
                   storage->virt_packet_last_line_interaction_in_id[storage->virt_packet_count] = storage->last_line_interaction_in_id[rpacket_get_id (packet)];
                   storage->virt_packet_last_line_interaction_out_id[storage->virt_packet_count] = storage->last_line_interaction_out_id[rpacket_get_id (packet)];

--- a/tardis/montecarlo/src/cmontecarlo.c
+++ b/tardis/montecarlo/src/cmontecarlo.c
@@ -719,6 +719,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
                       storage->virt_packet_nus = safe_realloc(storage->virt_packet_nus, sizeof(double) * storage->virt_array_size);
                       storage->virt_packet_energies = safe_realloc(storage->virt_packet_energies, sizeof(double) * storage->virt_array_size);
                       storage->virt_packet_last_interaction_in_nu = safe_realloc(storage->virt_packet_last_interaction_in_nu, sizeof(double) * storage->virt_array_size);
+		      storage->virt_packet_last_interaction_in_r = safe_realloc(storage->virt_packet_last_interaction_in_r, sizeof(double) * storage->virt_array_size);
                       storage->virt_packet_last_interaction_type = safe_realloc(storage->virt_packet_last_interaction_type, sizeof(int64_t) * storage->virt_array_size);
                       storage->virt_packet_last_line_interaction_in_id = safe_realloc(storage->virt_packet_last_line_interaction_in_id, sizeof(int64_t) * storage->virt_array_size);
                       storage->virt_packet_last_line_interaction_out_id = safe_realloc(storage->virt_packet_last_line_interaction_out_id, sizeof(int64_t) * storage->virt_array_size);
@@ -726,6 +727,7 @@ montecarlo_one_packet (storage_model_t * storage, rpacket_t * packet,
                   storage->virt_packet_nus[storage->virt_packet_count] = rpacket_get_nu(&virt_packet);
                   storage->virt_packet_energies[storage->virt_packet_count] = rpacket_get_energy(&virt_packet) * weight;
                   storage->virt_packet_last_interaction_in_nu[storage->virt_packet_count] = storage->last_interaction_in_nu[rpacket_get_id (packet)];
+		  storage->virt_packet_last_interaction_in_r[storage->virt_packet_count] = storage->last_interaction_in_r[rpacket_get_id (packet)];
                   storage->virt_packet_last_interaction_type[storage->virt_packet_count] = storage->last_interaction_type[rpacket_get_id (packet)];
                   storage->virt_packet_last_line_interaction_in_id[storage->virt_packet_count] = storage->last_line_interaction_in_id[rpacket_get_id (packet)];
                   storage->virt_packet_last_line_interaction_out_id[storage->virt_packet_count] = storage->last_line_interaction_out_id[rpacket_get_id (packet)];
@@ -954,6 +956,8 @@ montecarlo_line_scatter (rpacket_t * packet, storage_model_t * storage,
       rpacket_set_energy (packet, comov_energy * inverse_doppler_factor);
       storage->last_interaction_in_nu[rpacket_get_id (packet)] =
         rpacket_get_nu (packet);
+      storage->last_interaction_in_r[rpacket_get_id (packet)] = 
+	rpacket_get_r (packet);
       storage->last_line_interaction_in_id[rpacket_get_id (packet)] =
         next_line_id;
       storage->last_line_interaction_shell_id[rpacket_get_id (packet)] =
@@ -1195,6 +1199,7 @@ montecarlo_main_loop(storage_model_t * storage, int64_t virtual_packet_flag, int
   storage->virt_packet_nus = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
   storage->virt_packet_energies = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
   storage->virt_packet_last_interaction_in_nu = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
+  storage->virt_packet_last_interaction_in_r = (double *)safe_malloc(sizeof(double) * storage->no_of_packets);
   storage->virt_packet_last_interaction_type = (int64_t *)safe_malloc(sizeof(int64_t) * storage->no_of_packets);
   storage->virt_packet_last_line_interaction_in_id = (int64_t *)safe_malloc(sizeof(int64_t) * storage->no_of_packets);
   storage->virt_packet_last_line_interaction_out_id = (int64_t *)safe_malloc(sizeof(int64_t) * storage->no_of_packets);

--- a/tardis/montecarlo/src/storage.h
+++ b/tardis/montecarlo/src/storage.h
@@ -20,6 +20,7 @@ typedef struct StorageModel
   double *output_nus;
   double *output_energies;
   double *last_interaction_in_nu;
+  double *last_interaction_in_r;
   int64_t *last_line_interaction_in_id;
   int64_t *last_line_interaction_out_id;
   int64_t *last_line_interaction_shell_id;
@@ -79,6 +80,7 @@ typedef struct StorageModel
   double *virt_packet_nus;
   double *virt_packet_energies;
   double *virt_packet_last_interaction_in_nu;
+  double *virt_packet_last_interaction_in_r;
   int64_t *virt_packet_last_interaction_type;
   int64_t *virt_packet_last_line_interaction_in_id;
   int64_t *virt_packet_last_line_interaction_out_id;

--- a/tardis/montecarlo/struct.py
+++ b/tardis/montecarlo/struct.py
@@ -114,6 +114,7 @@ class StorageModel(Structure):
         ('virt_packet_nus', POINTER(c_double)),
         ('virt_packet_energies', POINTER(c_double)),
         ('virt_packet_last_interaction_in_nu', POINTER(c_double)),
+        ('virt_packet_last_interaction_in_r', POINTER(c_double)),
         ('virt_packet_last_interaction_type', POINTER(c_int64)),
         ('virt_packet_last_line_interaction_in_id', POINTER(c_int64)),
         ('virt_packet_last_line_interaction_out_id', POINTER(c_int64)),

--- a/tardis/montecarlo/struct.py
+++ b/tardis/montecarlo/struct.py
@@ -55,6 +55,7 @@ class StorageModel(Structure):
         ('output_nus', POINTER(c_double)),
         ('output_energies', POINTER(c_double)),
         ('last_interaction_in_nu', POINTER(c_double)),
+        ('last_interaction_in_r', POINTER(c_double)),
         ('last_line_interaction_in_id', POINTER(c_int64)),
         ('last_line_interaction_out_id', POINTER(c_int64)),
         ('last_line_interaction_shell_id', POINTER(c_int64)),


### PR DESCRIPTION
Multiple properties of packet last interactions are tracked by TARDIS including energy, frequency, type of interaction, etc.  Here I add the ability to track the radius from the center of the last interaction.

## Description
Numerous small additions are made to the C montecarlo implementation to track the distance from the center of the last packet interaction.  These changes are modeled after how the frequency of the last interaction is stored.

## Motivation and Context
Line identification is complicated not only by line blending in a given shell by different elements, but also by lines from different elements at different velocities.  Different blueshifts can cause some high velocity features to overlap with low velocity features of other lines.  One way to address this issue is to track where the last interaction happens for the photon packets.

## How Has This Been Tested?
I ran a simulation and then plotted the distribution of where packet last interactions happened for S, Na, and He.  The results are reasonable and shown in the figure below.
![image](https://user-images.githubusercontent.com/1607464/92770147-a42fd280-f367-11ea-97e9-74ec653479e0.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned/requested two reviewers for this pull request.
