### PR TITLE
Fix Logging #1029: Fixing the verbosity issue 

### DIFF
--- a/tardis/base.py
+++ b/tardis/base.py
@@ -7,6 +7,7 @@ def run_tardis(
     packet_source=None,
     simulation_callbacks=[],
     virtual_packet_logging=False,
+    verbosity=False
 ):
     """
     This function is one of the core functions to run TARDIS from a given
@@ -34,6 +35,13 @@ def run_tardis(
     from tardis.io.config_reader import Configuration
     from tardis.io.atom_data.base import AtomData
     from tardis.simulation import Simulation
+
+    #verbosity feature
+    import warnings
+    if verbosity==False:
+        warnings.filterwarnings("ignore")
+    else:
+        warnings.filterwarnings('default')
 
     if atom_data is not None:
         try:

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -7,7 +7,7 @@ def run_tardis(
     packet_source=None,
     simulation_callbacks=[],
     virtual_packet_logging=False,
-    verbosity=False
+    verbosity=False,
 ):
     """
     This function is one of the core functions to run TARDIS from a given
@@ -36,12 +36,13 @@ def run_tardis(
     from tardis.io.atom_data.base import AtomData
     from tardis.simulation import Simulation
 
-    #verbosity feature
+    # verbosity feature
     import warnings
-    if verbosity==False:
+
+    if verbosity == False:
         warnings.filterwarnings("ignore")
     else:
-        warnings.filterwarnings('default')
+        warnings.filterwarnings("default")
 
     if atom_data is not None:
         try:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
adding the ability to hide or show warnings to tackle the verbosity issue #1029 
## Description
<!--- Describe your changes in detail. -->
Changed the base.py file to add verbosity argument to run_tardis() function(defaults to False). setting verbosity to True shows all warnings 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Solves issue: #1029
## How Has This Been Tested?
- [x] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="950" alt="Screenshot 2021-03-25 at 12 39 42 AM" src="https://user-images.githubusercontent.com/30386504/112370937-02b90e80-8d04-11eb-92a9-6fd1e2d3bd30.png">
<img width="936" alt="Screenshot 2021-03-25 at 12 17 04 AM" src="https://user-images.githubusercontent.com/30386504/112370945-051b6880-8d04-11eb-84f9-180118629c3b.png">

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [ ] I have assigned and requested two reviewers for this pull request
