### PR TITLE
Adding Instructions For Enabling `virtual_packet_logging` Properties in Config

### DIFF
--- a/docs/using/visualization/generating_widgets.ipynb
+++ b/docs/using/visualization/generating_widgets.ipynb
@@ -575,11 +575,16 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Enabling `virtual_packet_logging` Property for Plotting \n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Important:** The virtual packet logging capability must be active in order to produce SDEC Plot. Thus, make sure to set `virtual_packet_logging: True` in your configuration file. It should be added under `virtual` property of `spectrum` property, as described in [configuration schema](https://tardis-sn.github.io/tardis/using/components/configuration/configuration.html#spectrum).\n",
+    "\n",
+    "</div>"
+   ]
   }
  ],
  "metadata": {
@@ -598,7 +603,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.8"
   },
   "notify_time": "5",
   "toc": {


### PR DESCRIPTION
Adds the required instructions for enabling `virtual_packet_logging` via config
Fixes #1374 

**Description**
This PR aims to add the required instructions for enabling the `virual_packet_logging` property in the Generating widget's notebook :)

**Motivation and context**
Adding these instructions would make it clear for the user to enable it for using the SDEC (Kromer) Plotting capabilities

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**ScreenShot**
![image](https://user-images.githubusercontent.com/66117751/115987068-286e5780-a5d1-11eb-9468-b38a969578d9.png)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
   - @jaladh-singhal 
   - @andrewfullard 
