### PR TITLE
final changes for update refdata pipeline

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -2,7 +2,11 @@
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 trigger: none
-pr: [ master ]
+
+pr:
+  branches:
+    include:
+    - '*'
 
 schedules:
   - cron: '0 0 1 * *'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -1,6 +1,13 @@
 # For more information on how to use this pipeline please refer to:
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
+# IMPORTANT: Only contributors with `Write` permission can trigger the build
+#            by commenting `/AzurePipelines run <pipeline-name>` on the pull
+#            request.
+#
+#            This feature can be disabled only through the Azure Pipelines
+#            dashboard.
+
 trigger: none
 
 pr:

--- a/azure-pipelines/run-unit-tests.yml
+++ b/azure-pipelines/run-unit-tests.yml
@@ -2,7 +2,14 @@
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 trigger:
-  - master
+  branches:
+    include:
+    - '*'
+
+pr:
+  branches:
+    include:
+    - '*'
 
 variables:
   codecov.token: 'a876d307-9ed5-4f5d-a6c4-e58291ac4111'

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -1,6 +1,13 @@
 # For more information on how to use this pipeline please refer to:
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
+# IMPORTANT: Only contributors with `Write` permission can trigger the build
+#            by commenting `/AzurePipelines run <pipeline-name>` on the pull
+#            request.
+#
+#            This feature can be disabled only through the Azure Pipelines
+#            dashboard.
+
 trigger: none
 
 pr:

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -2,7 +2,11 @@
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 trigger: none
-pr: [ master ]
+
+pr:
+  branches:
+    include:
+    - '*'
 
 variables:
   system.debug: false
@@ -20,9 +24,9 @@ jobs:
     steps:
       - template: templates/default.yml
         parameters:
-          fetchRefdata: false  # We don't want to fetch the mirror
+          fetchRefdata: false  # We don't want to fetch from the mirror
           useMamba: true
-          skipInstall: true  # Enable temporarily (works ok)
+          skipInstall: true  # Disable temporarily (works ok)
 
       - bash: git clone https://github.com/tardis-sn/tardis-refdata $(refdata.dir)
         displayName: 'Fetch reference data repository'
@@ -35,7 +39,7 @@ jobs:
         displayName: 'Generate reference data'
         condition: false  # Disable temporarily (not tested but should work)
 
-      # Push changes
+      # Step to push changes goes here
 
       # Run only if the pipeline is triggered by a pull request.
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -52,6 +56,6 @@ jobs:
             gitHubConnection: 'tardis-sn'
             repositoryName: 'tardis-sn/tardis'
             id: $(pr.number)
-            comment: '**Update failed** $(commit.sha) <br><br> Please check the [job log]($(log.url)).'
+            comment: '**Update failed** $(commit.sha) <br><br> Check the [job log]($(log.url)) for more information.'
           displayName: 'Post results (failed)'
           #condition: failed()  # Commented for testing purposes

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -39,7 +39,16 @@ jobs:
         displayName: 'Generate reference data'
         condition: false  # Disable temporarily (not tested but should work)
 
-      # Step to push changes goes here
+      - bash: |
+          cd $(refdata.dir)
+          git add unit_test_data.h5
+          git config --local user.email "wkerzendorf+tardis@gmail.com"
+          git config --local user.name "TARDIS Bot"
+          git commit -m "update reference data (pr $(pr.number))"
+          git remote set-url origin https://$(bot_token)@github.com/tardis-sn/tardis-refdata
+          git push origin master
+        displayName: 'Push new reference data'
+        condition: false  # Disable until final run
 
       # Run only if the pipeline is triggered by a pull request.
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -13,7 +13,7 @@ trigger: none
 pr:
   branches:
     include:
-    - '*'  # Change to `master` before merge
+    - master
 
 variables:
   system.debug: false
@@ -33,18 +33,16 @@ jobs:
         parameters:
           fetchRefdata: false  # We don't want to fetch from the mirror
           useMamba: true
-          skipInstall: true  # Disable temporarily (works ok)
+          skipInstall: false
 
       - bash: git clone https://github.com/tardis-sn/tardis-refdata $(refdata.dir)
         displayName: 'Fetch reference data repository'
-        condition: false  # Disable temporarily (works ok)
 
       - bash: |
           cd $(tardis.dir)
           source activate tardis
           pytest tardis --tardis-refdata=$(refdata.dir) --generate-reference
         displayName: 'Generate reference data'
-        condition: false  # Disable temporarily (not tested but should work)
 
       - bash: |
           cd $(refdata.dir)
@@ -55,7 +53,6 @@ jobs:
           git remote set-url origin https://$(bot_token)@github.com/tardis-sn/tardis-refdata
           git push origin master
         displayName: 'Push new reference data'
-        condition: false  # Disable until final run
 
       # Run only if the pipeline is triggered by a pull request.
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -74,4 +71,4 @@ jobs:
             id: $(pr.number)
             comment: '**Update failed** $(commit.sha) <br><br> For more information, check the [job log]($(log.url)).'
           displayName: 'Post results (failed)'
-          #condition: failed()  # Commented for testing purposes
+          condition: failed()

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -13,7 +13,7 @@ trigger: none
 pr:
   branches:
     include:
-    - '*'
+    - '*'  # Change to `master` before merge
 
 variables:
   system.debug: false

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -56,6 +56,6 @@ jobs:
             gitHubConnection: 'tardis-sn'
             repositoryName: 'tardis-sn/tardis'
             id: $(pr.number)
-            comment: '**Update failed** $(commit.sha) <br><br> Check the [job log]($(log.url)) for more information.'
+            comment: '**Update failed** $(commit.sha) <br><br> For more information, check the [job log]($(log.url)).'
           displayName: 'Post results (failed)'
           #condition: failed()  # Commented for testing purposes


### PR DESCRIPTION
## Description

- [x] `pr` trigger set for all target branches for testing, compare-refdata and update-refdata pipelines.
- [x] Write step to push new `unit_test_data.h5` to [tardis-sn/tardis-refdata](tardis-sn/tardis-refdata) repository .
- [ ] Run before merge :warning: **reference data will be updated** :warning: