### PR TITLE
Fix docstring mistakes in #1145

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -78,7 +78,7 @@ class AtomData(object):
             index : numerical index;
             columns : atomic_number, ion_number, level_number, nu[Hz], x_sect[cm^2]
 
-    two_photon_data: pandas.DataFrame
+    two_photon_data : pandas.DataFrame
         A DataFrame containing the *two photon decay data* with:
             index: atomic_number, ion_number, level_number_lower, level_number_upper
             columns: A_ul[1/s], nu0[Hz], alpha, beta, gamma
@@ -97,7 +97,7 @@ class AtomData(object):
     symbol2atomic_number : OrderedDict
     atomic_number2symbol : OrderedDict
     photoionization_data : pandas.DataFrame
-    two_photon_data: pandas.DataFrame
+    two_photon_data : pandas.DataFrame
 
     Methods
     -------

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -121,14 +121,14 @@ class PhotoIonizationData(ProcessingPlasmaProperty):
         Indices where the photoionization data for
         a given level starts. Needed for calculation
         of recombination rates.
-    nu_i: pandas.Series, dtype float
+    nu_i : pandas.Series, dtype float
         Threshold frequencies for ionization
-    energy_i: pandas.Series, dtype float
+    energy_i : pandas.Series, dtype float
         Energies of levels with bound-free transitions. Needed to calculate
         for example internal transition probabilities in the macro atom scheme.
-    photo_ion_index: pandas.MultiIndex, dtype int
+    photo_ion_index : pandas.MultiIndex, dtype int
         Atomic, ion and level numbers for which photoionization data exists.
-    level2continuum_idx: pandas.Series, dtype int
+    level2continuum_idx : pandas.Series, dtype int
         Maps a level MultiIndex (atomic_number, ion_number, level_number) to
         the continuum_idx of the corresponding bound-free continuum (which are
         sorted by decreasing frequency).
@@ -209,7 +209,7 @@ class TwoPhotonData(ProcessingPlasmaProperty):
         alpha, beta, gamma are fit coefficients for the frequency dependent
         transition probability A(y) of the two photon decay. See Eq. 2 in
         Nussbaumer & Schmutz (1984).
-    two_photon_idx: pandas.DataFrame, dtype int
+    two_photon_idx : pandas.DataFrame, dtype int
     """
 
     def calculate(self, atomic_data, continuum_interaction_species):
@@ -512,7 +512,7 @@ class YgData(ProcessingPlasmaProperty):
         ----------
         atomic_data : tardis.io.atom_data.AtomData
         t_electrons : numpy.ndarray
-        continuun_interaction_species : pandas.MultiIndex
+        continuum_interaction_species : pandas.MultiIndex
 
         Returns
         -------

--- a/tardis/plasma/properties/continuum_processes.py
+++ b/tardis/plasma/properties/continuum_processes.py
@@ -65,17 +65,17 @@ def integrate_array_by_blocks(f, x, block_references):
 
     Parameters
     ----------
-    f : Two-dimensional Numpy Array, dtype float
-        Input array to integrate.
-    x : One-dimensional Numpy Array, dtype float
-        The sample points corresponding to the `f` values.
-    block_references : One-dimensional Numpy Array, dtype int
-        The start indices of the blocks to be integrated.
+    f : numpy.ndarray, dtype float
+        2D input array to integrate.
+    x : numpy.ndarray, dtype float
+        1D array with the sample points corresponding to the `f` values.
+    block_references : numpy.ndarray, dtype int
+        1D array with the start indices of the blocks to be integrated.
 
     Returns
     -------
-    Two-dimensional Numpy Array, dtype float
-        Array with integrated values.
+    numpy.ndarray, dtype float
+        2D array with integrated values.
     """
     integrated = np.zeros((len(block_references) - 1, f.shape[1]))
     for i in prange(f.shape[1]):  # columns
@@ -781,7 +781,7 @@ class TwoPhotonEmissionCDF(ProcessingPlasmaProperty):
 
         Parameters
         ----------
-        y : np.ndarray, dtype float
+        y : numpy.ndarray, dtype float
             Emission frequency divided by that of the normal line
             transition corresponding to the two photon decay.
         alpha : float
@@ -793,7 +793,7 @@ class TwoPhotonEmissionCDF(ProcessingPlasmaProperty):
 
         Returns
         -------
-        np.ndarray, dtype float
+        numpy.ndarray, dtype float
             Unnormalized two photon emissivity in the frequency scale.
         """
         ay = y * (1 - y) * (1 - (4 * y * (1 - y)) ** gamma)
@@ -900,6 +900,7 @@ class BoundFreeOpacity(ProcessingPlasmaProperty):
     Attributes
     ----------
     chi_bf : pandas.DataFrame, dtype float
+        Bound-free opacity corrected for stimulated emission.
     """
 
     outputs = ("chi_bf",)

--- a/tardis/plasma/properties/continuum_processes.py
+++ b/tardis/plasma/properties/continuum_processes.py
@@ -784,11 +784,11 @@ class TwoPhotonEmissionCDF(ProcessingPlasmaProperty):
         y : np.ndarray, dtype float
             Emission frequency divided by that of the normal line
             transition corresponding to the two photon decay.
-        alpha: float
+        alpha : float
             Fit coefficient.
-        beta: float
+        beta : float
             Fit coefficient.
-        gamma: float
+        gamma : float
             Fit coefficient.
 
         Returns
@@ -863,7 +863,7 @@ class FreeBoundCoolingRate(TransitionProbabilitiesProperty):
         The total free-bound cooling rate of the electron gas.
     C_fb : pandas.DataFrame, dtype float
         The individual free-bound cooling rates of the electron gas.
-    p_fb_deac: pandas.DataFrame, dtype float
+    p_fb_deac : pandas.DataFrame, dtype float
         Probabilities of free-bound cooling in a specific continuum
         (identified by its continuum_idx).
     """

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -54,7 +54,7 @@ class SpMatrixSeriesConverterMixin(object):
         series : pandas.Series, dtype float
             Rates or transition probabilities. Indexed by
             source_level_idx, destination_level_idx.
-        idx2reduced_idx: pandas.Series
+        idx2reduced_idx : pandas.Series
             Values of (compact) matrix index. Indexed by references_idx.
             Maps the references_idx of a level to the index
             used in the sparse matrix.

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -91,6 +91,7 @@ class SpMatrixSeriesConverterMixin(object):
             used in the sparse matrix.
         names : array-like, optional
             Names of levels in MultiIndex of returned Series.
+
         Returns
         -------
         pandas.Series


### PR DESCRIPTION
This PR will fix some docstring errors from #1145.

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [x] Not at all

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
