### PR TITLE
Restructuring r_packet.py

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -5,8 +5,9 @@ import numpy as np
 from tardis.montecarlo.montecarlo_numba.r_packet import (
     RPacket,
     PacketStatus,
-    MonteCarloException,
 )
+from tardis.montecarlo.montecarlo_numba.utils import MonteCarloException
+
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
     PacketCollection,
     VPacketCollection,

--- a/tardis/montecarlo/montecarlo_numba/calculate_distances.py
+++ b/tardis/montecarlo/montecarlo_numba/calculate_distances.py
@@ -1,0 +1,157 @@
+import numpy as np
+from enum import IntEnum
+from numba import int64, float64, boolean
+from numba import njit
+from numba.experimental import jitclass
+
+import math
+from tardis.montecarlo.montecarlo_numba import (
+    njit_dict,
+    numba_config,
+    njit_dict_no_parallel,
+)
+from tardis.montecarlo import (
+    montecarlo_configuration as montecarlo_configuration,
+)
+from tardis.montecarlo.montecarlo_numba.numba_config import (
+    CLOSE_LINE_THRESHOLD,
+    C_SPEED_OF_LIGHT,
+    MISS_DISTANCE,
+    SIGMA_THOMSON,
+)
+
+from tardis.montecarlo.montecarlo_numba.utils import MonteCarloException
+
+
+@njit(**njit_dict_no_parallel)
+def calculate_distance_boundary(r, mu, r_inner, r_outer):
+    """
+    Calculate distance to shell boundary in cm.
+
+    Parameters
+    ----------
+    r : float
+       radial coordinate of the RPacket
+    mu : float
+       cosine of the direction of movement
+    r_inner : float
+       inner radius of current shell
+    r_outer : float
+       outer radius of current shell
+    """
+
+    delta_shell = 0
+    if mu > 0.0:
+        # direction outward
+        distance = math.sqrt(r_outer * r_outer + ((mu * mu - 1.0) * r * r)) - (
+            r * mu
+        )
+        delta_shell = 1
+    else:
+        # going inward
+        check = r_inner * r_inner + (r * r * (mu * mu - 1.0))
+
+        if check >= 0.0:
+            # hit inner boundary
+            distance = -r * mu - math.sqrt(check)
+            delta_shell = -1
+        else:
+            # miss inner boundary
+            distance = math.sqrt(
+                r_outer * r_outer + ((mu * mu - 1.0) * r * r)
+            ) - (r * mu)
+            delta_shell = 1
+
+    return distance, delta_shell
+
+
+# @log_decorator
+#'float64(RPacket, float64, int64, float64, float64)'
+@njit(**njit_dict_no_parallel)
+def calculate_distance_line(
+    r_packet, comov_nu, is_last_line, nu_line, time_explosion
+):
+    """
+    Calculate distance until RPacket is in resonance with the next line
+
+    Parameters
+    ----------
+    r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
+    comov_nu : float
+        comoving frequency at the CURRENT position of the RPacket
+    is_last_line : bool
+        return MISS_DISTANCE if at the end of the line list
+    nu_line : float
+        line to check the distance to
+    time_explosion : float
+        time since explosion in seconds
+
+    Returns
+    -------
+    """
+
+    nu = r_packet.nu
+
+    if is_last_line:
+        return MISS_DISTANCE
+
+    nu_diff = comov_nu - nu_line
+
+    # for numerical reasons, if line is too close, we set the distance to 0.
+    if r_packet.is_close_line:
+        nu_diff = 0.0
+        r_packet.is_close_line = False
+
+    if nu_diff >= 0:
+        distance = (nu_diff / nu) * C_SPEED_OF_LIGHT * time_explosion
+    else:
+        print("WARNING: nu difference is less than 0.0")
+        raise MonteCarloException(
+            "nu difference is less than 0.0; for more"
+            " information, see print statement beforehand"
+        )
+
+    if numba_config.ENABLE_FULL_RELATIVITY:
+        return calculate_distance_line_full_relativity(
+            nu_line, nu, time_explosion, r_packet
+        )
+    return distance
+
+
+@njit(**njit_dict_no_parallel)
+def calculate_distance_line_full_relativity(
+    nu_line, nu, time_explosion, r_packet
+):
+    # distance = - mu * r + (ct - nu_r * nu_r * sqrt(ct * ct - (1 + r * r * (1 - mu * mu) * (1 + pow(nu_r, -2))))) / (1 + nu_r * nu_r);
+    nu_r = nu_line / nu
+    ct = C_SPEED_OF_LIGHT * time_explosion
+    distance = -r_packet.mu * r_packet.r + (
+        ct
+        - nu_r
+        * nu_r
+        * math.sqrt(
+            ct * ct
+            - (
+                1
+                + r_packet.r
+                * r_packet.r
+                * (1 - r_packet.mu * r_packet.mu)
+                * (1 + 1.0 / (nu_r * nu_r))
+            )
+        )
+    ) / (1 + nu_r * nu_r)
+    return distance
+
+
+@njit(**njit_dict_no_parallel)
+def calculate_distance_electron(electron_density, tau_event):
+    """
+    Calculate distance to Thomson Scattering
+
+    Parameters
+    ----------
+    electron_density : float
+    tau_event : float
+    """
+    # add full_relativity here
+    return tau_event / (electron_density * numba_config.SIGMA_THOMSON)

--- a/tardis/montecarlo/montecarlo_numba/calculate_distances.py
+++ b/tardis/montecarlo/montecarlo_numba/calculate_distances.py
@@ -1,23 +1,16 @@
-import numpy as np
-from enum import IntEnum
-from numba import int64, float64, boolean
-from numba import njit
-from numba.experimental import jitclass
-
 import math
+
+from numba import njit
+
 from tardis.montecarlo.montecarlo_numba import (
-    njit_dict,
-    numba_config,
     njit_dict_no_parallel,
 )
-from tardis.montecarlo import (
-    montecarlo_configuration as montecarlo_configuration,
-)
+
 from tardis.montecarlo.montecarlo_numba.numba_config import (
-    CLOSE_LINE_THRESHOLD,
     C_SPEED_OF_LIGHT,
     MISS_DISTANCE,
     SIGMA_THOMSON,
+    ENABLE_FULL_RELATIVITY,
 )
 
 from tardis.montecarlo.montecarlo_numba.utils import MonteCarloException
@@ -111,7 +104,7 @@ def calculate_distance_line(
             " information, see print statement beforehand"
         )
 
-    if numba_config.ENABLE_FULL_RELATIVITY:
+    if ENABLE_FULL_RELATIVITY:
         return calculate_distance_line_full_relativity(
             nu_line, nu, time_explosion, r_packet
         )
