### PR TITLE
Add Sponsor button to TARDIS

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# otechie: # Replace with a single Otechie username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+
+github: numfocus
+custom: https://numfocus.org/donate-to-tardis


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
GitHub allows repositories to show a Sponsor button on side panel to make it easier to find it. Adding `FUNDING.yml` to `.github` will do that.

The rendered button will look exactly same as how it looks at [matplotlib](https://github.com/matplotlib/matplotlib) and [astropy](https://github.com/astropy/astropy) which are also sponsored by NumFocus. Here's how it looks at matplotlib - see "sponsor this project" section:
![image](https://user-images.githubusercontent.com/36361463/95080683-18c31a80-0736-11eb-88f4-3f5749408716.png)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1305

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This file is exactly same as [that at matplotlib](https://github.com/matplotlib/matplotlib/blob/master/.github/FUNDING.yml) so it will work as expected. Also I have enabled sponsorship feature from [tardis settings](https://github.com/tardis-sn/tardis/settings) and saw the correct preview when creating this file.
