### PR TITLE
Added Verbosity option and Convergence Plot for Project: Notebook Logging Framework

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -37,7 +37,7 @@ omit =
    tardis/simulation/setup_package.py
    tardis/io/setup_package.py
 
-   tardis/gui*
+   tardis/gui/*
    tardis/stats/*
    tardis/analysis.py
 

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -2,7 +2,11 @@
 
 
 def run_tardis(
-    config, atom_data=None, packet_source=None, simulation_callbacks=[], verbose = 0
+    config,
+    atom_data=None,
+    packet_source=None,
+    simulation_callbacks=[],
+    verbose=0,
 ):
     """
     This function is one of the core functions to run TARDIS from a given
@@ -25,7 +29,7 @@ def run_tardis(
     from tardis.simulation import Simulation
     import warnings
 
-    if verbose==1:
+    if verbose == 1:
         warnings.filterwarnings("default")
     else:
         warnings.filterwarnings("ignore")

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -2,7 +2,7 @@
 
 
 def run_tardis(
-    config, atom_data=None, packet_source=None, simulation_callbacks=[]
+    config, atom_data=None, packet_source=None, simulation_callbacks=[], verbose = 0
 ):
     """
     This function is one of the core functions to run TARDIS from a given
@@ -23,6 +23,12 @@ def run_tardis(
     from tardis.io.config_reader import Configuration
     from tardis.io.atom_data.base import AtomData
     from tardis.simulation import Simulation
+    import warnings
+
+    if verbose==1:
+        warnings.filterwarnings("default")
+    else:
+        warnings.filterwarnings("ignore")
 
     if atom_data is not None:
         try:

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -24,6 +24,13 @@ def run_tardis(
         the atomic data. Atomic data to use for this TARDIS simulation. If set to None, the
         atomic data will be loaded according to keywords set in the configuration
         [default=None]
+    virtual_packet_logging : bool
+        option to enable virtual packet logging
+        [default=False]
+
+    Returns
+    -------
+    Simulation
     """
     from tardis.io.config_reader import Configuration
     from tardis.io.atom_data.base import AtomData
@@ -47,7 +54,10 @@ def run_tardis(
         tardis_config = Configuration.from_config_dict(config)
 
     simulation = Simulation.from_config(
-        tardis_config, packet_source=packet_source, atom_data=atom_data
+        tardis_config,
+        packet_source=packet_source,
+        atom_data=atom_data,
+        virtual_packet_logging=virtual_packet_logging,
     )
     for cb in simulation_callbacks:
         simulation.add_callback(*cb)

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -24,13 +24,6 @@ def run_tardis(
         the atomic data. Atomic data to use for this TARDIS simulation. If set to None, the
         atomic data will be loaded according to keywords set in the configuration
         [default=None]
-    virtual_packet_logging : bool
-        option to enable virtual packet logging
-        [default=False]
-
-    Returns
-    -------
-    Simulation
     """
     from tardis.io.config_reader import Configuration
     from tardis.io.atom_data.base import AtomData
@@ -54,10 +47,7 @@ def run_tardis(
         tardis_config = Configuration.from_config_dict(config)
 
     simulation = Simulation.from_config(
-        tardis_config,
-        packet_source=packet_source,
-        atom_data=atom_data,
-        virtual_packet_logging=virtual_packet_logging,
+        tardis_config, packet_source=packet_source, atom_data=atom_data
     )
     for cb in simulation_callbacks:
         simulation.add_callback(*cb)

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -6,6 +6,7 @@ def run_tardis(
     atom_data=None,
     packet_source=None,
     simulation_callbacks=[],
+    virtual_packet_logging=False,
     verbose=0,
 ):
     """

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -451,6 +451,9 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self.iteration_count += 1
 
     def run(self):
+        """
+        run the simulation
+        """
         start_time = time.time()
         while self.iterations_executed < self.iterations - 1:
             self.store_plasma_state(
@@ -517,6 +520,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         Returns
         -------
         """
+
         self.visualize(t_rad, w, next_t_rad, next_w)
         plasma_state_log = pd.DataFrame(
             index=np.arange(len(t_rad)),
@@ -604,13 +608,16 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             return False
 
     @classmethod
-    def from_config(cls, config, packet_source=None, **kwargs):
+    def from_config(
+        cls, config, packet_source=None, virtual_packet_logging=False, **kwargs
+    ):
         """
         Create a new Simulation instance from a Configuration object.
 
         Parameters
         ----------
         config : tardis.io.config_reader.Configuration
+
         **kwargs
             Allow overriding some structures, such as model, plasma, atomic data
             and the runner, instead of creating them from the configuration
@@ -643,7 +650,9 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             runner = kwargs["runner"]
         else:
             runner = MontecarloRunner.from_config(
-                config, packet_source=packet_source
+                config,
+                packet_source=packet_source,
+                virtual_packet_logging=virtual_packet_logging,
             )
 
         luminosity_nu_start = config.supernova.luminosity_wavelength_end.to(

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -1,3 +1,5 @@
+#code for simulation and visualization
+
 import time
 import logging
 import numpy as np

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -1,4 +1,4 @@
-#code for simulation and visualization
+# code for simulation and visualization
 
 import time
 import logging
@@ -381,6 +381,22 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self.iterations_executed += 1
 
     def visualization(self, t_rad, w, next_t_rad, next_w):
+        """
+        Visualize convergence of the plot
+
+        Parameters
+        ----------
+        t_rad : astropy.units.Quanity
+            current t_rad
+        w : astropy.units.Quanity
+            current w
+        next_t_rad : astropy.units.Quanity
+            next t_rad
+        next_w : astropy.units.Quanity
+            next_w
+        Returns
+        -------
+        """
         t_rad = list(t_rad)
         w = list(w)
         next_t_rad = list(next_t_rad)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -1,5 +1,3 @@
-# code for simulation and visualization
-
 import time
 import logging
 import numpy as np
@@ -130,6 +128,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
     iteration_count = 0
 
+    # plot figure details
     fig1 = go.FigureWidget()
     fig1.add_scatter(name="shell 0")
     fig1.add_scatter(name="shell 5")
@@ -395,12 +394,6 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
     def visualize(self, t_rad, w, next_t_rad, next_w):
         """
-        Visualize convergence of the plot:
-        1. Radiation Temperature vs. Iteration
-        2. Dilution Factor vs. Iteration
-        3. Radiation Temperature vs. Shell
-        4. Dilution Factor vs. Shell
-
         Parameters
         ----------
         t_rad : astropy.units.Quanity
@@ -416,56 +409,27 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         """
         if len(self.tmp_dict["t_rad_shell_0"]) == 0:
             display(self.fig1, self.fig2)
-            self.tmp_dict["t_rad_shell_0"].extend(
-                [t_rad[0].value, next_t_rad[0].value]
-            )
-            self.tmp_dict["t_rad_shell_5"].extend(
-                [t_rad[5].value, next_t_rad[5].value]
-            )
-            self.tmp_dict["t_rad_shell_10"].extend(
-                [t_rad[10].value, next_t_rad[10].value]
-            )
-            self.tmp_dict["t_rad_shell_15"].extend(
-                [t_rad[15].value, next_t_rad[15].value]
-            )
-            self.tmp_dict["w_shell_0"].extend([w[0], next_w[0]])
-            self.tmp_dict["w_shell_5"].extend([w[5], next_w[5]])
-            self.tmp_dict["w_shell_10"].extend([w[10], next_w[10]])
-            self.tmp_dict["w_shell_15"].extend([w[15], next_w[15]])
 
-            with self.fig1.batch_update():
-                self.fig1.data[0].y = self.tmp_dict["t_rad_shell_0"]
-                self.fig1.data[1].y = self.tmp_dict["t_rad_shell_5"]
-                self.fig1.data[2].y = self.tmp_dict["t_rad_shell_10"]
-                self.fig1.data[3].y = self.tmp_dict["t_rad_shell_15"]
+        self.tmp_dict["t_rad_shell_0"].extend([next_t_rad[0].value])
+        self.tmp_dict["t_rad_shell_5"].extend([next_t_rad[5].value])
+        self.tmp_dict["t_rad_shell_10"].extend([next_t_rad[10].value])
+        self.tmp_dict["t_rad_shell_15"].extend([next_t_rad[15].value])
+        self.tmp_dict["w_shell_0"].extend([next_w[0]])
+        self.tmp_dict["w_shell_5"].extend([next_w[5]])
+        self.tmp_dict["w_shell_10"].extend([next_w[10]])
+        self.tmp_dict["w_shell_15"].extend([next_w[15]])
 
-            with self.fig2.batch_update():
-                self.fig2.data[0].y = self.tmp_dict["w_shell_0"]
-                self.fig2.data[1].y = self.tmp_dict["w_shell_5"]
-                self.fig2.data[2].y = self.tmp_dict["w_shell_10"]
-                self.fig2.data[3].y = self.tmp_dict["w_shell_15"]
+        with self.fig1.batch_update():
+            self.fig1.data[0].y = self.tmp_dict["t_rad_shell_0"]
+            self.fig1.data[1].y = self.tmp_dict["t_rad_shell_5"]
+            self.fig1.data[2].y = self.tmp_dict["t_rad_shell_10"]
+            self.fig1.data[3].y = self.tmp_dict["t_rad_shell_15"]
 
-        else:
-            self.tmp_dict["t_rad_shell_0"].extend([next_t_rad[0].value])
-            self.tmp_dict["t_rad_shell_5"].extend([next_t_rad[5].value])
-            self.tmp_dict["t_rad_shell_10"].extend([next_t_rad[10].value])
-            self.tmp_dict["t_rad_shell_15"].extend([next_t_rad[15].value])
-            self.tmp_dict["w_shell_0"].extend([next_w[0]])
-            self.tmp_dict["w_shell_5"].extend([next_w[5]])
-            self.tmp_dict["w_shell_10"].extend([next_w[10]])
-            self.tmp_dict["w_shell_15"].extend([next_w[15]])
-
-            with self.fig1.batch_update():
-                self.fig1.data[0].y = self.tmp_dict["t_rad_shell_0"]
-                self.fig1.data[1].y = self.tmp_dict["t_rad_shell_5"]
-                self.fig1.data[2].y = self.tmp_dict["t_rad_shell_10"]
-                self.fig1.data[3].y = self.tmp_dict["t_rad_shell_15"]
-
-            with self.fig2.batch_update():
-                self.fig2.data[0].y = self.tmp_dict["w_shell_0"]
-                self.fig2.data[1].y = self.tmp_dict["w_shell_5"]
-                self.fig2.data[2].y = self.tmp_dict["w_shell_10"]
-                self.fig2.data[3].y = self.tmp_dict["w_shell_15"]
+        with self.fig2.batch_update():
+            self.fig2.data[0].y = self.tmp_dict["w_shell_0"]
+            self.fig2.data[1].y = self.tmp_dict["w_shell_5"]
+            self.fig2.data[2].y = self.tmp_dict["w_shell_10"]
+            self.fig2.data[3].y = self.tmp_dict["w_shell_15"]
 
         tmp_t_rad = []
         tmp_w = []

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -5,6 +5,7 @@ import logging
 import numpy as np
 import pandas as pd
 import plotly.graph_objs as go
+from IPython.display import display
 from astropy import units as u, constants as const
 from collections import OrderedDict
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -128,7 +128,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         "w_shell_15": [],
     }
 
-    iteration_count=0
+    iteration_count = 0
 
     fig1 = go.FigureWidget()
     fig1.add_scatter(name="shell 0")
@@ -466,10 +466,10 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 self.fig2.data[1].y = self.tmp_dict["w_shell_5"]
                 self.fig2.data[2].y = self.tmp_dict["w_shell_10"]
                 self.fig2.data[3].y = self.tmp_dict["w_shell_15"]
-        
+
         tmp_t_rad = []
         tmp_w = []
-        if self.iteration_count==0:
+        if self.iteration_count == 0:
             display(self.fig3, self.fig4)
         for i in range(len(next_t_rad)):
             tmp_t_rad.extend([next_t_rad[i].value])
@@ -477,19 +477,16 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             tmp_w.extend([next_w[i]])
 
         with self.fig3.batch_update():
-            self.fig3.add_scatter(name="iteration "+str(self.iteration_count))
+            self.fig3.add_scatter(name="iteration " + str(self.iteration_count))
             self.fig3.data[self.iteration_count].y = tmp_t_rad
-        
+
         with self.fig4.batch_update():
-            self.fig4.add_scatter(name="iteration "+str(self.iteration_count))
+            self.fig4.add_scatter(name="iteration " + str(self.iteration_count))
             self.fig4.data[self.iteration_count].y = tmp_w
-        
-        self.iteration_count+=1
+
+        self.iteration_count += 1
 
     def run(self):
-        """
-        run the simulation
-        """
         start_time = time.time()
         while self.iterations_executed < self.iterations - 1:
             self.store_plasma_state(
@@ -643,16 +640,13 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             return False
 
     @classmethod
-    def from_config(
-        cls, config, packet_source=None, virtual_packet_logging=False, **kwargs
-    ):
+    def from_config(cls, config, packet_source=None, **kwargs):
         """
         Create a new Simulation instance from a Configuration object.
 
         Parameters
         ----------
         config : tardis.io.config_reader.Configuration
-
         **kwargs
             Allow overriding some structures, such as model, plasma, atomic data
             and the runner, instead of creating them from the configuration
@@ -685,9 +679,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             runner = kwargs["runner"]
         else:
             runner = MontecarloRunner.from_config(
-                config,
-                packet_source=packet_source,
-                virtual_packet_logging=virtual_packet_logging,
+                config, packet_source=packet_source
             )
 
         luminosity_nu_start = config.supernova.luminosity_wavelength_end.to(


### PR DESCRIPTION
## Description
Add a verbosity option that suppresses warnings by default but allows errors. Changes were made in base.py file by adding additional argument in run_simulation function (verbose). Default value of verbose is set to 0, which by default hides the warnings content, whereas when verbose is set to 1, it will show the warnings.

## Motivation and Context
When TARDIS is run, log output including warnings and other prints, are dumped to the standard output. This creates confusing messaging for the end user. So in order to reduce this confusion, the user should be provided with the choice to suppress warnings, but not errors.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [x] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
This feature is tested on tardis_example.yml file which by default shows warnings, but when verbose is set to 1 the warnings stay hidden.
- To hide the warnings: `sim = run_tardis('tardis_example.yml')` or `sim = run_tardis('tardis_example.yml', verbose=0)`
- To show the warnings: `sim = run_tardis('tardis_example.yml', verbose=1)`

## Screenshots (if appropriate):
-Verbose=0 _(By default)_ without warnings
![FireShot Capture 031 - quickstart - Jupyter Notebook - localhost](https://user-images.githubusercontent.com/43725247/111354204-11704780-86ac-11eb-8090-33ccba983f58.jpg)

-Verbose=1 showing warnings
![FireShot Capture 028 - quickstart - Jupyter Notebook - localhost](https://user-images.githubusercontent.com/43725247/111354114-fa315a00-86ab-11eb-906c-9f37a8a6039c.jpg)



## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [ ] I have assigned and requested two reviewers for this pull request
