### PR TITLE
Fixing Bad YAML output in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,6 +200,13 @@ def to_html_ext(path):
     return os.path.splitext(path)[0] + ".html"
 
 
+def autodoc_skip_member(app, what, name, obj, skip, options):
+    """Exclude specific functions/methods from the documentation"""
+    exclusions = ("yaml_constructors", "yaml_implicit_resolvers")
+    exclude = name in exclusions
+    return skip or exclude
+
+
 def create_redirect_files(app, docname):
     """Create redirect html files at old paths specified in `redirects` list."""
     template_html_path = os.path.join(
@@ -224,4 +231,5 @@ def create_redirect_files(app, docname):
 
 
 def setup(app):
+    app.connect("autodoc-skip-member", autodoc_skip_member)
     app.connect("build-finished", create_redirect_files)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This aims to fix #1370 

**Description**
<!--- Describe your changes in detail -->
I am using sphinx's [`autodoc-skip-member`](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#skipping-members) to exclude specific methods/functions from the documentation. 
The `add_constructor` and `add_implicit_resolver` methods in the `YAMLLoader` [class](https://github.com/tardis-sn/tardis/blob/master/tardis/io/util.py) were causing the bad YAML output and I tried to exclude them from the documentation. 


**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

This works correctly in [my documentation](https://atharva-2001.github.io/tardis/api/tardis.io.util.html).

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->
Before: 
![image](https://user-images.githubusercontent.com/55894364/115877721-63ec1300-a465-11eb-8770-795251608a99.png)

After:
![image](https://user-images.githubusercontent.com/55894364/115877607-428b2700-a465-11eb-8a8b-7c7f0b658ba9.png)


**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [X] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
