### PR TITLE
Corrected the Hyperlink reference

### DIFF
--- a/docs/quickstart/quickstart.ipynb
+++ b/docs/quickstart/quickstart.ipynb
@@ -15,7 +15,7 @@
     "You can obtain a copy of the atomic database from the\n",
     "(https://github.com/tardis-sn/tardis-refdata) repository\n",
     "(`atom_data` subfolder). We recommended to use the\n",
-    "`kurucz_cd23_chianti_H_He.h5` dataset (which is auto-downloaded in the second cell already). The configuration file for this quickstart is `tardis_example.yml`, which can be downloaded [here](https://https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/using/components/models/examples/tardis_example.yml)), though this file is auto-downloaded in the third cell.\n",
+    "`kurucz_cd23_chianti_H_He.h5` dataset (which is auto-downloaded in the second cell already). The configuration file for this quickstart is `tardis_example.yml`, which can be downloaded [here](https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/using/components/models/examples/tardis_example.yml)), though this file is auto-downloaded in the third cell.\n",
     "\n",
     "After the [installation](../installation.rst), start a Jupyter server executing `jupyter notebook` on the command line in a directory that contains this quickstart."
    ]


### PR DESCRIPTION
I corrected the hyperlink reference. 
Earlier <code>https://https//raw.githubusercontent.com/tardis-sn/tardis/master/docs/using/components/models/examples/tardis_example.yml</code>

 Now <code>https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/using/components/models/examples/tardis_example.yml</code>

extra <code> https://</code> was creating error. Now its okay.



## Description
I corrected the url

## Motivation and Context
https://github.com/tardis-sn/tardis/issues/1407

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Other (please describe)


## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [] My change requires a change to the documentation
- [] I have updated the documentation accordingly
- [] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [ ] I have assigned and requested two reviewers for this pull request
