### PR TITLE
Small fix for release pipeline

### DIFF
--- a/azure-pipelines/simple_test_framework.yml
+++ b/azure-pipelines/simple_test_framework.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - template: templates/default.yml
         parameters:
-          fetchRefdata: false
+          fetchRefdata: true
           useMamba: true
 
       - bash: |
           cd $(tardis.dir)
           source activate tardis
           pip install pytest-azurepipelines
-          pytest tardis --cov=tardis --cov-report=xml --cov-report=html
+          pytest tardis --tardis-refdata=$(refdata.dir) --cov=tardis --cov-report=xml --cov-report=html
         displayName: 'TARDIS test'
 
       - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines/simple_test_framework.yml
+++ b/azure-pipelines/simple_test_framework.yml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - template: templates/default.yml
         parameters:
-          fetchRefdata: true
+          fetchRefdata: false
           useMamba: true
 
       - bash: |
           cd $(tardis.dir)
           source activate tardis
           pip install pytest-azurepipelines
-          pytest tardis --tardis-refdata=$(refdata.dir) --cov=tardis --cov-report=xml --cov-report=html
+          pytest tardis --cov=tardis --cov-report=xml --cov-report=html
         displayName: 'TARDIS test'
 
       - bash: bash <(curl -s https://codecov.io/bash)

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -35,7 +35,7 @@ steps:
       displayName: 'Set package manager'
  
   - checkout: self
-    path: $(tardis.dir)
+    path: s/tardis
     displayName: 'Fetch main repository'
 
   - ${{ if eq(parameters.fetchRefdata, true) }}:

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -20,7 +20,6 @@ steps:
     condition: eq(variables['Agent.OS'], 'Linux')
 
   - bash: |
-      echo "##vso[task.setvariable variable=sources.dir]$(Build.SourcesDirectory)"
       echo "##vso[task.setvariable variable=tardis.dir]$(Build.SourcesDirectory)/tardis"
       echo "##vso[task.setvariable variable=refdata.dir]$(Build.SourcesDirectory)/tardis-refdata"
     displayName: 'Set source directories'
@@ -34,14 +33,15 @@ steps:
     - bash: |
         echo "##vso[task.setvariable variable=package.manager]mamba"
       displayName: 'Set package manager'
-
+ 
   - checkout: self
-    displayName: 'Fetch TARDIS repository from GitHub'
+    path: tardis
+    displayName: 'Fetch main repository'
 
   - ${{ if eq(parameters.fetchRefdata, true) }}:
     - checkout: git://TARDIS/tardis-refdata
       lfs: true
-      displayName: 'Fetch reference data repository from Azure Repos'
+      displayName: 'Fetch reference data repository'
 
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Add conda to PATH'
@@ -52,17 +52,17 @@ steps:
 
   - ${{ if eq(parameters.useMamba, true) }}:
     - bash: conda install mamba -c conda-forge -y
-      displayName: 'Install Mamba package manager'
+      displayName: 'Install package manager'
 
   - ${{ if eq(parameters.skipInstall, false) }}:
     - bash: |
         cd $(tardis.dir)
         $(package.manager) env create -f tardis_env3.yml
-      displayName: 'TARDIS environment install'
+      displayName: 'Install conda environment'
 
   - ${{ if eq(parameters.skipInstall, false) }}:
     - bash: |
         cd $(tardis.dir)
         source activate tardis
         python setup.py build_ext --inplace
-      displayName: 'TARDIS build & install'
+      displayName: 'Build C extensions'

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -35,7 +35,7 @@ steps:
       displayName: 'Set package manager'
  
   - checkout: self
-    path: tardis
+    path: $(tardis.dir)
     displayName: 'Fetch main repository'
 
   - ${{ if eq(parameters.fetchRefdata, true) }}:

--- a/docs/development/azure_links.inc
+++ b/docs/development/azure_links.inc
@@ -5,7 +5,7 @@
 .. _azure documentation section on variables: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch
 .. _azure documentation section on jobs: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml
 .. _azure documentation section on templates: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops
-.. _checking out multiple repositories: https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops
+.. _checking out multiple repositories: https://github.com/microsoft/azure-pipelines-yaml/blob/master/design/multi-checkout.md#behavior-changes-in-multi-checkout-mode
 .. general stuff
 .. _continuous integration: https://en.wikipedia.org/wiki/Continuous_integration
 

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -160,14 +160,16 @@ The most important (and confusing) predefined variables are the ones related
 to paths in Azure:
 
 * All folders for a given pipeline are created under ``Agent.BuildDirectory`` 
-  variable, alias ``Pipeline.Workspace``.
+  variable, alias ``Pipeline.Workspace``. This includes subdirectories like
+  ``/s`` for sources or ``/a`` for artifacts.
 
-* Cloned repositories are under the ``Build.Repository.LocalPath`` variable
-  alias ``Build.SourcesDirectory``. In TARDIS we implemented another alias 
-  for this variable, named ``sources.dir``.
+* Path to source code varies depending on how many repositories we fetch.
+  For example, source code is located under the ``Build.Repository.LocalPath``
+  variable (alias ``Build.SourcesDirectory``) when fetching a single repository,
+  but after fetching a second repository code is moved automatically to
+  ``Build.Repository.LocalPath/repository-name``.
 
-Our advice is to stick with ``Build.SourcesDirectory`` as much as possible
-to avoid problems when `checking out multiple repositories`_.
+See the Azure documentation to learn more about `checking out multiple repositories`_.
 
 
 Jobs
@@ -245,7 +247,6 @@ to start a new pipeline use::
 
 **List of predefined custom variables:**
 
-- ``sources.dir`` is equivalent to ``$(Build.SourcesDirectory)``.
 - ``tardis.dir`` is equivalent to ``$(Build.SourcesDirectory)/tardis``.
 - ``refdata.dir`` is equivalent to ``$(Build.SourcesDirectory)/tardis-refdata``.
 
@@ -262,7 +263,7 @@ Documentation pipeline
 ----------------------
 
 Builds and deploys the TARDIS documentation website. Currently, we are
-using a github action to complete this pipeline. The action can be found at ``.github/workflows/documentation-build.yml``
+using GitHub Actions for this purpose.
 
 
 Zenodo JSON pipeline


### PR DESCRIPTION
## Description

- [x] Set destination path for `self` repo (`tardis` main repo in this case)
- [x] Minor changes to step names
- [x] Update documentation

## Motivation and Context

Release pipeline failed because Azure uses different folder structure when fetching multiple repos ([see here](https://github.com/microsoft/azure-pipelines-yaml/blob/master/design/multi-checkout.md#behavior-changes-in-multi-checkout-mode)).

The main goal of this PR is to use the same folder structure across all Azure pipeline, independently of how many repositories we check out.

## How Has This Been Tested?

Running the testing pipeline without checking out reference data. Worked.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
