### PR TITLE
fix tests with --generate-reference flag

### DIFF
--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -68,11 +68,6 @@ def test_luminosity_density_lambda(spectrum):
 def test_flux_nu(spectrum):
     if getattr(spectrum, "distance", None):
 
-        if pytest.__version__ < "2.8":
-            pytest.xfail(
-                reason="requires pytest.warns (introduced in pytest v2.8)",
-            )
-
         with pytest.warns(DeprecationWarning):
             test_helper.assert_quantity_allclose(
                 spectrum.flux_nu,
@@ -87,11 +82,6 @@ def test_flux_nu(spectrum):
 
 def test_flux_lambda(spectrum):
     if getattr(spectrum, "distance", None):
-
-        if pytest.__version__ < "2.8":
-            pytest.xfail(
-                reason="requires pytest.warns (introduced in pytest v2.8)",
-            )
 
         with pytest.warns(DeprecationWarning):
             test_helper.assert_quantity_allclose(

--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -161,7 +161,7 @@ class TestPlasma(object):
         config["atom_data"] = chianti_he_db_fpath
         sim = Simulation.from_config(config)
         if request.config.getoption("--generate-reference"):
-            sim.plasma.to_hdf(tardis_ref_data, path=config.plasma.save_path)
+            sim.plasma.to_hdf(tardis_ref_data, path=config.plasma.save_path, overwrite=True)
             pytest.skip("Reference data saved at {0}".format(tardis_ref_data))
         return sim.plasma
 

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -53,9 +53,9 @@ def simulation_one_loop(
             "output_nu",
             "output_energy",
         ]
-        simulation.to_hdf(tardis_ref_data, "", "test_simulation")
-        simulation.model.to_hdf(tardis_ref_data, "", "test_simulation")
-        simulation.runner.to_hdf(tardis_ref_data, "", "test_simulation")
+        simulation.to_hdf(tardis_ref_data, "", "test_simulation", overwrite=True)
+        simulation.model.to_hdf(tardis_ref_data, "", "test_simulation", overwrite=True)
+        simulation.runner.to_hdf(tardis_ref_data, "", "test_simulation", overwrite=True)
         pytest.skip("Reference data was generated during this run.")
 
 

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -34,7 +34,7 @@ class TestRunnerSimple:
                 "spectrum",
                 "spectrum_virtual",
             ]
-            simulation.runner.to_hdf(tardis_ref_data, "", self.name)
+            simulation.runner.to_hdf(tardis_ref_data, "", self.name, overwrite=True)
             pytest.skip("Reference data was generated during this run.")
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

- Use `to_hdf` method with new `overwrite=True` when required.
- Removed unnecessary `if` statement for old `pytest` versions.

## Motivation and Context

Test failed with `--generate-reference` flag since #1366 was merged.


## How Has This Been Tested?
- [ ] Testing pipeline
- [x] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
`$ pytest tardis --tardis-refdata=/path/to/refdata --generate-reference`

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
