### PR TITLE
Add catch for missing elements in SDEC plot

### DIFF
--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -1016,20 +1016,25 @@ class SDECPlotter:
         elements_z = self.elements
         # Contribution from each element
         for i, atomic_number in enumerate(elements_z):
-            lower_level = upper_level
-            upper_level = (
-                lower_level
-                + self.emission_luminosities_df[atomic_number].to_numpy()
-            )
+            # Add a try catch because elemets_z comes from the total contribution of absorption and emission.
+            # Therefore it's possible that something in elements_z is not in the emission df
+            try:
+                lower_level = upper_level
+                upper_level = (
+                    lower_level
+                    + self.emission_luminosities_df[atomic_number].to_numpy()
+                )
 
-            self.ax.fill_between(
-                self.plot_wavelength,
-                lower_level,
-                upper_level,
-                color=self.cmap(i / len(self.elements)),
-                cmap=self.cmap,
-                linewidth=0,
-            )
+                self.ax.fill_between(
+                    self.plot_wavelength,
+                    lower_level,
+                    upper_level,
+                    color=self.cmap(i / len(self.elements)),
+                    cmap=self.cmap,
+                    linewidth=0,
+                )
+            except:
+                print(atomic_number2element_symbol(atomic_number) + " is not in the emitted packets; skipping")
 
     def _plot_absorption_mpl(self):
         """Plot absorption part of the SDEC Plot using matplotlib."""
@@ -1054,20 +1059,25 @@ class SDECPlotter:
 
         elements_z = self.elements
         for i, atomic_number in enumerate(elements_z):
-            upper_level = lower_level
-            lower_level = (
-                upper_level
-                - self.absorption_luminosities_df[atomic_number].to_numpy()
-            )
+            # Add a try catch because elemets_z comes from the total contribution of absorption and emission.
+            # Therefore it's possible that something in elements_z is not in the emission df
+            try:
+                upper_level = lower_level
+                lower_level = (
+                    upper_level
+                    - self.absorption_luminosities_df[atomic_number].to_numpy()
+                )
 
-            self.ax.fill_between(
-                self.plot_wavelength,
-                upper_level,
-                lower_level,
-                color=self.cmap(i / len(elements_z)),
-                cmap=self.cmap,
-                linewidth=0,
-            )
+                self.ax.fill_between(
+                    self.plot_wavelength,
+                    upper_level,
+                    lower_level,
+                    color=self.cmap(i / len(elements_z)),
+                    cmap=self.cmap,
+                    linewidth=0,
+                )
+            except:
+                print(atomic_number2element_symbol(atomic_number) + " is not in the emitted packets; skipping")
 
     def _show_colorbar_mpl(self):
         """Show matplotlib colorbar with labels of elements mapped to colors."""
@@ -1268,19 +1278,25 @@ class SDECPlotter:
 
         elements_z = self.elements
         for i, atomic_num in enumerate(elements_z):
-            self.fig.add_trace(
-                go.Scatter(
-                    x=self.emission_luminosities_df.index,
-                    y=self.emission_luminosities_df[atomic_num],
-                    mode="none",
-                    name=atomic_number2element_symbol(atomic_num),
-                    fillcolor=self.to_rgb255_string(
-                        self.cmap(i / len(self.elements))
-                    ),
-                    stackgroup="emission",
-                    showlegend=False,
+            # Add a try catch because elemets_z comes from the total contribution of absorption and emission.
+            # Therefore it's possible that something in elements_z is not in the emission df
+            try:
+                self.fig.add_trace(
+                    go.Scatter(
+                        x=self.emission_luminosities_df.index,
+                        y=self.emission_luminosities_df[atomic_num],
+                        mode="none",
+                        name=atomic_number2element_symbol(atomic_num),
+                        fillcolor=self.to_rgb255_string(
+                            self.cmap(i / len(self.elements))
+                        ),
+                        stackgroup="emission",
+                        showlegend=False,
+                    )
                 )
-            )
+            except:
+                print(atomic_number2element_symbol(atomic_num) + " is not in the emitted packets; skipping")
+
 
     def _plot_absorption_ply(self):
         """Plot absorption part of the SDEC Plot using plotly."""
@@ -1290,6 +1306,7 @@ class SDECPlotter:
             self.fig.add_trace(
                 go.Scatter(
                     x=self.absorption_luminosities_df.index,
+                    # to plot absorption luminosities along negative y-axis
                     y=self.absorption_luminosities_df.other * -1,
                     mode="none",
                     name="Other elements",
@@ -1300,22 +1317,26 @@ class SDECPlotter:
             )
 
         elements_z = self.elements
-
         for i, atomic_num in enumerate(elements_z):
-            self.fig.add_trace(
-                go.Scatter(
-                    x=self.absorption_luminosities_df.index,
-                    # to plot absorption luminosities along negative y-axis
-                    y=self.absorption_luminosities_df[atomic_num] * -1,
-                    mode="none",
-                    name=atomic_number2element_symbol(atomic_num),
-                    fillcolor=self.to_rgb255_string(
-                        self.cmap(i / len(self.elements))
-                    ),
-                    stackgroup="absorption",
-                    showlegend=False,
+            # Add a try catch because elemets_z comes from the total contribution of absorption and emission.
+            # Therefore it's possible that something in elements_z is not in the emission df
+            try:
+                self.fig.add_trace(
+                    go.Scatter(
+                        x=self.absorption_luminosities_df.index,
+                        # to plot absorption luminosities along negative y-axis
+                        y=self.absorption_luminosities_df[atomic_num] * -1,
+                        mode="none",
+                        name=atomic_number2element_symbol(atomic_num),
+                        fillcolor=self.to_rgb255_string(
+                            self.cmap(i / len(self.elements))
+                        ),
+                        stackgroup="absorption",
+                        showlegend=False,
+                    )
                 )
-            )
+            except:
+                print(atomic_number2element_symbol(atomic_num) + " is not in the emitted packets; skipping")
 
     def _show_colorbar_ply(self):
         """Show plotly colorbar with labels of elements mapped to colors."""

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -1077,7 +1077,7 @@ class SDECPlotter:
                     linewidth=0,
                 )
             except:
-                print(atomic_number2element_symbol(atomic_number) + " is not in the emitted packets; skipping")
+                print(atomic_number2element_symbol(atomic_number) + " is not in the absorbed packets; skipping")
 
     def _show_colorbar_mpl(self):
         """Show matplotlib colorbar with labels of elements mapped to colors."""
@@ -1336,7 +1336,7 @@ class SDECPlotter:
                     )
                 )
             except:
