### PR TITLE
Parallel numba setup

### DIFF
--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -5,10 +5,10 @@ properties:
   nthreads:
     type: number
     multipleOf: 1.0
-    default: 0
-    description: The number of OpenMP threads. If set to 0, the value stored in
-      the OMP_NUM_THREADS environment variable is used. If this variable is not
-      set, the maximum number of available threads are used.
+    default: 1
+    description: The number of Numba threads for parallelisation. Must be between 1 and the 
+      environment variable NUMBA_NUM_THREADS (by default NUMBA_NUM_THREADS is equal to the 
+      number of CPU cores on the local system).
   seed:
     type: number
     multipleOf: 1.0

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -4,6 +4,7 @@ import warnings
 
 from astropy import units as u
 from tardis import constants as const
+from numba import set_num_threads
 
 from scipy.special import zeta
 from tardis.montecarlo.spectrum import TARDISSpectrum
@@ -279,6 +280,9 @@ class MontecarloRunner(HDFWriterMixin):
         -------
         None
         """
+
+        set_num_threads(nthreads)
+
         self._integrator = FormalIntegrator(model, plasma, self)
         self.time_of_simulation = self.calculate_time_of_simulation(model)
         self.volume = model.volume

--- a/tardis/montecarlo/montecarlo_numba/__init__.py
+++ b/tardis/montecarlo/montecarlo_numba/__init__.py
@@ -1,7 +1,7 @@
 from llvmlite import binding
 
 binding.set_option("tmp", "-non-global-value-max-name-size=2048")
-njit_dict = {"fastmath": True, "error_model": "numpy"}
+njit_dict = {"fastmath": True, "error_model": "numpy", "parallel": True}
 
 from tardis.montecarlo.montecarlo_numba.r_packet import RPacket
 from tardis.montecarlo.montecarlo_numba.base import montecarlo_radial1d


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Numba does not currently run in parallel. With this patch, the user can specify the number of threads in their configuration, and Numba will parallelize as much as possible including NumPy functions. By default the value is 1 thread.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This greatly improves performance of the Numba code by allowing parallelization of results.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran quickstart notebook: before parallelization runtime was ~30s, after full parallelization on 8 CPU cores runtime was ~14s.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
