### PR TITLE
Add .log to gitignore, disabled montecarlo log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 __pycache__
 
+# Logging
+*.log
+
 
 # Ignore .c files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.

--- a/tardis/montecarlo/montecarlo_numba/montecarlo_logger.py
+++ b/tardis/montecarlo/montecarlo_numba/montecarlo_logger.py
@@ -2,7 +2,7 @@ import logging
 from functools import wraps
 
 DEBUG_MODE = False
-LOG_FILE = "montecarlo_log.log"
+LOG_FILE = False
 BUFFER = 1
 ticker = 1
 


### PR DESCRIPTION
Montecarlo log needs work.

<!--- Provide a general summary of your changes in the title above. -->

## Description
.log files are now ignored. Disabled the MC logging to file. Instead it will log to console.

## Motivation and Context
Issue #1397

## How Has This Been Tested?
- [x] Testing pipeline
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
