### PR TITLE
explicitly add parso to dependencies

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -68,6 +68,9 @@ dependencies:
   # Code quality
   - black
 
+  # Other
+  - parso=0.8
+
   - pip:
       # Documentation
       - sphinxcontrib-tikz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description

- Add `parso=0.8` to environment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Documentation build is broken due to incorrectly `jedi` dependency management in the conda recipe. See: https://github.com/conda-forge/jedi-feedstock/issues/34

This issue arised this week in TARDIS. Fixed by explicitly pinning `parso` to v0.8 until a fix arrives.

## How Has This Been Tested?
- [ ] Testing pipeline
- [x] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran documentation pipeline on my fork.

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
