### PR TITLE
Add workflow for autodeploying documentation to github pages via an action

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -16,6 +16,7 @@ jobs:
         with:
             environment-file: tardis_env3.yml
             activate-environment: tardis
+            mamba-version: "*"
 
       - name: Install TARDIS
         shell: bash -l {0}
@@ -30,3 +31,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html/
+          publish_branch: gh-pages

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -16,6 +16,7 @@ jobs:
         with:
             environment-file: tardis_env3.yml
             activate-environment: tardis
+            channels: conda-forge, defaults
             mamba-version: "*"
 
       - name: Install TARDIS

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,0 +1,32 @@
+name: documentation-build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  documentation_build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup TARDIS Environment 
+        uses: conda-incubator/setup-miniconda@v1 
+        with:
+            environment-file: tardis_env3.yml
+            activate-environment: tardis
+
+      - name: Install TARDIS
+        shell: bash -l {0}
+        run: python setup.py install 
+
+      - name: Build Sphinx Documentation
+        shell: bash -l {0}
+        run: python setup.py build_docs
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/_build/html/

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -261,8 +261,8 @@ extra steps to run the tests and upload the coverage results.
 Documentation pipeline
 ----------------------
 
-Builds and deploys the TARDIS documentation website. Currently, we are trying
-to move this pipeline to GitHub Actions.
+Builds and deploys the TARDIS documentation website. Currently, we are
+using a github action to complete this pipeline. The action can be found at ``.github/workflows/documentation-build.yml``
 
 
 Zenodo JSON pipeline


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add workflow for autodeploying documentation to github pages via an action

## Description
<!--- Describe your changes in detail -->
Added file .github/workflows/documentation-build.yml and compiled some other actions to properly build and deploy the sphinx documentation


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removes the need for Microsoft Azure to deploy our github pages. (which requires github secret tokens and is all around a mess) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It has been thoroughly tested on my fork with passing tests and proper deployment to morganlee123.github.io/tardis

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have assigned/requested two reviewers for this pull request.
