### PR TITLE
Updating Enum class for last_interaction_type 

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -30,12 +30,11 @@ from tardis.montecarlo.montecarlo_numba.numba_config import (
     ENABLE_FULL_RELATIVITY,
 )
 
-
 class InteractionType(IntEnum):
-    BOUNDARY = 1
+    NO_INTERACTION = -1
+    BOUNDARY = 0
+    ESCATTERING = 1
     LINE = 2
-    ESCATTERING = 3
-
 
 class PacketStatus(IntEnum):
     IN_PROCESS = 0
@@ -189,7 +188,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
             (distance_electron < distance_trace)
             and (distance_electron < distance_boundary)
         ) and distance_trace != 0.0:
-            interaction_type = InteractionType.ESCATTERING
+            interaction_type = InteractionType.ESCATTERING  # E-SCATTERING
             # print('scattering')
             distance = distance_electron
             r_packet.next_line_id = cur_line_id
@@ -211,7 +210,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
             tau_trace_combined > tau_event
             and not montecarlo_configuration.disable_line_scattering
         ):
-            interaction_type = InteractionType.LINE  # Line
+            interaction_type = InteractionType.LINE  # LINE
             r_packet.last_interaction_in_nu = r_packet.nu
             r_packet.last_line_interaction_in_id = cur_line_id
             r_packet.next_line_id = cur_line_id

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -32,9 +32,10 @@ from tardis.montecarlo.montecarlo_numba.numba_config import (
 
 class InteractionType(IntEnum):
     NO_INTERACTION = -1
-    BOUNDARY = 0
-    ESCATTERING = 1
+    BOUNDARY = 1
     LINE = 2
+    ESCATTERING = 3
+
 
 class PacketStatus(IntEnum):
     IN_PROCESS = 0
@@ -179,7 +180,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
             (distance_boundary <= distance_trace)
             and (distance_boundary <= distance_electron)
         ) and distance_trace != 0.0:
-            interaction_type = InteractionType.BOUNDARY  # BOUNDARY
+            interaction_type = InteractionType.BOUNDARY  
             r_packet.next_line_id = cur_line_id
             distance = distance_boundary
             break
@@ -188,7 +189,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
             (distance_electron < distance_trace)
             and (distance_electron < distance_boundary)
         ) and distance_trace != 0.0:
-            interaction_type = InteractionType.ESCATTERING  # E-SCATTERING
+            interaction_type = InteractionType.ESCATTERING  
             # print('scattering')
             distance = distance_electron
             r_packet.next_line_id = cur_line_id
@@ -210,7 +211,7 @@ def trace_packet(r_packet, numba_model, numba_plasma, estimators):
             tau_trace_combined > tau_event
             and not montecarlo_configuration.disable_line_scattering
         ):
-            interaction_type = InteractionType.LINE  # LINE
+            interaction_type = InteractionType.LINE
             r_packet.last_interaction_in_nu = r_packet.nu
             r_packet.last_line_interaction_in_id = cur_line_id
             r_packet.next_line_id = cur_line_id

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -877,7 +877,7 @@ class SDECPlotter:
             self.data[packets_mode].packets_df["last_interaction_type"][
                 self.packet_nu_range_mask
             ]
-            == 1  # E-Scattering 
+            == 1  # E-Scattering
         ) & (
             self.data[packets_mode].packets_df["last_line_interaction_in_id"][
                 self.packet_nu_range_mask

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -877,7 +877,7 @@ class SDECPlotter:
             self.data[packets_mode].packets_df["last_interaction_type"][
                 self.packet_nu_range_mask
             ]
-            == InteractionType.BOUNDARY
+            == 1  # E-Scattering 
         ) & (
             self.data[packets_mode].packets_df["last_line_interaction_in_id"][
                 self.packet_nu_range_mask

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -877,7 +877,7 @@ class SDECPlotter:
             self.data[packets_mode].packets_df["last_interaction_type"][
                 self.packet_nu_range_mask
             ]
-            == 1
+            == InteractionType.ESCATTERING
         ) & (
             self.data[packets_mode].packets_df["last_line_interaction_in_id"][
                 self.packet_nu_range_mask

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -877,7 +877,7 @@ class SDECPlotter:
             self.data[packets_mode].packets_df["last_interaction_type"][
                 self.packet_nu_range_mask
             ]
-            == InteractionType.ESCATTERING
+            == InteractionType.BOUNDARY
         ) & (
             self.data[packets_mode].packets_df["last_line_interaction_in_id"][
                 self.packet_nu_range_mask

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -22,6 +22,7 @@ from tardis.util.base import (
     roman_to_int,
     int_to_roman,
 )
+from tardis.montecarlo.montecarlo_numba.r_packet import InteractionType
 from tardis.visualization import plot_util as pu
 
 import logging
@@ -116,7 +117,10 @@ class SDECData:
         self.time_of_simulation = time_of_simulation
 
         # Create dataframe of packets that experience line interaction
-        line_mask = (self.packets_df["last_interaction_type"] > -1) & (
+        line_mask = (
+            self.packets_df["last_interaction_type"]
+            > InteractionType.NO_INTERACTION
+        ) & (
             self.packets_df["last_line_interaction_in_id"] > -1
         )  # & operator is quite faster than np.logical_and on pd.Series
         self.packets_df_line_interaction = self.packets_df.loc[line_mask].copy()


### PR DESCRIPTION
This PR aims to implement & fix #1396 
Implements & Updates `Enum` class for `last_interaction_type` :)

**Description**
Updated the `InteractionType` enum class for `last_interaction_type` as stated through the issue.
Restructured this class to the `base.py` from the `r_packet.py` module. Updated required references :)

**Motivation and context**
Updating the enumeration `InteractionType` class will allow for easier usage of the parameters for calculation as well as comparison. 
Values have been given the correct parameter name :)

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
