### PR TITLE
compare refdata with arbitrary labels

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -33,7 +33,7 @@ jobs:
       - bash: |
           MY_PAT=$(azure_pat)
           B64_PAT=$(printf ":$MY_PAT" | base64)
-          GIT_LFS_SKIP_SMUDGE=1 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata $(refdata.dir)
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata $(refdata.dir)
           cd $(refdata.dir); git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs fetch --all
         displayName: 'Fetch reference data repository'
 

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -28,26 +28,15 @@ jobs:
           fetchRefdata: false  # See the comment below.
           useMamba: true
 
-      #  Conflict:
-      #
-      #     requirement 1: Azure Repos requires token auth for public repositories containing LFS objects (bug).
-      #     requirement 2: GitHubComment task requires secret sharing enabled to work.
-      #
-      #  If secret sharing is enabled, the token needed to fetch Azure Repos is not shared for security reasons,
-      #  breaking the pipeline.
-      #
-      #  Solution: Fetch reference data from GitHub repository until a fix for Azure Repos bug arrives.
-
+      #  Azure Repos requires token auth for public repositories containing LFS objects (bug).
+      #  Fetch reference data from Azure with a PAT until a fix arrives.
       - bash: |
-          GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/tardis-sn/tardis-refdata.git $(refdata.dir)
+          MY_PAT=$(azure_pat)
+          B64_PAT=$(printf ":$MY_PAT" | base64)
+          GIT_LFS_SKIP_SMUDGE=1 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata $(refdata.dir)
           cd $(refdata.dir)
-          git lfs pull --include="atom_data/kurucz_cd23_chianti_H_He.h5"
-          git lfs pull --include="atom_data/chianti_He.h5"
-          git lfs pull --include="unit_test_data.h5"
-          git lfs pull --include="packet_unittest.h5"
-          git lfs pull --include="montecarlo_1e5_compare_data.h5"
-          git lfs pull --include="montecarlo_one_packet_compare_data.h5"
-        displayName: 'Fetch reference data repository'
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs fetch --all
+        displayName: 'Fetch reference data repository (slow)'
 
       - bash: |
           cd $(refdata.dir)
@@ -61,10 +50,11 @@ jobs:
           source activate tardis
           pytest tardis --tardis-refdata=$(refdata.dir) --generate-reference
         displayName: 'Generate reference data'
+        condition: or(eq(variables['ref1.hash'], ''), eq(variables['ref2.hash'], ''))
 
       - bash: |
           source activate tardis
-          $(package.manager) install bokeh --channel conda-forge --no-update-deps --yes
+          $(package.manager) install bokeh=2.2 --channel conda-forge --no-update-deps --yes
         displayName: 'Install Bokeh'
 
       - bash: |
@@ -99,7 +89,7 @@ jobs:
         displayName: 'Copy files to server'
         condition: succeededOrFailed()
 
-      # Run if the pipeline is triggered by a pull request.
+      # Run only if the pipeline is triggered by a pull request.
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - task: GitHubComment@0
           inputs:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,6 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
+  #ref1.hash: ''
+  #ref2.hash: ''
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -28,8 +30,8 @@ jobs:
           fetchRefdata: false  # See the comment below.
           useMamba: true
 
-      #  Azure Repos requires token auth for public repositories containing LFS objects (bug).
-      #  Fetch reference data from Azure with a PAT until a fix arrives.
+      # Azure Repos requires token auth for public repositories containing LFS objects (bug).
+      # Fetch reference data from Azure with a PAT until a fix arrives.
       - bash: |
           MY_PAT=$(azure_pat)
           B64_PAT=$(printf ":$MY_PAT" | base64)

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -34,13 +34,12 @@ jobs:
           MY_PAT=$(azure_pat)
           B64_PAT=$(printf ":$MY_PAT" | base64)
           GIT_LFS_SKIP_SMUDGE=1 git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata $(refdata.dir)
-          cd $(refdata.dir)
-          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs fetch --all
-        displayName: 'Fetch reference data repository (slow)'
+          cd $(refdata.dir); git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs fetch --all
+        displayName: 'Fetch reference data repository'
 
       - bash: |
           cd $(refdata.dir)
-          git remote add upstream https://github.com/tardis-sn/tardis-refdata.git
+          git remote add upstream https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
         displayName: 'Set upstream remote'

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -1,5 +1,4 @@
-.. include:: git_links.inc
-.. include:: azure_links.inc
+.. include:: links.inc
 
 **********************
 Continuous Integration
@@ -290,17 +289,28 @@ Release pipeline
 Publishes a new release of TARDIS every sunday at 00:00 UTC. 
 
 
-Reference data pipeline
-=======================
+Compare reference data pipeline
+===============================
 
