### PR TITLE
Fix version number in docs

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Setup TARDIS Environment 
         uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
Solves #1391

**Motivation and context**

> I was porting the carsus doc to GA and suddenly realized what's happening. The `checkout` action from GA by default just fetches the latest commit, and the "old" `astropy_helper` version solver uses the number of commits to calculate the `dev` version. Using `fetch-depth: 0` in the step args solves this issue.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

Tested in `carsus` documentation.
 
**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
