### PR TITLE
Fix duplicate appending of scalars in HDF writer and add an overwrite option

### DIFF
--- a/tardis/io/tests/test_HDFWriter.py
+++ b/tardis/io/tests/test_HDFWriter.py
@@ -37,7 +37,7 @@ simple_objects = [1.5, "random_string", 4.2e7]
 def test_simple_write(tmpdir, attr):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(attr)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected = pd.read_hdf(fname, key="/test/mock_hdf/scalars")["property"]
     assert actual.property == expected
 
@@ -59,7 +59,7 @@ complex_objects = [
 def test_complex_obj_write(tmpdir, attr):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(attr)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected = pd.read_hdf(fname, key="/test/mock_hdf/property").values
     assert_array_almost_equal(actual.property, expected)
 
@@ -76,7 +76,7 @@ mock_multiIndex = pd.MultiIndex.from_arrays(arr.transpose())
 def test_MultiIndex_write(tmpdir):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(mock_multiIndex)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected = pd.read_hdf(fname, key="/test/mock_hdf/property")
     expected = pd.MultiIndex.from_tuples(expected.unstack().values)
     pdt.assert_almost_equal(actual.property, expected)
@@ -92,7 +92,7 @@ def test_quantity_objects_write(tmpdir, attr):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     attr_quantity = u.Quantity(attr, "g/cm**3")
     actual = MockHDF(attr_quantity)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected = pd.read_hdf(fname, key="/test/mock_hdf/property")
     assert_array_almost_equal(actual.property.cgs.value, expected)
 
@@ -105,7 +105,7 @@ def test_scalar_quantity_objects_write(tmpdir, attr):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     attr_quantity = u.Quantity(attr, "g/cm**3")
     actual = MockHDF(attr_quantity)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected = pd.read_hdf(fname, key="/test/mock_hdf/scalars/")["property"]
     assert_array_almost_equal(actual.property.cgs.value, expected)
 
@@ -113,7 +113,7 @@ def test_scalar_quantity_objects_write(tmpdir, attr):
 def test_none_write(tmpdir):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(None)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected = pd.read_hdf(fname, key="/test/mock_hdf/scalars/")["property"]
     if expected == "none":
         expected = None
@@ -138,7 +138,7 @@ def test_objects_write(tmpdir, attr):
     nested_object = MockHDF(np.array([4.0e14, 2, 2e14, 27.5]))
     attr_quantity = u.Quantity(attr, "g/cm**3")
     actual = MockClass(attr_quantity, nested_object)
-    actual.to_hdf(fname, path="test")
+    actual.to_hdf(fname, path="test", overwrite=True)
     expected_property = pd.read_hdf(fname, key="/test/mock_class/property")
     assert_array_almost_equal(actual.property.cgs.value, expected_property)
     nested_property = pd.read_hdf(

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -64,7 +64,7 @@ def test_config_hdf(hdf_file_path, tardis_config_verysimple):
     expected = Configuration.from_config_dict(
         tardis_config_verysimple, validate=True, config_dirname="test"
     )
-    expected.to_hdf(hdf_file_path)
+    expected.to_hdf(hdf_file_path, overwrite=True)
     actual = pd.read_hdf(hdf_file_path, key="/simulation/config")
     expected = expected.get_properties()["config"]
     assert actual[0] == expected[0]

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -199,9 +199,7 @@ class HDFWriterMixin(object):
     def to_hdf_util(
         path_or_buf, path, elements, overwrite, complevel=9, complib="blosc"
     ):
-        """
-        A function to uniformly store TARDIS data
-        to an HDF file.
+        """A function to uniformly store TARDIS data to an HDF file.
 
         Scalars will be stored in a Series under path/scalars
         1D arrays will be stored under path/property_name as distinct Series
@@ -211,16 +209,20 @@ class HDFWriterMixin(object):
 
         Parameters
         ----------
-        path_or_buf :
-            Path or buffer to the HDF store
+        path_or_buf : str or pandas.io.pytables.HDFStore
+            Path or buffer to the HDF file
         path : str
-            Path inside the HDF store to store the `elements`
+            Path inside the HDF file to store the `elements`
         elements : dict
             A dict of property names and their values to be
             stored.
+        overwrite: bool
+            If the HDF file path already exists, whether overwrite it or not
 
-        Returns
-        -------
+        Notes
+        -----
+        `overwrite` option doesn't have any effect when `path_or_buf` is an
+        HDFStore because it depends on user that in which they've opened it.
         """
         buf_opened = False
 
@@ -232,7 +234,7 @@ class HDFWriterMixin(object):
                 buf = path_or_buf
             else:
                 raise e
-        else:
+        else:  # path_or_buf was a str
             if os.path.exists(path_or_buf) and not overwrite:
                 buf.close()
                 raise FileExistsError(
@@ -292,19 +294,18 @@ class HDFWriterMixin(object):
         s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", s)
         return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
-    def to_hdf(self, file_path, path="", name=None, overwrite=False):
+    def to_hdf(self, file_path_or_buf, path="", name=None, overwrite=False):
         """
         Parameters
         ----------
-        file_path : str
-            Path or buffer to the HDF store
+        file_path_or_buf : str or pandas.io.pytables.HDFStore
+            Path or buffer to the HDF file
         path : str
-            Path inside the HDF store to store the `elements`
+            Path inside the HDF file to store the `elements`
         name : str
-            Group inside the HDF store to which the `elements` need to be saved
-
-        Returns
-        -------
+            Group inside the HDF file to which the `elements` need to be saved
+        overwrite: bool
+            If the HDF file path already exists, whether overwrite it or not
         """
         if name is None:
             try:
@@ -314,7 +315,7 @@ class HDFWriterMixin(object):
 
         data = self.get_properties()
         buff_path = os.path.join(path, name)
-        self.to_hdf_util(file_path, buff_path, data, overwrite)
+        self.to_hdf_util(file_path_or_buf, buff_path, data, overwrite)
 
 
 class PlasmaWriterMixin(HDFWriterMixin):
@@ -340,31 +341,35 @@ class PlasmaWriterMixin(HDFWriterMixin):
         return data
 
     def to_hdf(
-        self, file_path, path="", name=None, collection=None, overwrite=False
+        self,
+        file_path_or_buf,
+        path="",
+        name=None,
+        collection=None,
+        overwrite=False,
     ):
         """
         Parameters
         ----------
-        file_path : str
-            Path or buffer to the HDF store
+        file_path_or_buf : str or pandas.io.pytables.HDFStore
+            Path or buffer to the HDF file
         path : str
-            Path inside the HDF store to store the `elements`
+            Path inside the HDF file to store the `elements`
         name : str
-            Group inside the HDF store to which the `elements` need to be saved
+            Group inside the HDF file to which the `elements` need to be saved
         collection :
             `None` or a `PlasmaPropertyCollection` of which members are
             the property types which will be stored. If `None` then
-            all types of properties will be stored.
-
-            This acts like a filter, for example if a value of
-            `property_collections.basic_inputs` is given, only
-            those input parameters will be stored to the HDF store.
-
-        Returns
-        -------
+            all types of properties will be stored. This acts like a filter,
+            for example if a value of `property_collections.basic_inputs` is
+            given, only those input parameters will be stored to the HDF file.
+        overwrite: bool
+            If the HDF file path already exists, whether overwrite it or not
         """
         self.collection = collection
-        super(PlasmaWriterMixin, self).to_hdf(file_path, path, name, overwrite)
+        super(PlasmaWriterMixin, self).to_hdf(
+            file_path_or_buf, path, name, overwrite
+        )
 
 
 def download_from_url(url, dst):

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -217,13 +217,13 @@ class HDFWriterMixin(object):
             A dict of property names and their values to be
             stored.
         overwrite: bool
-            If the HDF file path already exists, whether overwrite it or not
+            If the HDF file path already exists, whether to overwrite it or not
 
         Notes
         -----
         `overwrite` option doesn't have any effect when `path_or_buf` is an
-        HDFStore because it depends on user that in which mode they've opened
-        it.
+        HDFStore because the user decides on the mode in which they have
+        opened the HDFStore ('r', 'w' or 'a').
         """
         buf_opened = False
 
@@ -306,7 +306,7 @@ class HDFWriterMixin(object):
         name : str
             Group inside the HDF file to which the `elements` need to be saved
         overwrite: bool
-            If the HDF file path already exists, whether overwrite it or not
+            If the HDF file path already exists, whether to overwrite it or not
         """
         if name is None:
             try:
@@ -365,7 +365,7 @@ class PlasmaWriterMixin(HDFWriterMixin):
             for example if a value of `property_collections.basic_inputs` is
             given, only those input parameters will be stored to the HDF file.
         overwrite: bool
-            If the HDF file path already exists, whether overwrite it or not
+            If the HDF file path already exists, whether to overwrite it or not
         """
         self.collection = collection
         super(PlasmaWriterMixin, self).to_hdf(

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -222,7 +222,8 @@ class HDFWriterMixin(object):
         Notes
         -----
         `overwrite` option doesn't have any effect when `path_or_buf` is an
-        HDFStore because it depends on user that in which they've opened it.
+        HDFStore because it depends on user that in which mode they've opened
+        it.
         """
         buf_opened = False
 

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -225,8 +225,6 @@ class HDFWriterMixin(object):
         HDFStore because the user decides on the mode in which they have
         opened the HDFStore ('r', 'w' or 'a').
         """
-        buf_opened = False
-
         try:  # when path_or_buf is a str, the HDFStore should get created
             buf = pd.HDFStore(path_or_buf, complevel=complevel, complib=complib)
         except TypeError as e:
@@ -242,11 +240,9 @@ class HDFWriterMixin(object):
                     "The specified HDF file already exists. If you still want "
                     "to overwrite it, set option overwrite=True"
                 )
-            buf_opened = True
 
         if not buf.is_open:
             buf.open()
-            buf_opened = True
 
         scalars = {}
         for key, value in elements.items():
@@ -275,7 +271,7 @@ class HDFWriterMixin(object):
         if scalars:
             pd.Series(scalars).to_hdf(buf, os.path.join(path, "scalars"))
 
-        if buf_opened:
+        if buf.is_open:
             buf.close()
 
     def get_properties(self):

--- a/tardis/model/tests/test_base.py
+++ b/tardis/model/tests/test_base.py
@@ -240,7 +240,7 @@ def test_model_decay(simple_isotope_abundance):
 
 @pytest.fixture(scope="module", autouse=True)
 def to_hdf_buffer(hdf_file_path, simulation_verysimple):
-    simulation_verysimple.model.to_hdf(hdf_file_path)
+    simulation_verysimple.model.to_hdf(hdf_file_path, overwrite=True)
 
 model_scalar_attrs = ['t_inner']
 

--- a/tardis/model/tests/test_density.py
+++ b/tardis/model/tests/test_density.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_almost_equal
 
 @pytest.fixture(scope="module", autouse=True)
 def to_hdf_buffer(hdf_file_path,simulation_verysimple):
-    simulation_verysimple.model.homologous_density.to_hdf(hdf_file_path)
+    simulation_verysimple.model.homologous_density.to_hdf(hdf_file_path, overwrite=True)
 
 def test_hdf_density_0(hdf_file_path, simulation_verysimple):
     actual = simulation_verysimple.model.homologous_density.density_0

--- a/tardis/montecarlo/tests/test_base.py
+++ b/tardis/montecarlo/tests/test_base.py
@@ -12,7 +12,9 @@ from numpy.testing import assert_almost_equal
 
 @pytest.fixture(scope="module", autouse=True)
 def to_hdf_buffer(hdf_file_path, simulation_verysimple):
-    simulation_verysimple.runner.to_hdf(hdf_file_path, name="runner")
+    simulation_verysimple.runner.to_hdf(
+        hdf_file_path, name="runner", overwrite=True
+    )
 
 
 runner_properties = [

--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -153,7 +153,7 @@ def compare_spectra(actual, desired):
 
 @pytest.fixture(autouse=True)
 def to_hdf_buffer(hdf_file_path, spectrum):
-    spectrum.to_hdf(hdf_file_path, name="spectrum")
+    spectrum.to_hdf(hdf_file_path, name="spectrum", overwrite=True)
 
 
 @pytest.mark.parametrize("attr", TARDISSpectrum.hdf_properties)

--- a/tardis/plasma/tests/test_hdf_plasma.py
+++ b/tardis/plasma/tests/test_hdf_plasma.py
@@ -12,7 +12,7 @@ from tardis.plasma.properties import property_collections
 
 @pytest.fixture(scope="module", autouse=True)
 def to_hdf_buffer(hdf_file_path, simulation_verysimple):
-    simulation_verysimple.plasma.to_hdf(hdf_file_path)
+    simulation_verysimple.plasma.to_hdf(hdf_file_path, overwrite=True)
 
 
 plasma_properties_list = [
@@ -104,6 +104,7 @@ def to_hdf_collection_buffer(hdf_file_path, simulation_verysimple):
         hdf_file_path,
         name="collection",
         collection=property_collections.basic_inputs,
+        overwrite=True,
     )
 
 

--- a/tardis/widgets/tests/test_shell_info.py
+++ b/tardis/widgets/tests/test_shell_info.py
@@ -29,7 +29,7 @@ def simulation_shell_info(simulation_verysimple):
 
 @pytest.fixture(scope="class")
 def hdf_shell_info(hdf_file_path, simulation_verysimple):
-    simulation_verysimple.to_hdf(hdf_file_path)  # save sim at hdf_file_path
+    simulation_verysimple.to_hdf(hdf_file_path, overwrite=True)  # save sim at hdf_file_path
     return HDFShellInfo(hdf_file_path)
 
 


### PR DESCRIPTION
When saving a simulation object in HDF using `to_hdf()` to same file path, the scalars are appended instead of being overwritten causing duplicate values in scalrs series of HDF. This is unlike what happens to other properties like numpy arrays, dataframes, etc. which are always overwritten. 

Besides making scalars overwrite (instead of append), this PR makes sure to explicitly prompt users when overwriting a pre-existing HDF file (which earlier used to happen implicitly). For this, a boolean `overwrite` option is added to `to_hdf()` which is by default `False`.

## Changes made
- ` tardis/io/util.py` - fixed scalars appending, added overwrite option & improved related docstrings
- **Several test files using `to_hdf()`** - added `overwrite=True` since parameterization and session scoped fixtures use same hdf file path and earlier implementation implicitly overwrote the written HDFs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local tests pass, hopefully Azure pipelines pass too!
