### PR TITLE
[DO NOT MERGE] review reference data before update

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  ref1.hash: 'b447418'
-  ref2.hash: 'b6e5238'
+  ref1.hash: 'b6e5238'
+  ref2.hash: 'ae743ac'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  ref1.hash: 'b6e5238'
-  ref2.hash: 'ae743ac'
+  ref1.hash: 'ae743ac'
+  ref2.hash: 'upstream/master'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  ref1.hash: 'b6e5238'
-  ref2.hash: 'ae743ac'
+  ref1.hash: 'b447418'
+  ref2.hash: 'b6e5238'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  ref1.hash: 'ae743ac'
-  #ref2.hash: ''
+  #ref1.hash: ''
+  ref2.hash: 'ae743ac'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -17,7 +17,7 @@ variables:
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
   ref1.hash: 'ae743ac'
-  ref2.hash: 'upstream/master'
+  #ref2.hash: ''
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  ref1.hash: 'b447418'
-  ref2.hash: 'b6e5283'
+  ref1.hash: 'b6e5238'
+  ref2.hash: 'ae743ac'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  ref1.hash: '0a890a0'
-  ref2.hash: 'b447418'
+  ref1.hash: 'b447418'
+  ref2.hash: 'b6e5283'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  #ref1.hash: ''
-  ref2.hash: 'ae743ac'
+  ref1.hash: 'ae743ac'
+  ref2.hash: '9c6dc59'
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -16,8 +16,8 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  #ref1.hash: ''
-  #ref2.hash: ''
+  ref1.hash: '0a890a0'
+  ref2.hash: 'b447418'
 
 pool:
   vmImage: 'ubuntu-latest'


### PR DESCRIPTION
Here we review/discuss the changes to the reference data made since 2019 before we update it again.

I selected some commits to compare based on the [history](https://github.com/tardis-sn/tardis-refdata/commits/master/unit_test_data.h5) of file `unit_test_data.h5`:

- `0a890a0` **add fix for NLTE normalization** (Apr 2019) :vs: `b447418` **Added unit test for black body sampling** (Jan 2020) - [click here](http://opensupernova.org/~azuredevops/files/refdata-results/1467/12c98e9c63d532e9187519520b93f1876b169d91.html)
- `b447418` :vs: `b6e5238` **Update refdata (integrated luminosity)** (Jan 2020) - [click here](http://opensupernova.org/~azuredevops/files/refdata-results/1467/dea2e6a4557b9591c04cb72da4227603af8362c8.html)
- `b6e5238` :vs: `ae743ac` **Really fixed refdata this time (numba)** (Nov 2021) - [click here](http://opensupernova.org/~azuredevops/files/refdata-results/1467/c561cb70237096a92c9572b825e0082487751a46.html)
- `ae743ac` :vs: **refdata generated with latest `tardis` commit** (Feb 2021) - [click here](http://opensupernova.org/~azuredevops/files/refdata-results/1467/5a006ff11a08aabaee0899d4e6719bb1203f7179.html)
- `ae743ac` :vs: `9c6dc59` **updated test data to include formal integral values** (Apr 2021) - [click here](http://opensupernova.org/~azuredevops/files/refdata-results/1467/b15e8454b2e77e9df3ed05612be3efc2bde858e3.html)

You can safely ignore the Azure Bot comments and failed runs below (my bad!).
