### PR TITLE
Fixed the array types when interpolate_shells > 0.  Now returns the p…

### DIFF
--- a/tardis/montecarlo/formal_integral.py
+++ b/tardis/montecarlo/formal_integral.py
@@ -250,26 +250,26 @@ class FormalIntegrator(object):
 
         r_middle_integ = (r_integ[:-1] + r_integ[1:]) / 2.0
 
-        runner.electron_densities_integ = interp1d(
+        runner.electron_densities_integ = pd.Series(interp1d(
             r_middle,
             plasma.electron_densities,
             fill_value="extrapolate",
             kind="nearest",
-        )(r_middle_integ)
+        )(r_middle_integ))
         # Assume tau_sobolevs to be constant within a shell
         # (as in the MC simulation)
-        runner.tau_sobolevs_integ = interp1d(
+        runner.tau_sobolevs_integ = pd.DataFrame(interp1d(
             r_middle,
             plasma.tau_sobolevs,
             fill_value="extrapolate",
             kind="nearest",
-        )(r_middle_integ)
+        )(r_middle_integ))
         att_S_ul = interp1d(r_middle, att_S_ul, fill_value="extrapolate")(
             r_middle_integ
         )
-        Jredlu = interp1d(r_middle, Jredlu, fill_value="extrapolate")(
+        Jredlu = pd.DataFrame(interp1d(r_middle, Jredlu, fill_value="extrapolate")(
             r_middle_integ
-        )
+        ))
         Jbluelu = interp1d(r_middle, Jbluelu, fill_value="extrapolate")(
             r_middle_integ
         )


### PR DESCRIPTION
When interpolate_shells > 0, the formal integral broke with an attribute error claiming that numpy arrays had no attribute "values"
Issue #1463 

<!--- Provide a general summary of your changes in the title above. -->
I've corrected the return types of one of the functions so that they are no longer numpy arrays.

## Description
<!--- Describe your changes in detail. -->
When interpolate_shells > 0, `interpolate_integrator_quantities` would change the type of electron_densities_integ, tau_sobolev_integ, and Jredlu from pandas dataframes or series to numpy arrays due to the fact that `scipy.interp1d` always returns a numpy array.  This was problematic because the formal_integral Cython wrapper access the `.values` attributes of these arrays assuming they were pandas objects.  I've corrected this so now these arrays are set to have the correct type.
## Motivation and Context
Now interpolate_shells can have values greater than 0 without failing.

## How Has This Been Tested?
- [x] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
