### PR TITLE
Added Documentation for Parallel execution with Numba and OpenMP

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ Mission Statement
     using/components/index
     using/visualization/index
     using/interaction/index
+    using/parallelisation/index
 
 
 .. toctree::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -78,31 +78,6 @@ then install TARDIS, as follows::
     python setup.py install
 
 
-.. _install_openmp:
-
-Enabling parallel execution with OpenMP
----------------------------------------
-
-
-Manually, cloning the repository enables other options such as running the code in parallel (enabling OpenMP).
-In general, we encourage downloading the compilers from `conda` as we then can ensure that they work with TARDIS.
-Within the TARDIS conda environment do::
-
-    conda install -c conda-forge compilers
-
-For macOS::
-
-    conda install -c conda-forge llvm-openmp
-
-For Linux::
-
-    conda install -c conda-forge openmp
-
-To compile TARDIS for parallel execution::
-
-    python setup.py install --with-openmp
-
-
 .. _troubleshooting_inst_label:
 
 Installation Troubles (FAQ)

--- a/docs/using/interaction/using_formal_integral.rst
+++ b/docs/using/interaction/using_formal_integral.rst
@@ -23,4 +23,6 @@ Note that the integrated spectrum (``simulation.runner.spectrum_integrated``)
 is a lazy property so it will be only generated (and then cached) once it is
 accessed. The spectrum integration routine is Open-MP parallelized, so this
 process may be significantly sped-up if TARDIS is built with the
-``--with-openmp`` option and more then one thread is used.
+``--with-openmp`` option and more then one thread is used. More instructions on
+how to enable parallelisation of the code is given in the :ref:`parallelisation`
+section.

--- a/docs/using/parallelisation/index.rst
+++ b/docs/using/parallelisation/index.rst
@@ -27,7 +27,7 @@ To compile TARDIS for parallel execution::
 
 
 
-Usage Guide
+Numba Usage Guide
 ===========
 
 The ``montecarlo`` section of the Configuration file accepts the parameter ``nthreads`` which sets the number of

--- a/docs/using/parallelisation/index.rst
+++ b/docs/using/parallelisation/index.rst
@@ -1,0 +1,36 @@
+.. _parallelisation:
+
+*****************************************
+Parallel execution with Numba and OpenMP
+*****************************************
+
+Enabling parallel execution with OpenMP
+========================================
+
+Manually, cloning the repository enables other options such as running the code in parallel (enabling OpenMP).
+In general, we encourage downloading the compilers from `conda` as we then can ensure that they work with TARDIS.
+Within the TARDIS conda environment do::
+
+    conda install -c conda-forge compilers
+
+For macOS::
+
+    conda install -c conda-forge llvm-openmp
+
+For Linux::
+
+    conda install -c conda-forge openmp
+
+To compile TARDIS for parallel execution::
+
+    python setup.py install --with-openmp
+
+
+
+Usage Guide
+===========
+
+The ``montecarlo`` section of the Configuration file accepts the parameter ``nthreads`` which sets the number of
+threads to be used for parallelisation. Setting the value of the parameter between 1 and the environment variable
+``NUMBA_NUM_THREADS`` (which is, by default, the number of CPU cores on your system) will automatically invoke Numba
+to parallelise the code. (See :ref:`config-file` section).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Fixes #1376 
This PR adds a clear documentation to achieve parallelisation in code using Numba and OpenMP, using configuration parameters such as `nthreads`. 
The old documentation has been moved from the Installation section and a new section is created to provide the instructions. (as advised by @andrewfullard).
Relevant links has also been added.

@andrewfullard @wkerzendorf Kindly review.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [x] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
The Documentation preview has been made available in https://aribalam.github.io/tardis/

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] None of the above (Documentation fix)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [X] I have assigned and requested two reviewers for this pull request
