### PR TITLE
Remove pip install option from TARDIS installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -68,16 +68,11 @@ TARDIS is used.
 
 For TARDIS development purposes please follow the steps :ref:`here <forking>`
 until the step to install TARDIS in the development mode
-``python setup.py develop``.
+``python setup.py develop``. Development guidelines for
+TARDIS can be found `here <https://tardis-sn.github.io/tardis/development/index.html>`_.
 
-You can also install TARDIS for the latest development version
-(but this is only recommended for pure users)::
-
-    pip install git+https://github.com/tardis-sn/tardis
-
-Development guidelines for TARDIS can be found `here <https://tardis-sn.github.io/tardis/development/index.html>`_.
-
-Alternatively, you can manually clone our repository and install TARDIS by::
+To install TARDIS, it is recommended to first clone our repository and
+then install TARDIS, as follows::
 
     git clone https://github.com/tardis-sn/tardis.git
     cd tardis


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`pip install git+https://github.com/tardis-sn/tardis` seems not to be working as mentioned in #1211 and as Anaconda [suggests](https://www.anaconda.com/blog/using-pip-in-a-conda-environment) that pip should better be avoided with conda, so it needs to be removed from TARDIS installation docs to avoid any confusion for new users.

The only recommended way in our case is to use `python setup.py install` which is already mentioned in docs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid pip in conda and `pip install` not working but is still mentioned in docs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
