### PR TITLE
HotPR to remove the bad tick marks from documentation

### DIFF
--- a/docs/development/code_quality.rst
+++ b/docs/development/code_quality.rst
@@ -55,18 +55,18 @@ At TARDIS, we follow the `Numpy docstring format <https://numpydoc.readthedocs.i
 
         Parameters
         ----------
-        `filename` : str
-            filename or path of the density file
-        `filetype` : str
+        filename : str
+            file name or path of the density file
+        filetype : str
             type of the density file
 
         Returns
         -------
-        `time_of_model` : astropy.units.Quantity
+        time_of_model : astropy.units.Quantity
             time at which the model is valid
-        `velocity` : np.ndarray
+        velocity : np.ndarray
             the array containing the velocities
-        `unscaled_mean_densities` : np.ndarray
+        unscaled_mean_densities : np.ndarray
             the array containing the densities
         """
 


### PR DESCRIPTION
Removed back ` marks around variables that were used improperly

## Description
Not following the coding guidelines

## Motivation and Context
Having mistakes in the documentation guidelines for documentation isn't a good look

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [x] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [ ] I have assigned and requested two reviewers for this pull request
