### PR TITLE
Clean up numba parallelization warnings #1416

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/__init__.py
+++ b/tardis/montecarlo/montecarlo_numba/__init__.py
@@ -2,6 +2,7 @@ from llvmlite import binding
 
 binding.set_option("tmp", "-non-global-value-max-name-size=2048")
 njit_dict = {"fastmath": True, "error_model": "numpy", "parallel": True}
+njit_dict_no_parallel = {"fastmath": True, "error_model": "numpy", "parallel": False}
 
 from tardis.montecarlo.montecarlo_numba.r_packet import RPacket
 from tardis.montecarlo.montecarlo_numba.base import montecarlo_radial1d

--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -1,5 +1,5 @@
 from numba import njit
-from tardis.montecarlo.montecarlo_numba import njit_dict
+from tardis.montecarlo.montecarlo_numba import njit_dict,njit_dict_no_parallel
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
     LineInteractionType,
 )
@@ -17,7 +17,7 @@ from tardis.montecarlo.montecarlo_numba.r_packet import (
 from tardis.montecarlo.montecarlo_numba.macro_atom import macro_atom
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def thomson_scatter(r_packet, time_explosion):
     """
     Thomson scattering — no longer line scattering
@@ -50,7 +50,7 @@ def thomson_scatter(r_packet, time_explosion):
         )
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def line_scatter(r_packet, time_explosion, line_interaction_type, numba_plasma):
     """
     Line scatter function that handles the scattering itself, including new angle drawn, and calculating nu out using macro atom
@@ -84,7 +84,7 @@ def line_scatter(r_packet, time_explosion, line_interaction_type, numba_plasma):
         line_emission(r_packet, emission_line_id, time_explosion, numba_plasma)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def line_emission(r_packet, emission_line_id, time_explosion, numba_plasma):
     """
     Sets the frequency of the RPacket properly given the emission channel

--- a/tardis/montecarlo/montecarlo_numba/macro_atom.py
+++ b/tardis/montecarlo/montecarlo_numba/macro_atom.py
@@ -2,7 +2,7 @@ import numpy as np
 from enum import IntEnum
 
 from numba import njit
-from tardis.montecarlo.montecarlo_numba import njit_dict
+from tardis.montecarlo.montecarlo_numba import njit_dict ,njit_dict_no_parallel
 
 
 class MacroAtomError(ValueError):
@@ -18,7 +18,7 @@ class MacroAtomTransitionType(IntEnum):
     ADIABATIC_COOLING = -4
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def macro_atom(r_packet, numba_plasma):
     """
     Parameters

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -5,7 +5,7 @@ from numba import njit
 from numba.experimental import jitclass
 
 import math
-from tardis.montecarlo.montecarlo_numba import njit_dict, numba_config
+from tardis.montecarlo.montecarlo_numba import njit_dict, numba_config , njit_dict_no_parallel
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
@@ -82,7 +82,7 @@ class RPacket(object):
         self.next_line_id = next_line_id
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calculate_distance_boundary(r, mu, r_inner, r_outer):
     """
     Calculate distance to shell boundary in cm.
@@ -126,7 +126,7 @@ def calculate_distance_boundary(r, mu, r_inner, r_outer):
 
 # @log_decorator
 #'float64(RPacket, float64, int64, float64, float64)'
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calculate_distance_line(
     r_packet, comov_nu, is_last_line, nu_line, time_explosion
 ):
@@ -177,7 +177,7 @@ def calculate_distance_line(
     return distance
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calculate_distance_line_full_relativity(
     nu_line, nu, time_explosion, r_packet
 ):
@@ -202,7 +202,7 @@ def calculate_distance_line_full_relativity(
     return distance
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calculate_distance_electron(electron_density, tau_event):
     """
     Calculate distance to Thomson Scattering
@@ -216,7 +216,7 @@ def calculate_distance_electron(electron_density, tau_event):
     return tau_event / (electron_density * numba_config.SIGMA_THOMSON)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calculate_tau_electron(electron_density, distance):
     """
     Calculate tau for Thomson scattering
@@ -229,7 +229,7 @@ def calculate_tau_electron(electron_density, distance):
     return electron_density * numba_config.SIGMA_THOMSON * distance
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_doppler_factor(r, mu, time_explosion):
     inv_c = 1 / C_SPEED_OF_LIGHT
     inv_t = 1 / time_explosion
@@ -240,17 +240,17 @@ def get_doppler_factor(r, mu, time_explosion):
         return get_doppler_factor_full_relativity(mu, beta)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_doppler_factor_partial_relativity(mu, beta):
     return 1.0 - mu * beta
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_doppler_factor_full_relativity(mu, beta):
     return (1.0 - mu * beta) / math.sqrt(1 - beta * beta)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_inverse_doppler_factor(r, mu, time_explosion):
     """
     Calculate doppler factor for frame transformation
@@ -270,22 +270,22 @@ def get_inverse_doppler_factor(r, mu, time_explosion):
         return get_inverse_doppler_factor_full_relativity(mu, beta)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_inverse_doppler_factor_partial_relativity(mu, beta):
     return 1.0 / (1.0 - mu * beta)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_inverse_doppler_factor_full_relativity(mu, beta):
     return (1.0 + mu * beta) / math.sqrt(1 - beta * beta)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def get_random_mu():
     return 2.0 * np.random.random() - 1.0
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def update_line_estimators(
     estimators, r_packet, cur_line_id, distance_trace, time_explosion
 ):
@@ -322,13 +322,13 @@ def update_line_estimators(
     ] += energy
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calc_packet_energy_full_relativity(r_packet):
     # accurate to 1 / gamma - according to C. Vogl
     return r_packet.energy
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def calc_packet_energy(r_packet, distance_trace, time_explosion):
     doppler_factor = 1.0 - (
         (distance_trace + r_packet.mu * r_packet.r)
@@ -338,7 +338,7 @@ def calc_packet_energy(r_packet, distance_trace, time_explosion):
     return energy
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def trace_packet(r_packet, numba_model, numba_plasma, estimators):
     """
     Traces the RPacket through the ejecta and stops when an interaction happens (heart of the calculation)
@@ -493,7 +493,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
     return distance, interaction_type, delta_shell
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
     """
     Move packet a distance and recalculate the new angle mu
@@ -540,7 +540,7 @@ def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
             )
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def set_estimators(r_packet, distance, numba_estimator, comov_nu, comov_energy):
     """
     Updating the estimators
@@ -553,7 +553,7 @@ def set_estimators(r_packet, distance, numba_estimator, comov_nu, comov_energy):
     )
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def set_estimators_full_relativity(
     r_packet, distance, numba_estimator, comov_nu, comov_energy, doppler_factor
 ):
@@ -565,7 +565,7 @@ def set_estimators_full_relativity(
     )
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def move_packet_across_shell_boundary(packet, delta_shell, no_of_shells):
     """
     Move packet across shell boundary - realizing if we are still in the simulation or have
@@ -593,7 +593,7 @@ def move_packet_across_shell_boundary(packet, delta_shell, no_of_shells):
         packet.current_shell_id = next_shell_id
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def angle_aberration_CMF_to_LF(r_packet, time_explosion, mu):
     """
     Converts angle aberration from comoving frame to
@@ -604,7 +604,7 @@ def angle_aberration_CMF_to_LF(r_packet, time_explosion, mu):
     return (r_packet.mu + beta) / (1.0 + beta * mu)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def angle_aberration_LF_to_CMF(r_packet, time_explosion, mu):
     """
 
@@ -617,7 +617,7 @@ def angle_aberration_LF_to_CMF(r_packet, time_explosion, mu):
     return (mu - beta) / (1.0 - beta * mu)
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def test_for_close_line(r_packet, line_id, nu_line, numba_plasma):
     r_packet.is_close_line = abs(
         numba_plasma.line_list_nu[line_id] - nu_line

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -2,7 +2,7 @@ from numba import float64, int64, boolean
 from numba import njit, gdb
 from numba.experimental import jitclass
 
-from tardis.montecarlo.montecarlo_numba import njit_dict
+from tardis.montecarlo.montecarlo_numba import njit_dict , njit_dict_no_parallel
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
@@ -58,7 +58,7 @@ class VPacket(object):
         self.is_close_line = is_close_line
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def trace_vpacket_within_shell(v_packet, numba_model, numba_plasma):
     """
     Trace VPacket within one shell (relatively simple operation)
@@ -134,7 +134,7 @@ def trace_vpacket_within_shell(v_packet, numba_model, numba_plasma):
     return tau_trace_combined, distance_boundary, delta_shell
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def trace_vpacket(v_packet, numba_model, numba_plasma):
     """
     Trace single vpacket.
@@ -189,7 +189,7 @@ def trace_vpacket(v_packet, numba_model, numba_plasma):
     return tau_trace_combined
 
 
-@njit(**njit_dict)
+@njit(**njit_dict_no_parallel)
 def trace_vpacket_volley(
     r_packet, vpacket_collection, numba_model, numba_plasma
 ):


### PR DESCRIPTION
This pull request resolves the large number of warnings that were printed because of numba parallelization njit_dict = {"parallel": True} failing for some functions.

## Description
The changes made to the code are
- Declared a new dict in tardis/montecarlo/montecarlo_numba/init.py
```njit_dict_no_parallel = {"fastmath": True, "error_model": "numpy", "parallel": False}```
- Replaced the ```njit_dict ``` with ```njit_dict_no_parallel``` for all the functions that were giving warning while running the jupyter cell


## Motivation and Context
This pull request addresses the issue raised in #1416
Initially, a large number of warning were raised due to 2 major issues -
- RuntimeWarning: divide by zero encountered in double_scalars
- The keyword argument 'parallel=True' was specified but no transformation for parallel execution was possible.

This PR resolves the issue raised without hampering the performance by resolving the warning caused due to 2nd reason.
The numba parallelization had to be applied to the code more selectively instead of as a single dict


## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [x] Other (please describe)

I built the documentation locally. The number of warnings decreased, and everything built as expected. I ran the example notebook https://tardis-sn.github.io/tardis/quickstart/quickstart.html in the ```conda tardis``` environment as described in docs .

I also performed the unit test using ``` python setup.py test ``` and got this log output 
```156 passed, 1254 skipped, 6 xpassed in 17.79s```

Final Log Output before changes:
```Simulation finished in 20 iterations and took 45.60 s (base.py:384```
Final Log Output after changes:
```Simulation finished in 20 iterations and took 44.96 s (base.py:384)```

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
These are some ss from the entire log file

### Before 

<img width="559" alt="Screenshot 2021-02-09 at 12 19 30 AM" src="https://user-images.githubusercontent.com/57298405/107469538-ec118a80-6b8f-11eb-81c3-de5b1550b9d3.png">
<img width="559" alt="Screenshot 2021-02-09 at 12 19 39 AM" src="https://user-images.githubusercontent.com/57298405/107469555-f59af280-6b8f-11eb-834e-3d2debe7b87d.png">
<img width="490" alt="Screenshot 2021-02-10 at 10 47 08 AM" src="https://user-images.githubusercontent.com/57298405/107469633-16fbde80-6b90-11eb-9b6a-5f0bd317ef74.png">

### After

<img width="559" alt="Screenshot 2021-02-10 at 10 43 44 AM" src="https://user-images.githubusercontent.com/57298405/107473181-431a5e00-6b96-11eb-86f9-78f8faf857c7.png">
<img width="559" alt="Screenshot 2021-02-10 at 10 43 51 AM" src="https://user-images.githubusercontent.com/57298405/107473186-44e42180-6b96-11eb-828d-2ffcff7d6bd3.png">
<img width="559" alt="Screenshot 2021-02-10 at 10 43 59 AM" src="https://user-images.githubusercontent.com/57298405/107473213-53cad400-6b96-11eb-8276-ba41bb932489.png">

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [ ] I have assigned and requested two reviewers for this pull request
