### PR TITLE
Fixed `calculate_distance_line` showing nu_diff < 0

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -89,7 +89,7 @@ def calculate_distance_line(
 
     nu = r_packet.nu
 
-    if last_line == 0.0:
+    if last_line:
         return MISS_DISTANCE
 
     nu_diff = comov_nu - nu_line

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -71,7 +71,7 @@ def calculate_distance_boundary(r, mu, r_inner, r_outer):
 @njit(**njit_dict)
 def calculate_distance_line(
         r_packet, comov_nu,
-        nu_last_interaction, nu_line, time_explosion):
+        last_line, nu_line, time_explosion):
     """
 
     Parameters
@@ -89,11 +89,10 @@ def calculate_distance_line(
 
     nu = r_packet.nu
 
-    if nu_line == 0.0:
+    if last_line == 0.0:
         return MISS_DISTANCE
 
     nu_diff = comov_nu - nu_line
-    nu_diff_last = nu_last_interaction - nu_line
 
     # for numerical reasons, if line is too close, we set the distance to 0.
     if r_packet.close_line > 0:
@@ -304,8 +303,11 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators, sigma_thomson)
 
         # Calculating the distance until the current photons co-moving nu
         # redshifts to the line frequency
+        last_line = 0
+        if cur_line_id == len(numba_plasma.line_list_nu) - 1:
+            last_line = 1
         distance_trace = calculate_distance_line(
-            r_packet, comov_nu, nu_line_last_interaction,
+            r_packet, comov_nu, last_line,
             nu_line, numba_model.time_explosion
         )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running `calculate_distance_line`, once in a while nu_diff would be computed as a negative number.  In the C version, when computing the distance to a line, there is first a check to see if we're at the last line in the list.  If we are, we return MISS_DISTANCE instead.  The numba code had a check that returned MISS_DISTANCE but it checked if nu_line was 0 instead of checking if we were at the last line.

## How Has This Been Tested?
I've run an example tardis config with both the numba and C versions.  The numba version no longer complains about negative nu_diff values and the spectra seem consistent between eachother.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