-                print(atomic_number2element_symbol(atomic_num) + " is not in the emitted packets; skipping")
+                print(atomic_number2element_symbol(atomic_num) + " is not in the absorbed packets; skipping")
 
     def _show_colorbar_ply(self):
         """Show plotly colorbar with labels of elements mapped to colors."""

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -1034,7 +1034,10 @@ class SDECPlotter:
                     linewidth=0,
                 )
             except:
-                print(atomic_number2element_symbol(atomic_number) + " is not in the emitted packets; skipping")
+                print(
+                    atomic_number2element_symbol(atomic_number)
+                    + " is not in the emitted packets; skipping"
+                )
 
     def _plot_absorption_mpl(self):
         """Plot absorption part of the SDEC Plot using matplotlib."""
@@ -1077,7 +1080,10 @@ class SDECPlotter:
                     linewidth=0,
                 )
             except:
-                print(atomic_number2element_symbol(atomic_number) + " is not in the absorbed packets; skipping")
+                print(
+                    atomic_number2element_symbol(atomic_number)
+                    + " is not in the absorbed packets; skipping"
+                )
 
     def _show_colorbar_mpl(self):
         """Show matplotlib colorbar with labels of elements mapped to colors."""
@@ -1295,8 +1301,10 @@ class SDECPlotter:
                     )
                 )
             except:
-                print(atomic_number2element_symbol(atomic_num) + " is not in the emitted packets; skipping")
-
+                print(
+                    atomic_number2element_symbol(atomic_num)
+                    + " is not in the emitted packets; skipping"
+                )
 
     def _plot_absorption_ply(self):
         """Plot absorption part of the SDEC Plot using plotly."""
@@ -1336,7 +1344,10 @@ class SDECPlotter:
                     )
                 )
             except:
-                print(atomic_number2element_symbol(atomic_num) + " is not in the absorbed packets; skipping")
+                print(
+                    atomic_number2element_symbol(atomic_num)
+                    + " is not in the absorbed packets; skipping"
+                )
 
     def _show_colorbar_ply(self):
         """Show plotly colorbar with labels of elements mapped to colors."""

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -1063,7 +1063,7 @@ class SDECPlotter:
         elements_z = self.elements
         for i, atomic_number in enumerate(elements_z):
             # Add a try catch because elemets_z comes from the total contribution of absorption and emission.
-            # Therefore it's possible that something in elements_z is not in the emission df
+            # Therefore it's possible that something in elements_z is not in the absorption df
             try:
                 upper_level = lower_level
                 lower_level = (
@@ -1327,7 +1327,7 @@ class SDECPlotter:
         elements_z = self.elements
         for i, atomic_num in enumerate(elements_z):
             # Add a try catch because elemets_z comes from the total contribution of absorption and emission.
-            # Therefore it's possible that something in elements_z is not in the emission df
+            # Therefore it's possible that something in elements_z is not in the absorption df
             try:
                 self.fig.add_trace(
                     go.Scatter(


### PR DESCRIPTION
This fixes  #1516.

The elements coloured in the plot are determined via the absorption and emission. It's possible however, that these elements are not the same, e.g. if you specify a limited wavelength range. For example, you could have a small wavelength region where Fe is absorbed, but not emitted. This could give an error if you try to plot an element not in the emission dataframe, for example. This adds a try statement to catch this case. 

## How Has This Been Tested?
- [ ] Testing pipeline
- [ ] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [X] Other (please describe)
I've tried artificially adding new elements to the elements list that are not included in the model. This produces the following:

![Screenshot 2021-03-26 at 16 26 49](https://user-images.githubusercontent.com/53613663/112663432-bb8c6400-8e50-11eb-8fb1-d2a6aa169c96.png)


## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [X] I have assigned and requested two reviewers for this pull request
