### PR TITLE
Updated gitignore to ignore auto-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ __pycache__
 htmlcov
 .coverage
 .ipynb_checkpoints/
+.pytest_cache/
 
 
 # IDE Specific files

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,3 @@ distribute-*.tar.gz
 
 # Mac OSX
 .DS_Store
-
-# Jupyter checkpoints
-.ipynb_checkpoints


### PR DESCRIPTION
- Adds `.pytest_cache` to ignore it
- Removes redundant entry of `.ipynb_checkpoints`