-Generates new reference data according to the changes present in the
-current pull request. Then, compares against reference data present in the
-head of ``tardis-refdata`` repository by running a notebook. Finally, uploads
-the rendered notebook to the pipeline results.
-
-To trigger this pipeline is necessary to leave a comment in the GitHub pull
-request.
+This pipeline compares two versions of the reference data. It's triggered manually via
+the Azure Pipelines web UI, or when a TARDIS contributor leaves the following comment
+on a pull request:
 ::
   /AzurePipelines run compare-refdata
 
 For brevity, you can comment using ``/azp`` instead of ``/AzurePipelines``.
+
+By default, generates new reference data for the ``HEAD`` of the pull request. Then, 
+compares against latest reference data stored in ``tardis-refdata`` repository. The
+web UI also allows to compare any version of the reference data by providing two
+labels (SHAs, branches, tags, etc.) as variables named ``ref1.hash`` and ``ref2.hash``
+at runtime.
+
+.. warning:: Do not define ``ref1.hash`` and ``ref2.hash`` between quotation marks 
+            or **the pipeline will fail**.
+
+Finally, the report is uploaded to the
+`OpenSupernova.org server <http://opensupernova.org/~azuredevops/files/refdata-results/>`_
+following the ``<pr>/<commit>`` folder structure. If the pipeline fails, also a report is 
+generated, but not necessarily gives useful debug information (depends on which step the
+pipeline has failed).

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -303,8 +303,8 @@ For brevity, you can comment using ``/azp`` instead of ``/AzurePipelines``.
 By default, generates new reference data for the ``HEAD`` of the pull request. Then, 
 compares against latest reference data stored in ``tardis-refdata`` repository. If
 you want to compare two different labels (SHAs, branches, tags, etc.) uncomment and
-set the `ref1.hash` and `ref2.hash` variables in `.github/workflows/compare-refdata.yml`
-on your pull request. For example:
+set the ``ref1.hash`` and ``ref2.hash`` variables in 
+`.github/workflows/compare-refdata.yml` on your pull request. For example:
 ::
   ref1.hash: 'upstream/pr/11'
   ref2.hash: 'upstream/master'

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -304,7 +304,7 @@ By default, generates new reference data for the ``HEAD`` of the pull request. T
 compares against latest reference data stored in ``tardis-refdata`` repository. If
 you want to compare two different labels (SHAs, branches, tags, etc.) uncomment and
 set the ``ref1.hash`` and ``ref2.hash`` variables in 
-`.github/workflows/compare-refdata.yml` on your pull request. For example:
+``.github/workflows/compare-refdata.yml`` on your pull request. For example:
 ::
   ref1.hash: 'upstream/pr/11'
   ref2.hash: 'upstream/master'

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -301,13 +301,21 @@ on a pull request:
 For brevity, you can comment using ``/azp`` instead of ``/AzurePipelines``.
 
 By default, generates new reference data for the ``HEAD`` of the pull request. Then, 
-compares against latest reference data stored in ``tardis-refdata`` repository. The
-web UI also allows to compare any version of the reference data by providing two
-labels (SHAs, branches, tags, etc.) as variables named ``ref1.hash`` and ``ref2.hash``
-at runtime.
+compares against latest reference data stored in ``tardis-refdata`` repository. If
+you want to compare two different labels (SHAs, branches, tags, etc.) uncomment and
+set the `ref1.hash` and `ref2.hash` variables in `.github/workflows/compare-refdata.yml`
+on your pull request. For example:
+::
+  ref1.hash: 'upstream/pr/11'
+  ref2.hash: 'upstream/master'
 
-.. warning:: Do not define ``ref1.hash`` and ``ref2.hash`` between quotation marks 
-            or **the pipeline will fail**.
+The web UI also allows to compare any version of the reference data by providing those
+variables at runtime, but the access to the dashboard is restricted to a small group
+of developers.
+
+.. warning:: If using the Azure dashboard, do not define ``ref1.hash`` and ``ref2.hash``
+          between quotation marks or **the pipeline will fail**. This does not apply for
+          the YAML file.
 
 Finally, the report is uploaded to the
 `OpenSupernova.org server <http://opensupernova.org/~azuredevops/files/refdata-results/>`_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
Allow pipeline to compare two versions of the reference data by specifying labels (commit hashes, tags, branches, etc.).  

- If no label is specified, the pipeline will run as usual generating new reference data and comparing against the latest version stored in `tardis-refdata` repo.

- Also I found a workaround to fetch LFS data from Azure Mirror with PAT.

**It's working!** See :http://opensupernova.org/~azuredevops/files/refdata-results/1430/d963e15e26a98f56b00778e44a016e547883f26a.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of the CI/CD project.

## How Has This Been Tested?
- [ ] Testing pipeline
- [x] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
