### PR TITLE
Fixed real packet logging of properties

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -54,6 +54,9 @@ def montecarlo_radial1d(model, plasma, runner):
     (
         v_packets_energy_hist,
         last_interaction_type,
+        last_interaction_in_nu,
+        last_line_interaction_in_id,
+        last_line_interaction_out_id,
         virt_packet_nus,
         virt_packet_energies,
         virt_packet_last_interaction_in_nu,
@@ -72,6 +75,9 @@ def montecarlo_radial1d(model, plasma, runner):
 
     runner._montecarlo_virtual_luminosity.value[:] = v_packets_energy_hist
     runner.last_interaction_type = last_interaction_type
+    runner.last_interaction_in_nu = last_interaction_in_nu
+    runner.last_line_interaction_in_id = last_line_interaction_in_id
+    runner.last_line_interaction_out_id = last_line_interaction_out_id
 
     if montecarlo_configuration.VPACKET_LOGGING and number_of_vpackets > 0:
         runner.virt_packet_nus = np.concatenate(
@@ -125,6 +131,14 @@ def montecarlo_main_loop(
     )
     output_energies = np.empty_like(packet_collection.packets_output_nu)
 
+    last_interaction_in_nus = np.empty_like(packet_collection.packets_output_nu)
+    last_line_interaction_in_ids = (
+        np.ones_like(packet_collection.packets_output_nu) * -1
+    )
+    last_line_interaction_out_ids = (
+        np.ones_like(packet_collection.packets_output_nu) * -1
+    )
+
     v_packets_energy_hist = np.zeros_like(spectrum_frequency)
     delta_nu = spectrum_frequency[1] - spectrum_frequency[0]
 
@@ -167,6 +181,9 @@ def montecarlo_main_loop(
         #     raise MonteCarloException
 
         output_nus[i] = r_packet.nu
+        last_interaction_in_nus[i] = r_packet.last_interaction_in_nu
+        last_line_interaction_in_ids[i] = r_packet.last_line_interaction_in_id
+        last_line_interaction_out_ids[i] = r_packet.last_line_interaction_out_id
 
         if r_packet.status == PacketStatus.REABSORBED:
             output_energies[i] = -r_packet.energy
@@ -217,6 +234,9 @@ def montecarlo_main_loop(
     return (
         v_packets_energy_hist,
         last_interaction_types,
+        last_interaction_in_nus,
+        last_line_interaction_in_ids,
+        last_line_interaction_out_ids,
         virt_packet_nus,
         virt_packet_energies,
         virt_packet_last_interaction_in_nu,

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -45,6 +45,8 @@ rpacket_spec = [
     ("index", int64),
     ("is_close_line", boolean),
     ("last_interaction_type", int64),
+    ("last_interaction_in_nu", float64),
+    ("last_line_interaction_in_id", int64),
     ("last_line_interaction_out_id", int64),
 ]
 
@@ -62,6 +64,8 @@ class RPacket(object):
         self.index = index
         self.is_close_line = is_close_line
         self.last_interaction_type = -1
+        self.last_interaction_in_nu = 0.0
+        self.last_line_interaction_in_id = -1
         self.last_line_interaction_out_id = -1
 
     def initialize_line_id(self, numba_plasma, numba_model):
@@ -456,6 +460,8 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
             and not montecarlo_configuration.disable_line_scattering
         ):
             interaction_type = InteractionType.LINE  # Line
+            r_packet.last_interaction_in_nu = r_packet.nu
+            r_packet.last_line_interaction_in_id = cur_line_id
             r_packet.next_line_id = cur_line_id
             distance = distance_trace
             break

--- a/tardis/widgets/tests/test_line_info.py
+++ b/tardis/widgets/tests/test_line_info.py
@@ -24,7 +24,6 @@ def line_info_widget(simulation_verysimple):
 class TestLineInfoWidgetData:
     """Tests for methods that handles data in LineInfoWidget."""
 
-    @pytest.mark.xfail(reason="Add real packet information to runner")
     def test_get_species_interactions(
         self, line_info_widget, wavelength_range, filter_mode
     ):
@@ -171,8 +170,6 @@ class TestLineInfoWidgetEvents:
 
         return liw, selection_range
 
-
-    @pytest.mark.xfail(reason="Add real packet information to runner")
     def test_selection_on_plot(self, liw_with_selection):
         """
         Test if selection on spectrum plot, updates correct data in both
@@ -220,7 +217,6 @@ class TestLineInfoWidgetEvents:
             line_info_widget.total_packets_label.widget.children[1].value
         )
 
-    @pytest.mark.xfail(reason="Add real packet information to runner")
     @pytest.mark.parametrize("selected_filter_mode_idx", [0, 1])
     def test_filter_mode_toggle(
         self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
rpacket logging in the numba code was incomplete. I added the properties required for visualization in the appropriate locations so that real packet properties are updated. These properties are last_interaction_in_nu, last_line_interaction_in_id, last_line_interaction_out_id. They are output to the runner object.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Widget tests were broken!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Widget tests now pass locally with the xfails removed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