@@ -154,4 +147,4 @@ def calculate_distance_electron(electron_density, tau_event):
     tau_event : float
     """
     # add full_relativity here
-    return tau_event / (electron_density * numba_config.SIGMA_THOMSON)
+    return tau_event / (electron_density * SIGMA_THOMSON)

--- a/tardis/montecarlo/montecarlo_numba/estimators.py
+++ b/tardis/montecarlo/montecarlo_numba/estimators.py
@@ -9,6 +9,10 @@ from tardis.montecarlo.montecarlo_numba.frame_transformations import (
     calc_packet_energy_full_relativity,
 )
 
+from tardis.montecarlo.montecarlo_numba.numba_config import (
+    ENABLE_FULL_RELATIVITY,
+)
+
 
 @njit(**njit_dict_no_parallel)
 def set_estimators(r_packet, distance, numba_estimator, comov_nu, comov_energy):
@@ -59,7 +63,7 @@ def update_line_estimators(
     ( time_explosion * C)
     """
 
-    if not numba_config.ENABLE_FULL_RELATIVITY:
+    if not ENABLE_FULL_RELATIVITY:
         energy = calc_packet_energy(r_packet, distance_trace, time_explosion)
     else:
         energy = calc_packet_energy_full_relativity(r_packet)

--- a/tardis/montecarlo/montecarlo_numba/estimators.py
+++ b/tardis/montecarlo/montecarlo_numba/estimators.py
@@ -1,24 +1,9 @@
-import numpy as np
-from enum import IntEnum
-from numba import int64, float64, boolean
 from numba import njit
-from numba.experimental import jitclass
 
-import math
 from tardis.montecarlo.montecarlo_numba import (
-    njit_dict,
-    numba_config,
     njit_dict_no_parallel,
 )
-from tardis.montecarlo import (
-    montecarlo_configuration as montecarlo_configuration,
-)
-from tardis.montecarlo.montecarlo_numba.numba_config import (
-    CLOSE_LINE_THRESHOLD,
-    C_SPEED_OF_LIGHT,
-    MISS_DISTANCE,
-    SIGMA_THOMSON,
-)
+
 from tardis.montecarlo.montecarlo_numba.frame_transformations import (
     calc_packet_energy,
     calc_packet_energy_full_relativity,

--- a/tardis/montecarlo/montecarlo_numba/estimators.py
+++ b/tardis/montecarlo/montecarlo_numba/estimators.py
@@ -1,0 +1,87 @@
+import numpy as np
+from enum import IntEnum
+from numba import int64, float64, boolean
+from numba import njit
+from numba.experimental import jitclass
+
+import math
+from tardis.montecarlo.montecarlo_numba import (
+    njit_dict,
+    numba_config,
+    njit_dict_no_parallel,
+)
+from tardis.montecarlo import (
+    montecarlo_configuration as montecarlo_configuration,
+)
+from tardis.montecarlo.montecarlo_numba.numba_config import (
+    CLOSE_LINE_THRESHOLD,
+    C_SPEED_OF_LIGHT,
+    MISS_DISTANCE,
+    SIGMA_THOMSON,
+)
+from tardis.montecarlo.montecarlo_numba.frame_transformations import (
+    calc_packet_energy,
+    calc_packet_energy_full_relativity,
+)
+
+
+@njit(**njit_dict_no_parallel)
+def set_estimators(r_packet, distance, numba_estimator, comov_nu, comov_energy):
+    """
+    Updating the estimators
+    """
+    numba_estimator.j_estimator[r_packet.current_shell_id] += (
+        comov_energy * distance
+    )
+    numba_estimator.nu_bar_estimator[r_packet.current_shell_id] += (
+        comov_energy * distance * comov_nu
+    )
+
+
+@njit(**njit_dict_no_parallel)
+def set_estimators_full_relativity(
+    r_packet, distance, numba_estimator, comov_nu, comov_energy, doppler_factor
+):
+    numba_estimator.j_estimator[r_packet.current_shell_id] += (
+        comov_energy * distance * doppler_factor
+    )
+    numba_estimator.nu_bar_estimator[r_packet.current_shell_id] += (
+        comov_energy * distance * comov_nu * doppler_factor
+    )
+
+
+@njit(**njit_dict_no_parallel)
+def update_line_estimators(
+    estimators, r_packet, cur_line_id, distance_trace, time_explosion
+):
+    """
+    Function to update the line estimators
+
+    Parameters
+    ----------
+    estimators : tardis.montecarlo.montecarlo_numba.numba_interface.Estimators
+    r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
+    cur_line_id : int
+    distance_trace : float
+    time_explosion : float
+    """
+
+    """ Actual calculation - simplified below
+    r_interaction = math.sqrt(r_packet.r**2 + distance_trace**2 +
+                            2 * r_packet.r * distance_trace * r_packet.mu)
+    mu_interaction = (r_packet.mu * r_packet.r + distance_trace) / r_interaction
+    doppler_factor = 1.0 - mu_interaction * r_interaction /
+    ( time_explosion * C)
+    """
+
+    if not numba_config.ENABLE_FULL_RELATIVITY:
+        energy = calc_packet_energy(r_packet, distance_trace, time_explosion)
+    else:
+        energy = calc_packet_energy_full_relativity(r_packet)
+
+    estimators.j_blue_estimator[cur_line_id, r_packet.current_shell_id] += (
+        energy / r_packet.nu
+    )
+    estimators.Edotlu_estimator[
+        cur_line_id, r_packet.current_shell_id
+    ] += energy

--- a/tardis/montecarlo/montecarlo_numba/frame_transformations.py
+++ b/tardis/montecarlo/montecarlo_numba/frame_transformations.py
@@ -1,23 +1,14 @@
-import numpy as np
-from enum import IntEnum
-from numba import int64, float64, boolean
-from numba import njit
-from numba.experimental import jitclass
-
 import math
+
+from numba import njit
+
 from tardis.montecarlo.montecarlo_numba import (
-    njit_dict,
-    numba_config,
     njit_dict_no_parallel,
 )
-from tardis.montecarlo import (
-    montecarlo_configuration as montecarlo_configuration,
-)
+
 from tardis.montecarlo.montecarlo_numba.numba_config import (
-    CLOSE_LINE_THRESHOLD,
     C_SPEED_OF_LIGHT,
-    MISS_DISTANCE,
-    SIGMA_THOMSON,
+    ENABLE_FULL_RELATIVITY,
 )
 
 
@@ -26,7 +17,7 @@ def get_doppler_factor(r, mu, time_explosion):
     inv_c = 1 / C_SPEED_OF_LIGHT
     inv_t = 1 / time_explosion
     beta = r * inv_t * inv_c
-    if not numba_config.ENABLE_FULL_RELATIVITY:
+    if not ENABLE_FULL_RELATIVITY:
         return get_doppler_factor_partial_relativity(mu, beta)
     else:
         return get_doppler_factor_full_relativity(mu, beta)
@@ -56,7 +47,7 @@ def get_inverse_doppler_factor(r, mu, time_explosion):
     inv_c = 1 / C_SPEED_OF_LIGHT
     inv_t = 1 / time_explosion
     beta = r * inv_t * inv_c
-    if not numba_config.ENABLE_FULL_RELATIVITY:
+    if not ENABLE_FULL_RELATIVITY:
         return get_inverse_doppler_factor_partial_relativity(mu, beta)
     else:
         return get_inverse_doppler_factor_full_relativity(mu, beta)

--- a/tardis/montecarlo/montecarlo_numba/frame_transformations.py
+++ b/tardis/montecarlo/montecarlo_numba/frame_transformations.py
@@ -1,0 +1,112 @@
+import numpy as np
+from enum import IntEnum
+from numba import int64, float64, boolean
+from numba import njit
+from numba.experimental import jitclass
+
+import math
+from tardis.montecarlo.montecarlo_numba import (
+    njit_dict,
+    numba_config,
+    njit_dict_no_parallel,
+)
+from tardis.montecarlo import (
+    montecarlo_configuration as montecarlo_configuration,
+)
+from tardis.montecarlo.montecarlo_numba.numba_config import (
+    CLOSE_LINE_THRESHOLD,
+    C_SPEED_OF_LIGHT,
+    MISS_DISTANCE,
+    SIGMA_THOMSON,
+)
+
+
+@njit(**njit_dict_no_parallel)
+def get_doppler_factor(r, mu, time_explosion):
+    inv_c = 1 / C_SPEED_OF_LIGHT
+    inv_t = 1 / time_explosion
+    beta = r * inv_t * inv_c
+    if not numba_config.ENABLE_FULL_RELATIVITY:
+        return get_doppler_factor_partial_relativity(mu, beta)
+    else:
+        return get_doppler_factor_full_relativity(mu, beta)
+
+
+@njit(**njit_dict_no_parallel)
+def get_doppler_factor_partial_relativity(mu, beta):
+    return 1.0 - mu * beta
+
+
+@njit(**njit_dict_no_parallel)
+def get_doppler_factor_full_relativity(mu, beta):
+    return (1.0 - mu * beta) / math.sqrt(1 - beta * beta)
+
+
+@njit(**njit_dict_no_parallel)
+def get_inverse_doppler_factor(r, mu, time_explosion):
+    """
+    Calculate doppler factor for frame transformation
+
+    Parameters
+    ----------
+    r : float
+    mu : float
+    time_explosion : float
+    """
+    inv_c = 1 / C_SPEED_OF_LIGHT
+    inv_t = 1 / time_explosion
+    beta = r * inv_t * inv_c
+    if not numba_config.ENABLE_FULL_RELATIVITY:
+        return get_inverse_doppler_factor_partial_relativity(mu, beta)
+    else:
+        return get_inverse_doppler_factor_full_relativity(mu, beta)
+
+
+@njit(**njit_dict_no_parallel)
+def get_inverse_doppler_factor_partial_relativity(mu, beta):
+    return 1.0 / (1.0 - mu * beta)
+
+
+@njit(**njit_dict_no_parallel)
+def get_inverse_doppler_factor_full_relativity(mu, beta):
+    return (1.0 + mu * beta) / math.sqrt(1 - beta * beta)
+
+
+@njit(**njit_dict_no_parallel)
+def calc_packet_energy_full_relativity(r_packet):
+    # accurate to 1 / gamma - according to C. Vogl
+    return r_packet.energy
+
+
+@njit(**njit_dict_no_parallel)
+def calc_packet_energy(r_packet, distance_trace, time_explosion):
+    doppler_factor = 1.0 - (
+        (distance_trace + r_packet.mu * r_packet.r)
+        / (time_explosion * C_SPEED_OF_LIGHT)
+    )
+    energy = r_packet.energy * doppler_factor
+    return energy
+
+
+@njit(**njit_dict_no_parallel)
+def angle_aberration_CMF_to_LF(r_packet, time_explosion, mu):
+    """
+    Converts angle aberration from comoving frame to
+    laboratory frame.
+    """
+    ct = C_SPEED_OF_LIGHT * time_explosion
+    beta = r_packet.r / (ct)
+    return (r_packet.mu + beta) / (1.0 + beta * mu)
+
+
+@njit(**njit_dict_no_parallel)
+def angle_aberration_LF_to_CMF(r_packet, time_explosion, mu):
+    """
+
+    c code:
+    double beta = rpacket_get_r (packet) * storage->inverse_time_explosion * INVERSE_C;
+    return (mu - beta) / (1.0 - beta * mu);
+    """
+    ct = C_SPEED_OF_LIGHT * time_explosion
+    beta = r_packet.r / (ct)
+    return (mu - beta) / (1.0 - beta * mu)

--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 from numba import njit
 from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
@@ -14,15 +12,12 @@ from tardis.montecarlo.montecarlo_numba.frame_transformations import (
     get_inverse_doppler_factor,
     angle_aberration_CMF_to_LF,
 )
-from tardis.montecarlo.montecarlo_numba.r_packet import test_for_close_line
+from tardis.montecarlo.montecarlo_numba.r_packet import (
+    test_for_close_line,
+    InteractionType,
+)
 from tardis.montecarlo.montecarlo_numba.utils import get_random_mu
 from tardis.montecarlo.montecarlo_numba.macro_atom import macro_atom
-
-
-class InteractionType(IntEnum):
-    BOUNDARY = 1
-    LINE = 2
-    ESCATTERING = 3
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -1,5 +1,5 @@
 from numba import njit
-from tardis.montecarlo.montecarlo_numba import njit_dict,njit_dict_no_parallel
+from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
     LineInteractionType,
 )
@@ -7,13 +7,13 @@ from tardis.montecarlo.montecarlo_numba.numba_interface import (
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
-from tardis.montecarlo.montecarlo_numba.r_packet import (
+from tardis.montecarlo.montecarlo_numba.frame_transformations import (
     get_doppler_factor,
     get_inverse_doppler_factor,
-    get_random_mu,
     angle_aberration_CMF_to_LF,
-    test_for_close_line,
 )
+from tardis.montecarlo.montecarlo_numba.r_packet import test_for_close_line
+from tardis.montecarlo.montecarlo_numba.utils import get_random_mu
 from tardis.montecarlo.montecarlo_numba.macro_atom import macro_atom
 
 
@@ -54,7 +54,7 @@ def thomson_scatter(r_packet, time_explosion):
 def line_scatter(r_packet, time_explosion, line_interaction_type, numba_plasma):
     """
     Line scatter function that handles the scattering itself, including new angle drawn, and calculating nu out using macro atom
-    
+
     Parameters
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket

--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -1,3 +1,5 @@
+from enum import IntEnum
+
 from numba import njit
 from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
@@ -15,6 +17,12 @@ from tardis.montecarlo.montecarlo_numba.frame_transformations import (
 from tardis.montecarlo.montecarlo_numba.r_packet import test_for_close_line
 from tardis.montecarlo.montecarlo_numba.utils import get_random_mu
 from tardis.montecarlo.montecarlo_numba.macro_atom import macro_atom
+
+
+class InteractionType(IntEnum):
+    BOUNDARY = 1
+    LINE = 2
+    ESCATTERING = 3
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/montecarlo/montecarlo_numba/opacities.py
+++ b/tardis/montecarlo/montecarlo_numba/opacities.py
@@ -1,22 +1,10 @@
-import numpy as np
-from enum import IntEnum
-from numba import int64, float64, boolean
 from numba import njit
-from numba.experimental import jitclass
 
-import math
 from tardis.montecarlo.montecarlo_numba import (
-    njit_dict,
-    numba_config,
     njit_dict_no_parallel,
 )
-from tardis.montecarlo import (
-    montecarlo_configuration as montecarlo_configuration,
-)
+
 from tardis.montecarlo.montecarlo_numba.numba_config import (
-    CLOSE_LINE_THRESHOLD,
-    C_SPEED_OF_LIGHT,
-    MISS_DISTANCE,
     SIGMA_THOMSON,
 )
 
@@ -31,4 +19,4 @@ def calculate_tau_electron(electron_density, distance):
     electron_density : float
     distance : float
     """
-    return electron_density * numba_config.SIGMA_THOMSON * distance
+    return electron_density * SIGMA_THOMSON * distance

--- a/tardis/montecarlo/montecarlo_numba/opacities.py
+++ b/tardis/montecarlo/montecarlo_numba/opacities.py
@@ -1,0 +1,34 @@
+import numpy as np
+from enum import IntEnum
+from numba import int64, float64, boolean
+from numba import njit
+from numba.experimental import jitclass
+
+import math
+from tardis.montecarlo.montecarlo_numba import (
+    njit_dict,
+    numba_config,
+    njit_dict_no_parallel,
+)
+from tardis.montecarlo import (
+    montecarlo_configuration as montecarlo_configuration,
+)
+from tardis.montecarlo.montecarlo_numba.numba_config import (
+    CLOSE_LINE_THRESHOLD,
+    C_SPEED_OF_LIGHT,
+    MISS_DISTANCE,
+    SIGMA_THOMSON,
+)
+
+
+@njit(**njit_dict_no_parallel)
+def calculate_tau_electron(electron_density, distance):
+    """
+    Calculate tau for Thomson scattering
+
+    Parameters
+    ----------
+    electron_density : float
+    distance : float
+    """
+    return electron_density * numba_config.SIGMA_THOMSON * distance

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -5,7 +5,20 @@ from numba import njit
 from numba.experimental import jitclass
 
 import math
-from tardis.montecarlo.montecarlo_numba import njit_dict, numba_config , njit_dict_no_parallel
+from tardis.montecarlo.montecarlo_numba import (
+    njit_dict,
+    numba_config,
+    njit_dict_no_parallel,
+    utils,
+    opacities,
+    calculate_distances,
+    frame_transformations,
+)
+from tardis.montecarlo.montecarlo_numba.estimators import (
+    set_estimators,
+    set_estimators_full_relativity,
+    update_line_estimators,
+)
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
@@ -15,10 +28,6 @@ from tardis.montecarlo.montecarlo_numba.numba_config import (
     MISS_DISTANCE,
     SIGMA_THOMSON,
 )
-
-
-class MonteCarloException(ValueError):
-    pass
 
 
 class PacketStatus(IntEnum):
@@ -70,7 +79,7 @@ class RPacket(object):
 
     def initialize_line_id(self, numba_plasma, numba_model):
         inverse_line_list_nu = numba_plasma.line_list_nu[::-1]
-        doppler_factor = get_doppler_factor(
+        doppler_factor = frame_transformations.get_doppler_factor(
             self.r, self.mu, numba_model.time_explosion
         )
         comov_nu = self.nu * doppler_factor
@@ -80,262 +89,6 @@ class RPacket(object):
         if next_line_id == len(numba_plasma.line_list_nu):
             next_line_id -= 1
         self.next_line_id = next_line_id
-
-
-@njit(**njit_dict_no_parallel)
-def calculate_distance_boundary(r, mu, r_inner, r_outer):
-    """
-    Calculate distance to shell boundary in cm.
-
-    Parameters
-    ----------
-    r : float
-       radial coordinate of the RPacket
-    mu : float
-       cosine of the direction of movement
-    r_inner : float
-       inner radius of current shell
-    r_outer : float
-       outer radius of current shell
-    """
-
-    delta_shell = 0
-    if mu > 0.0:
-        # direction outward
-        distance = math.sqrt(r_outer * r_outer + ((mu * mu - 1.0) * r * r)) - (
-            r * mu
-        )
-        delta_shell = 1
-    else:
-        # going inward
-        check = r_inner * r_inner + (r * r * (mu * mu - 1.0))
-
-        if check >= 0.0:
-            # hit inner boundary
-            distance = -r * mu - math.sqrt(check)
-            delta_shell = -1
-        else:
-            # miss inner boundary
-            distance = math.sqrt(
-                r_outer * r_outer + ((mu * mu - 1.0) * r * r)
-            ) - (r * mu)
-            delta_shell = 1
-
-    return distance, delta_shell
-
-
-# @log_decorator
-#'float64(RPacket, float64, int64, float64, float64)'
-@njit(**njit_dict_no_parallel)
-def calculate_distance_line(
-    r_packet, comov_nu, is_last_line, nu_line, time_explosion
-):
-    """
-    Calculate distance until RPacket is in resonance with the next line
-    
-    Parameters
-    ----------
-    r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
-    comov_nu : float
-        comoving frequency at the CURRENT position of the RPacket
-    is_last_line : bool
-        return MISS_DISTANCE if at the end of the line list
-    nu_line : float
-        line to check the distance to
-    time_explosion : float
-        time since explosion in seconds
-    
-    Returns
-    -------
-    """
-
-    nu = r_packet.nu
-
-    if is_last_line:
-        return MISS_DISTANCE
-
-    nu_diff = comov_nu - nu_line
-
-    # for numerical reasons, if line is too close, we set the distance to 0.
-    if r_packet.is_close_line:
-        nu_diff = 0.0
-        r_packet.is_close_line = False
-
-    if nu_diff >= 0:
-        distance = (nu_diff / nu) * C_SPEED_OF_LIGHT * time_explosion
-    else:
-        print("WARNING: nu difference is less than 0.0")
-        raise MonteCarloException(
-            "nu difference is less than 0.0; for more"
-            " information, see print statement beforehand"
-        )
-
-    if numba_config.ENABLE_FULL_RELATIVITY:
-        return calculate_distance_line_full_relativity(
-            nu_line, nu, time_explosion, r_packet
-        )
-    return distance
-
-
-@njit(**njit_dict_no_parallel)
-def calculate_distance_line_full_relativity(
-    nu_line, nu, time_explosion, r_packet
-):
-    # distance = - mu * r + (ct - nu_r * nu_r * sqrt(ct * ct - (1 + r * r * (1 - mu * mu) * (1 + pow(nu_r, -2))))) / (1 + nu_r * nu_r);
-    nu_r = nu_line / nu
-    ct = C_SPEED_OF_LIGHT * time_explosion
-    distance = -r_packet.mu * r_packet.r + (
-        ct
-        - nu_r
-        * nu_r
-        * math.sqrt(
-            ct * ct
-            - (
-                1
-                + r_packet.r
-                * r_packet.r
-                * (1 - r_packet.mu * r_packet.mu)
-                * (1 + 1.0 / (nu_r * nu_r))
-            )
-        )
-    ) / (1 + nu_r * nu_r)
-    return distance
-
-
-@njit(**njit_dict_no_parallel)
-def calculate_distance_electron(electron_density, tau_event):
-    """
-    Calculate distance to Thomson Scattering
-
-    Parameters
-    ----------
-    electron_density : float
-    tau_event : float
-    """
-    # add full_relativity here
-    return tau_event / (electron_density * numba_config.SIGMA_THOMSON)
-
-
-@njit(**njit_dict_no_parallel)
-def calculate_tau_electron(electron_density, distance):
-    """
-    Calculate tau for Thomson scattering
-
-    Parameters
-    ----------
-    electron_density : float
-    distance : float
-    """
-    return electron_density * numba_config.SIGMA_THOMSON * distance
-
-
-@njit(**njit_dict_no_parallel)
-def get_doppler_factor(r, mu, time_explosion):
-    inv_c = 1 / C_SPEED_OF_LIGHT
-    inv_t = 1 / time_explosion
-    beta = r * inv_t * inv_c
-    if not numba_config.ENABLE_FULL_RELATIVITY:
-        return get_doppler_factor_partial_relativity(mu, beta)
-    else:
-        return get_doppler_factor_full_relativity(mu, beta)
-
-
-@njit(**njit_dict_no_parallel)
-def get_doppler_factor_partial_relativity(mu, beta):
-    return 1.0 - mu * beta
-
-
-@njit(**njit_dict_no_parallel)
-def get_doppler_factor_full_relativity(mu, beta):
-    return (1.0 - mu * beta) / math.sqrt(1 - beta * beta)
-
-
-@njit(**njit_dict_no_parallel)
-def get_inverse_doppler_factor(r, mu, time_explosion):
-    """
-    Calculate doppler factor for frame transformation
-
-    Parameters
-    ----------
-    r : float
-    mu : float
-    time_explosion : float
-    """
-    inv_c = 1 / C_SPEED_OF_LIGHT
-    inv_t = 1 / time_explosion
-    beta = r * inv_t * inv_c
-    if not numba_config.ENABLE_FULL_RELATIVITY:
-        return get_inverse_doppler_factor_partial_relativity(mu, beta)
-    else:
-        return get_inverse_doppler_factor_full_relativity(mu, beta)
-
-
-@njit(**njit_dict_no_parallel)
-def get_inverse_doppler_factor_partial_relativity(mu, beta):
-    return 1.0 / (1.0 - mu * beta)
-
-
-@njit(**njit_dict_no_parallel)
-def get_inverse_doppler_factor_full_relativity(mu, beta):
-    return (1.0 + mu * beta) / math.sqrt(1 - beta * beta)
-
-
-@njit(**njit_dict_no_parallel)
-def get_random_mu():
-    return 2.0 * np.random.random() - 1.0
-
-
-@njit(**njit_dict_no_parallel)
-def update_line_estimators(
-    estimators, r_packet, cur_line_id, distance_trace, time_explosion
-):
-    """
-    Function to update the line estimators
-
-    Parameters
-    ----------
-    estimators : tardis.montecarlo.montecarlo_numba.numba_interface.Estimators
-    r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
-    cur_line_id : int
-    distance_trace : float
-    time_explosion : float
-    """
-
-    """ Actual calculation - simplified below
-    r_interaction = math.sqrt(r_packet.r**2 + distance_trace**2 +
-                            2 * r_packet.r * distance_trace * r_packet.mu)
-    mu_interaction = (r_packet.mu * r_packet.r + distance_trace) / r_interaction
-    doppler_factor = 1.0 - mu_interaction * r_interaction /
-    ( time_explosion * C)
-    """
-
-    if not numba_config.ENABLE_FULL_RELATIVITY:
-        energy = calc_packet_energy(r_packet, distance_trace, time_explosion)
-    else:
-        energy = calc_packet_energy_full_relativity(r_packet)
-
-    estimators.j_blue_estimator[cur_line_id, r_packet.current_shell_id] += (
-        energy / r_packet.nu
-    )
-    estimators.Edotlu_estimator[
-        cur_line_id, r_packet.current_shell_id
-    ] += energy
-
-
-@njit(**njit_dict_no_parallel)
-def calc_packet_energy_full_relativity(r_packet):
-    # accurate to 1 / gamma - according to C. Vogl
-    return r_packet.energy
-
-
-@njit(**njit_dict_no_parallel)
-def calc_packet_energy(r_packet, distance_trace, time_explosion):
-    doppler_factor = 1.0 - (
-        (distance_trace + r_packet.mu * r_packet.r)
-        / (time_explosion * C_SPEED_OF_LIGHT)
-    )
-    energy = r_packet.energy * doppler_factor
-    return energy
 
 
 @njit(**njit_dict_no_parallel)
@@ -357,7 +110,10 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
     r_inner = numba_model.r_inner[r_packet.current_shell_id]
     r_outer = numba_model.r_outer[r_packet.current_shell_id]
 
-    distance_boundary, delta_shell = calculate_distance_boundary(
+    (
+        distance_boundary,
+        delta_shell,
+    ) = calculate_distances.calculate_distance_boundary(
         r_packet.r, r_packet.mu, r_inner, r_outer
     )
 
@@ -373,12 +129,12 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
     cur_electron_density = numba_plasma.electron_density[
         r_packet.current_shell_id
     ]
-    distance_electron = calculate_distance_electron(
+    distance_electron = calculate_distances.calculate_distance_electron(
         cur_electron_density, tau_event
     )
 
     # Calculating doppler factor
-    doppler_factor = get_doppler_factor(
+    doppler_factor = frame_transformations.get_doppler_factor(
         r_packet.r, r_packet.mu, numba_model.time_explosion
     )
     comov_nu = r_packet.nu * doppler_factor
@@ -405,7 +161,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
         # redshifts to the line frequency
         is_last_line = cur_line_id == last_line_id
 
-        distance_trace = calculate_distance_line(
+        distance_trace = calculate_distances.calculate_distance_line(
             r_packet,
             comov_nu,
             is_last_line,
@@ -414,7 +170,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
         )
 
         # calculating the tau electron of how far the trace has progressed
-        tau_trace_electron = calculate_tau_electron(
+        tau_trace_electron = opacities.calculate_tau_electron(
             cur_electron_density, distance_trace
         )
 
@@ -470,7 +226,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
 
         # Recalculating distance_electron using tau_event -
         # tau_trace_line_combined
-        distance_electron = calculate_distance_electron(
+        distance_electron = calculate_distances.calculate_distance_electron(
             cur_electron_density, tau_event - tau_trace_line_combined
         )
 
@@ -510,7 +266,9 @@ def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
         distance in cm
     """
 
-    doppler_factor = get_doppler_factor(r_packet.r, r_packet.mu, time_explosion)
+    doppler_factor = frame_transformations.get_doppler_factor(
+        r_packet.r, r_packet.mu, time_explosion
+    )
 
     r = r_packet.r
     if distance > 0.0:
@@ -541,31 +299,6 @@ def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
 
 
 @njit(**njit_dict_no_parallel)
-def set_estimators(r_packet, distance, numba_estimator, comov_nu, comov_energy):
-    """
-    Updating the estimators
-    """
-    numba_estimator.j_estimator[r_packet.current_shell_id] += (
-        comov_energy * distance
-    )
-    numba_estimator.nu_bar_estimator[r_packet.current_shell_id] += (
-        comov_energy * distance * comov_nu
-    )
-
-
-@njit(**njit_dict_no_parallel)
-def set_estimators_full_relativity(
-    r_packet, distance, numba_estimator, comov_nu, comov_energy, doppler_factor
-):
-    numba_estimator.j_estimator[r_packet.current_shell_id] += (
-        comov_energy * distance * doppler_factor
-    )
-    numba_estimator.nu_bar_estimator[r_packet.current_shell_id] += (
-        comov_energy * distance * comov_nu * doppler_factor
-    )
-
-
-@njit(**njit_dict_no_parallel)
 def move_packet_across_shell_boundary(packet, delta_shell, no_of_shells):
     """
     Move packet across shell boundary - realizing if we are still in the simulation or have
@@ -591,30 +324,6 @@ def move_packet_across_shell_boundary(packet, delta_shell, no_of_shells):
         packet.status = PacketStatus.REABSORBED
     else:
         packet.current_shell_id = next_shell_id
-
-
-@njit(**njit_dict_no_parallel)
-def angle_aberration_CMF_to_LF(r_packet, time_explosion, mu):
-    """
-    Converts angle aberration from comoving frame to
-    laboratory frame.
-    """
-    ct = C_SPEED_OF_LIGHT * time_explosion
-    beta = r_packet.r / (ct)
-    return (r_packet.mu + beta) / (1.0 + beta * mu)
-
-
-@njit(**njit_dict_no_parallel)
-def angle_aberration_LF_to_CMF(r_packet, time_explosion, mu):
-    """
-
-    c code:
-    double beta = rpacket_get_r (packet) * storage->inverse_time_explosion * INVERSE_C;
-    return (mu - beta) / (1.0 - beta * mu);
-    """
-    ct = C_SPEED_OF_LIGHT * time_explosion
-    beta = r_packet.r / (ct)
-    return (mu - beta) / (1.0 - beta * mu)
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -9,7 +9,7 @@ from numba.experimental import jitclass
 from tardis.montecarlo.montecarlo_numba import (
     njit_dict_no_parallel,
 )
-from tardis.montecarlo.montecarlo_numba.interaction import InteractionType
+
 from tardis.montecarlo.montecarlo_numba.estimators import (
     set_estimators,
     set_estimators_full_relativity,
@@ -29,6 +29,12 @@ from tardis.montecarlo.montecarlo_numba.numba_config import (
     CLOSE_LINE_THRESHOLD,
     ENABLE_FULL_RELATIVITY,
 )
+
+
+class InteractionType(IntEnum):
+    BOUNDARY = 1
+    LINE = 2
+    ESCATTERING = 3
 
 
 class PacketStatus(IntEnum):

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -1,32 +1,33 @@
-import numpy as np
+import math
 from enum import IntEnum
+
+import numpy as np
 from numba import int64, float64, boolean
 from numba import njit
 from numba.experimental import jitclass
 
-import math
 from tardis.montecarlo.montecarlo_numba import (
-    njit_dict,
-    numba_config,
     njit_dict_no_parallel,
-    utils,
-    opacities,
-    calculate_distances,
-    frame_transformations,
 )
+from tardis.montecarlo.montecarlo_numba.interaction import InteractionType
 from tardis.montecarlo.montecarlo_numba.estimators import (
     set_estimators,
     set_estimators_full_relativity,
     update_line_estimators,
 )
-from tardis.montecarlo import (
-    montecarlo_configuration as montecarlo_configuration,
+from tardis.montecarlo.montecarlo_numba.opacities import calculate_tau_electron
+from tardis.montecarlo.montecarlo_numba.calculate_distances import (
+    calculate_distance_boundary,
+    calculate_distance_electron,
+    calculate_distance_line,
 )
+from tardis.montecarlo.montecarlo_numba.frame_transformations import (
+    get_doppler_factor,
+)
+from tardis.montecarlo import montecarlo_configuration
 from tardis.montecarlo.montecarlo_numba.numba_config import (
     CLOSE_LINE_THRESHOLD,
-    C_SPEED_OF_LIGHT,
-    MISS_DISTANCE,
-    SIGMA_THOMSON,
+    ENABLE_FULL_RELATIVITY,
 )
 
 
@@ -34,12 +35,6 @@ class PacketStatus(IntEnum):
     IN_PROCESS = 0
     EMITTED = 1
     REABSORBED = 2
-
-
-class InteractionType(IntEnum):
-    BOUNDARY = 1
-    LINE = 2
-    ESCATTERING = 3
 
 
 rpacket_spec = [
@@ -79,7 +74,7 @@ class RPacket(object):
 
     def initialize_line_id(self, numba_plasma, numba_model):
         inverse_line_list_nu = numba_plasma.line_list_nu[::-1]
-        doppler_factor = frame_transformations.get_doppler_factor(
+        doppler_factor = get_doppler_factor(
             self.r, self.mu, numba_model.time_explosion
         )
         comov_nu = self.nu * doppler_factor
@@ -113,9 +108,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
     (
         distance_boundary,
         delta_shell,
-    ) = calculate_distances.calculate_distance_boundary(
-        r_packet.r, r_packet.mu, r_inner, r_outer
-    )
+    ) = calculate_distance_boundary(r_packet.r, r_packet.mu, r_inner, r_outer)
 
     # defining start for line interaction
     start_line_id = r_packet.next_line_id
@@ -129,12 +122,12 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
     cur_electron_density = numba_plasma.electron_density[
         r_packet.current_shell_id
     ]
-    distance_electron = calculate_distances.calculate_distance_electron(
+    distance_electron = calculate_distance_electron(
         cur_electron_density, tau_event
     )
 
     # Calculating doppler factor
-    doppler_factor = frame_transformations.get_doppler_factor(
+    doppler_factor = get_doppler_factor(
         r_packet.r, r_packet.mu, numba_model.time_explosion
     )
     comov_nu = r_packet.nu * doppler_factor
@@ -161,7 +154,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
         # redshifts to the line frequency
         is_last_line = cur_line_id == last_line_id
 
-        distance_trace = calculate_distances.calculate_distance_line(
+        distance_trace = calculate_distance_line(
             r_packet,
             comov_nu,
             is_last_line,
@@ -170,7 +163,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
         )
 
         # calculating the tau electron of how far the trace has progressed
-        tau_trace_electron = opacities.calculate_tau_electron(
+        tau_trace_electron = calculate_tau_electron(
             cur_electron_density, distance_trace
         )
 
@@ -226,7 +219,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
 
         # Recalculating distance_electron using tau_event -
         # tau_trace_line_combined
-        distance_electron = calculate_distances.calculate_distance_electron(
+        distance_electron = calculate_distance_electron(
             cur_electron_density, tau_event - tau_trace_line_combined
         )
 
@@ -266,9 +259,7 @@ def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
         distance in cm
     """
 
-    doppler_factor = frame_transformations.get_doppler_factor(
-        r_packet.r, r_packet.mu, time_explosion
-    )
+    doppler_factor = get_doppler_factor(r_packet.r, r_packet.mu, time_explosion)
 
     r = r_packet.r
     if distance > 0.0:
@@ -281,7 +272,7 @@ def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
         comov_nu = r_packet.nu * doppler_factor
         comov_energy = r_packet.energy * doppler_factor
 
-        if not numba_config.ENABLE_FULL_RELATIVITY:
+        if not ENABLE_FULL_RELATIVITY:
             set_estimators(
                 r_packet, distance, numba_estimator, comov_nu, comov_energy
             )

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -4,11 +4,15 @@ import numpy as np
 from tardis.montecarlo.montecarlo_numba.r_packet import (
     InteractionType,
     PacketStatus,
-    get_inverse_doppler_factor,
     trace_packet,
     move_packet_across_shell_boundary,
     move_r_packet,
-    MonteCarloException,
+)
+
+from tardis.montecarlo.montecarlo_numba.utils import MonteCarloException
+
+from tardis.montecarlo.montecarlo_numba.frame_transformations import (
+    get_inverse_doppler_factor,
 )
 from tardis.montecarlo.montecarlo_numba.interaction import (
     thomson_scatter,

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -2,7 +2,6 @@ from numba import njit
 import numpy as np
 
 from tardis.montecarlo.montecarlo_numba.r_packet import (
-    InteractionType,
     PacketStatus,
     trace_packet,
     move_packet_across_shell_boundary,
@@ -15,6 +14,7 @@ from tardis.montecarlo.montecarlo_numba.frame_transformations import (
     get_inverse_doppler_factor,
 )
 from tardis.montecarlo.montecarlo_numba.interaction import (
+    InteractionType,
     thomson_scatter,
     line_scatter,
 )

--- a/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
@@ -4,6 +4,14 @@ import numpy as np
 import pandas as pd
 import tardis.montecarlo.formal_integral as formal_integral
 import tardis.montecarlo.montecarlo_numba.r_packet as r_packet
+import tardis.montecarlo.montecarlo_numba.calculate_distances as calculate_distances
+import tardis.montecarlo.montecarlo_numba.frame_transformations as frame_transformations
+import tardis.montecarlo.montecarlo_numba.opacities as opacities
+from tardis.montecarlo.montecarlo_numba.estimators import (
+    set_estimators,
+    update_line_estimators,
+)
+import tardis.montecarlo.montecarlo_numba.utils as utils
 import tardis.montecarlo.montecarlo_configuration as mc
 import tardis.montecarlo.montecarlo_numba.numba_interface as numba_interface
 from tardis import constants as const
@@ -57,7 +65,7 @@ def test_calculate_distance_boundary(packet_params, expected_params, model):
     mu = packet_params["mu"]
     r = packet_params["r"]
 
-    d_boundary = r_packet.calculate_distance_boundary(
+    d_boundary = calculate_distances.calculate_distance_boundary(
         r, mu, model.r_inner[0], model.r_outer[0]
     )
 
@@ -81,11 +89,11 @@ def test_calculate_distance_boundary(packet_params, expected_params, model):
         ),
         (
             {"nu_line": 0.5, "next_line_id": 1, "is_last_line": False},
-            {"tardis_error": r_packet.MonteCarloException, "d_line": 0.0},
+            {"tardis_error": utils.MonteCarloException, "d_line": 0.0},
         ),
         (
             {"nu_line": 0.6, "next_line_id": 0, "is_last_line": False},
-            {"tardis_error": r_packet.MonteCarloException, "d_line": 0.0},
+            {"tardis_error": utils.MonteCarloException, "d_line": 0.0},
         ),
     ],
 )
@@ -97,7 +105,7 @@ def test_calculate_distance_line(
 
     time_explosion = model.time_explosion
 
-    doppler_factor = r_packet.get_doppler_factor(
+    doppler_factor = frame_transformations.get_doppler_factor(
         static_packet.r, static_packet.mu, time_explosion
     )
     comov_nu = static_packet.nu * doppler_factor
@@ -105,11 +113,11 @@ def test_calculate_distance_line(
     d_line = 0
     obtained_tardis_error = None
     try:
-        d_line = r_packet.calculate_distance_line(
+        d_line = calculate_distances.calculate_distance_line(
             static_packet, comov_nu, is_last_line, nu_line, time_explosion
         )
-    except r_packet.MonteCarloException:
-        obtained_tardis_error = r_packet.MonteCarloException
+    except utils.MonteCarloException:
+        obtained_tardis_error = utils.MonteCarloException
 
     assert_almost_equal(d_line, expected_params["d_line"])
     assert obtained_tardis_error == expected_params["tardis_error"]
@@ -119,7 +127,9 @@ def test_calculate_distance_line(
     ["electron_density", "tau_event"], [(1e-5, 1.0), (1e10, 1e10)]
 )
 def test_calculate_distance_electron(electron_density, tau_event):
-    actual = r_packet.calculate_distance_electron(electron_density, tau_event)
+    actual = calculate_distances.calculate_distance_electron(
+        electron_density, tau_event
+    )
     expected = tau_event / (electron_density * SIGMA_THOMSON)
 
     assert_almost_equal(actual, expected)
@@ -130,7 +140,7 @@ def test_calculate_distance_electron(electron_density, tau_event):
     [(1e-5, 1.0), (1e10, 1e10), (-1, 0), (-1e10, -1e10)],
 )
 def test_calculate_tau_electron(electron_density, distance):
-    actual = r_packet.calculate_tau_electron(electron_density, distance)
+    actual = opacities.calculate_tau_electron(electron_density, distance)
     expected = electron_density * SIGMA_THOMSON * distance
 
     assert_almost_equal(actual, expected)
@@ -152,7 +162,7 @@ def test_get_doppler_factor(mu, r, inv_t_exp, expected):
     # Perform any other setups just before this, they can be additional calls
     # to other methods or introduction of some temporary variables
 
-    obtained = r_packet.get_doppler_factor(r, mu, time_explosion)
+    obtained = frame_transformations.get_doppler_factor(r, mu, time_explosion)
 
     # Perform required assertions
     assert_almost_equal(obtained, expected)
@@ -174,7 +184,9 @@ def test_get_inverse_doppler_factor(mu, r, inv_t_exp, expected):
     # Perform any other setups just before this, they can be additional calls
     # to other methods or introduction of some temporary variables
 
-    obtained = r_packet.get_inverse_doppler_factor(r, mu, time_explosion)
+    obtained = frame_transformations.get_inverse_doppler_factor(
+        r, mu, time_explosion
+    )
 
     # Perform required assertions
     assert_almost_equal(obtained, expected)
@@ -186,7 +198,7 @@ def test_get_random_mu(set_seed_fixture):
     """
     set_seed_fixture(1963)
 
-    output1 = r_packet.get_random_mu()
+    output1 = utils.get_random_mu()
     assert output1 == 0.9136407866175174
 
 
@@ -234,7 +246,7 @@ def test_update_line_estimators(
     expected_j_blue,
     expected_Edotlu,
 ):
-    r_packet.update_line_estimators(
+    update_line_estimators(
         estimators, static_packet, cur_line_id, distance_trace, time_explosion
     )
 
@@ -242,7 +254,7 @@ def test_update_line_estimators(
     assert_allclose(estimators.Edotlu_estimator, expected_Edotlu)
 
 
-@pytest.mark.xfail(reason='Need to fix estimator differences across runs')
+@pytest.mark.xfail(reason="Need to fix estimator differences across runs")
 # TODO set RNG consistently
 def test_trace_packet(
     packet,
@@ -307,7 +319,7 @@ def test_move_r_packet(
 
     numba_config.ENABLE_FULL_RELATIVITY = ENABLE_FULL_RELATIVITY
     r_packet.move_r_packet.recompile()  # This must be done as move_r_packet was jitted with ENABLE_FULL_RELATIVITY
-    doppler_factor = r_packet.get_doppler_factor(
+    doppler_factor = frame_transformations.get_doppler_factor(
         packet.r, packet.mu, model.time_explosion
     )
 

--- a/tardis/montecarlo/montecarlo_numba/tests/test_vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_vpacket.py
@@ -11,6 +11,10 @@ from tardis import constants as const
 from tardis.montecarlo.montecarlo_numba.numba_interface import Estimators
 from tardis.montecarlo.montecarlo_numba import macro_atom
 
+from tardis.montecarlo.montecarlo_numba.frame_transformations import (
+    get_doppler_factor,
+)
+
 C_SPEED_OF_LIGHT = const.c.to("cm/s").value
 
 import numpy.testing as npt
@@ -32,7 +36,7 @@ def v_packet():
 
 def v_packet_initialize_line_id(v_packet, numba_plasma, numba_model):
     inverse_line_list_nu = numba_plasma.line_list_nu[::-1]
-    doppler_factor = r_packet.get_doppler_factor(
+    doppler_factor = get_doppler_factor(
         v_packet.r, v_packet.mu, numba_model.time_explosion
     )
     comov_nu = v_packet.nu * doppler_factor

--- a/tardis/montecarlo/montecarlo_numba/utils.py
+++ b/tardis/montecarlo/montecarlo_numba/utils.py
@@ -1,8 +1,6 @@
 import numpy as np
 from numba import njit
 from tardis.montecarlo.montecarlo_numba import (
-    njit_dict,
-    numba_config,
     njit_dict_no_parallel,
 )
 

--- a/tardis/montecarlo/montecarlo_numba/utils.py
+++ b/tardis/montecarlo/montecarlo_numba/utils.py
@@ -1,0 +1,16 @@
+import numpy as np
+from numba import njit
+from tardis.montecarlo.montecarlo_numba import (
+    njit_dict,
+    numba_config,
+    njit_dict_no_parallel,
+)
+
+
+class MonteCarloException(ValueError):
+    pass
+
+
+@njit(**njit_dict_no_parallel)
+def get_random_mu():
+    return 2.0 * np.random.random() - 1.0

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -1,3 +1,6 @@
+import math
+
+import numpy as np
 from numba import float64, int64, boolean
 from numba import njit, gdb
 from numba.experimental import jitclass
@@ -6,8 +9,6 @@ from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
-import math
-import numpy as np
 
 from tardis.montecarlo.montecarlo_numba.r_packet import (
     PacketStatus,

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -2,7 +2,7 @@ from numba import float64, int64, boolean
 from numba import njit, gdb
 from numba.experimental import jitclass
 
-from tardis.montecarlo.montecarlo_numba import njit_dict , njit_dict_no_parallel
+from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
@@ -10,16 +10,23 @@ import math
 import numpy as np
 
 from tardis.montecarlo.montecarlo_numba.r_packet import (
-    calculate_distance_boundary,
-    get_doppler_factor,
-    calculate_distance_line,
-    calculate_tau_electron,
     PacketStatus,
     move_packet_across_shell_boundary,
-    angle_aberration_LF_to_CMF,
-    angle_aberration_CMF_to_LF,
     test_for_close_line,
 )
+
+from tardis.montecarlo.montecarlo_numba.calculate_distances import (
+    calculate_distance_boundary,
+    calculate_distance_line,
+)
+
+from tardis.montecarlo.montecarlo_numba.frame_transformations import (
+    get_doppler_factor,
+    angle_aberration_LF_to_CMF,
+    angle_aberration_CMF_to_LF,
+)
+
+from tardis.montecarlo.montecarlo_numba.opacities import calculate_tau_electron
 
 vpacket_spec = [
     ("r", float64),

--- a/tardis/montecarlo/tests/test_montecarlo.py
+++ b/tardis/montecarlo/tests/test_montecarlo.py
@@ -50,6 +50,7 @@ import numpy as np
 import pandas as pd
 import tardis.montecarlo.formal_integral as formal_integral
 import tardis.montecarlo.montecarlo_numba.r_packet as r_packet
+import tardis.montecarlo.montecarlo_numba.utils as utils
 import tardis.montecarlo.montecarlo_configuration as mc
 from tardis import constants as const
 from tardis.montecarlo.montecarlo_numba.numba_interface import Estimators
@@ -679,11 +680,11 @@ def test_compute_distance2boundary(
         ),
         (
             {"nu_line": 0.5, "next_line_id": 1, "last_line": 0},
-            {"tardis_error": r_packet.MonteCarloException, "d_line": 0.0},
+            {"tardis_error": utils.MonteCarloException, "d_line": 0.0},
         ),
         (
             {"nu_line": 0.6, "next_line_id": 0, "last_line": 0},
-            {"tardis_error": r_packet.MonteCarloException, "d_line": 0.0},
+            {"tardis_error": utils.MonteCarloException, "d_line": 0.0},
         ),
     ],
 )
@@ -706,8 +707,8 @@ def test_compute_distance2line(packet_params, expected_params, packet, model):
         d_line = r_packet.calculate_distance_line(
             packet, comov_nu, nu_line, time_explosion
         )
-    except r_packet.MonteCarloException:
-        obtained_tardis_error = r_packet.MonteCarloException
+    except utils.MonteCarloException:
+        obtained_tardis_error = utils.MonteCarloException
 
     assert_almost_equal(d_line, expected_params["d_line"])
     assert obtained_tardis_error == expected_params["tardis_error"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
r_packet has been broken into additional files utils (containing utility functions, currently just the MonteCarloException class and get_random_mu), estimators (all estimator set/update), opacities (currently just tau electron), calculate_distances (all distance calls), frame_transformations (any doppler shifts or changes between frames)

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
We need to clean up the r packet loops so that we can use the Monte Carlo framework for multiple different applications

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
