### PR TITLE
Correct .coveragerc file

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -37,7 +37,7 @@ omit =
    tardis/simulation/setup_package.py
    tardis/io/setup_package.py
 
-   tardis/gui*
+   tardis/gui/*
    tardis/stats/*
    tardis/analysis.py
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

## Description
<!--- Describe your changes in detail. -->
Here is a missing '\\' in `.coveragerc` file in line 40. Although it is a simple modification, I think it should be done in case coverage check fails because of this.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I noticed #1419 so I went through `.coveragerc` file and found this mistake. Furthermore, I'd like to know whether I can make some additions to `.coveragerc` section to fix #1419 (_e.g._ add the montecarlo logger to the file). 

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [ ] I have assigned and requested two reviewers for this pull request
