### PR TITLE
Packet logging fixes for visualization

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -187,10 +187,10 @@ def montecarlo_main_loop(
 
         if r_packet.status == PacketStatus.REABSORBED:
             output_energies[i] = -r_packet.energy
-            last_interaction_types[i] = 0
+            last_interaction_types[i] = r_packet.last_interaction_type
         elif r_packet.status == PacketStatus.EMITTED:
             output_energies[i] = r_packet.energy
-            last_interaction_types[i] = 1
+            last_interaction_types[i] = r_packet.last_interaction_type
 
         vpackets_nu = vpacket_collection.nus[: vpacket_collection.idx]
         vpackets_energy = vpacket_collection.energies[: vpacket_collection.idx]

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -493,8 +493,6 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
 
     # r_packet.next_line_id = cur_line_id
 
-    r_packet.last_interaction_type = interaction_type
-
     return distance, interaction_type, delta_shell
 
 

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -86,7 +86,6 @@ def single_packet_loop(
             )
 
         elif interaction_type == InteractionType.LINE:
-
             r_packet.last_interaction_type = 2
 
             move_r_packet(

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -86,6 +86,9 @@ def single_packet_loop(
             )
 
         elif interaction_type == InteractionType.LINE:
+
+            r_packet.last_interaction_type = 2
+
             move_r_packet(
                 r_packet, distance, numba_model.time_explosion, estimators
             )
@@ -100,6 +103,9 @@ def single_packet_loop(
             )
 
         elif interaction_type == InteractionType.ESCATTERING:
+
+            r_packet.last_interaction_type = 1
+
             move_r_packet(
                 r_packet, distance, numba_model.time_explosion, estimators
             )

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -103,7 +103,6 @@ def single_packet_loop(
             )
 
         elif interaction_type == InteractionType.ESCATTERING:
-
             r_packet.last_interaction_type = 1
 
             move_r_packet(

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -288,6 +288,6 @@ def trace_vpacket_volley(
             v_packet.energy,
             r_packet.nu,
             r_packet.last_interaction_type,
-            r_packet.next_line_id,
+            r_packet.last_line_interaction_in_id,
             r_packet.last_line_interaction_out_id,
         )

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -286,7 +286,7 @@ def trace_vpacket_volley(
         vpacket_collection.set_properties(
             v_packet.nu,
             v_packet.energy,
-            r_packet.nu,
+            r_packet.last_interaction_in_nu,
             r_packet.last_interaction_type,
             r_packet.last_line_interaction_in_id,
             r_packet.last_line_interaction_out_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The rpacket last_interaction_type property is now the same as the C code, returning 1 for e-scatter and 2 for line scatter.
The vpacket last_line_interaction_in_id now correctly reports the last line interaction ID that the corresponding real packet had before line scattering.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Packet logging has changed between numba and the C code, so this PR fixes errors made when the numba version logging was set up.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Visual comparison with the C code Kromer plot.
Standard unit tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have assigned/requested two reviewers for this pull request.
