### PR TITLE
Add TARDIS ref parameter on pipeline template

### DIFF
--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -14,6 +14,10 @@ parameters:
     type: boolean
     default: false
 
+  - name: tardisRef
+    type: string
+    default: 'HEAD'
+
 steps:
   - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
     displayName: 'Set BASH exit on error'
@@ -37,6 +41,12 @@ steps:
   - checkout: self
     path: s/tardis
     displayName: 'Fetch main repository'
+
+  - ${{ if ne(parameters.tardisRef, 'HEAD') }}:
+    - bash: |
+        cd $(tardis.dir)
+        git checkout ${{ parameters.tardisRef }}
+      displayName: 'Check out to ${{ parameters.tardisRef }}'
 
   - ${{ if eq(parameters.fetchRefdata, true) }}:
     - checkout: git://TARDIS/tardis-refdata


### PR DESCRIPTION
## Description

This PR will allow pipelines to run unit test or reference data tests with a specific TARDIS version given by a reference (commit, tag, branch). This has some limitations due to the nature of `conda` environments: you can checkout and install any version of the environment file you want, but this environment is solved differently (or maybe unsolvable). A solution for this needs to be discussed with the core team. See: https://github.com/conda/conda/issues/7248.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves the current pipeline template.

## How Has This Been Tested?
- [x] Testing pipeline
- [x] Reference Data Comparison following these [instructions](https://tardis-sn.github.io/tardis/development/continuous_integration.html)
- [ ] Other (please describe)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- What types of changes does your code introduce? -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] None of the above (please describe)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply: -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have built the documentation on my fork following [these instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html)
- [x] I have assigned and requested two reviewers for this pull request
