### PR TITLE
Update changelog workflow

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -1,3 +1,6 @@
+# For more information on how to use this template please refer to:
+# http://tardis-sn.github.io/tardis/development/continuous_integration.html
+
 name: documentation-build
 
 on:

--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '10 0 * * 0'
 
 jobs:
   documentation_build:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Commit files
         run: |
-          git config --local user.email "wkerzendorf@gmail.com"
+          git config --local user.email "wkerzendorf+tardis@gmail.com"
           git add CHANGELOG.md
           git commit -m "Update CHANGELOG.md [skip ci]"
 

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,3 +1,6 @@
+# For more information on how to use this template please refer to:
+# http://tardis-sn.github.io/tardis/development/continuous_integration.html
+
 name: update-changelog
 
 on:

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,18 @@
+name: update-changelog
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: 'Install github-changes'
+        run: sudo npm install -g github-changes
+
+      - name: 'Update changelog'
+        run: github-changes -o tardis-sn -r tardis --only-pulls --use-commit-body -f CHANGELOG.md

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,4 +15,4 @@ jobs:
         run: sudo npm install -g github-changes
 
       - name: 'Update changelog'
-        run: github-changes -o tardis-sn -r tardis --only-pulls --use-commit-body -f CHANGELOG.md
+        run: github-changes -o tardis-sn -r tardis --only-pulls --use-commit-body -f CHANGELOG.md -k ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,8 +1,8 @@
 name: update-changelog
 
 on:
-  pull_request:
-    branches: [ master ]
+  schedule:
+    - cron: '50 23 * * 0'
 
 jobs:
   build:
@@ -11,8 +11,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: 'Install github-changes'
+      - name: Install github-changes
         run: sudo npm install -g github-changes
 
-      - name: 'Update changelog'
+      - name: Update changelog
         run: github-changes -o tardis-sn -r tardis --only-pulls --use-commit-body -f CHANGELOG.md -k ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit files
+        run: |
+          git config --local user.email "wkerzendorf@gmail.com"
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG.md [skip ci]"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -5,7 +5,7 @@ on:
     - cron: '50 23 * * 0'
 
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
- [x] Add workflow for updating changelog

## Motivation and Context

Before #1326 the `CHANGELOG.md` file was updated only in the `gh-pages` branch and not pushed to `master` via the documentation pipeline. I created a GitHub workflow to automatically update and push the changelog 10 minutes before a new TARDIS release is made. Also, I added a `cron` job to the documentation build (10 minutes after the release).

In the near future, we want to release TARDIS less often.

## How Has This Been Tested?

The first steps of the pipeline were tested (see the Actions tab). The push steps were not tested, we should merge and wait for the `cron` trigger.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
