### PR TITLE
Conversion of enlisted variable to int64 datatype 

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -127,16 +127,16 @@ def montecarlo_main_loop(
     """
     output_nus = np.empty_like(packet_collection.packets_output_nu)
     last_interaction_types = (
-        np.ones_like(packet_collection.packets_output_nu) * -1
+        np.ones_like(packet_collection.packets_output_nu, dtype=np.int64) * -1
     )
     output_energies = np.empty_like(packet_collection.packets_output_nu)
 
     last_interaction_in_nus = np.empty_like(packet_collection.packets_output_nu)
     last_line_interaction_in_ids = (
-        np.ones_like(packet_collection.packets_output_nu) * -1
+        np.ones_like(packet_collection.packets_output_nu, dtype=np.int64) * -1
     )
     last_line_interaction_out_ids = (
-        np.ones_like(packet_collection.packets_output_nu) * -1
+        np.ones_like(packet_collection.packets_output_nu, dtype=np.int64) * -1
     )
 
     v_packets_energy_hist = np.zeros_like(spectrum_frequency)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
This PR aims to fix #1389, change of data type of the enlisted variables of enlisted 

## Description 
- Fixed the data type from `float64` to `int64` 

<!--- Describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solving #1389 
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [x] Testing pipeline
- [ ] Other (please describe)  
<!--- Please describe in detail how you tested your changes. -->
Checking the changes through local test too 😄  
<!--- Include details of your testing environment, tests ran to see how -->
Ran on `tardis` env created through `tardis3_env.yml`
<!--- your change affects other areas of the code, etc. -->
Changes the data type of the main variables in `Montecarlo simulation runner`

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
