### PR TITLE
Improved default number of interpolate_shells for the formal integral

### DIFF
--- a/tardis/io/schemas/spectrum.yml
+++ b/tardis/io/schemas/spectrum.yml
@@ -28,9 +28,11 @@ properties:
             the calculation of the integrated spectrum
       interpolate_shells:
         type: number
-        default: -1
+        default: 0
         description: Number of shells on which the formal
-            integral quantities are interpolated
+            integral quantities are interpolated. For -1 no interpolation
+            is used. The default is to use twice the number of computational
+            shells but at least 80.
   virtual:
     type: object
     default: {}

--- a/tardis/montecarlo/formal_integral.py
+++ b/tardis/montecarlo/formal_integral.py
@@ -84,13 +84,20 @@ class FormalIntegrator(object):
         return True
 
     def calculate_spectrum(
-        self, frequency, points=None, interpolate_shells=-1, raises=True
+        self, frequency, points=None, interpolate_shells=0, raises=True
     ):
         # Very crude implementation
         # The c extension needs bin centers (or something similar)
         # while TARDISSpectrum needs bin edges
         self.check(raises)
         N = points or self.points
+        if interpolate_shells == 0:  # Default value
+            interpolate_shells = max(2 * self.model.no_of_shells, 80)
+            warnings.warn(
+                "The number of interpolate_shells was not "
+                f"specified. The value was set to {interpolate_shells}."
+            )
+
         self.interpolate_shells = interpolate_shells
         frequency = frequency.to("Hz", u.spectral())
         luminosity = u.Quantity(formal_integral(self, frequency, N), "erg") * (


### PR DESCRIPTION
## Description
This PR changes the default value of interpolate_shells for the formal integral to a more sensible value: twice the number of computational shells (but at least 80).

## Motivation and Context
The current default value of interpolate_shells (-1, i.e. no interpolation) for the formal integral yields integrated spectra of bad quality, which do not agree with the real and virtual spectrum.

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [x] On my local machine (for now)

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
