### PR TITLE
Fixing RST Formatting for `config_validator.rst`

### DIFF
--- a/docs/using/components/configuration/config_validator.rst
+++ b/docs/using/components/configuration/config_validator.rst
@@ -3,24 +3,29 @@ Configuration Validator
 ***********************
 
 The default config validator takes a user configuration and a default configuration and creates a consistent and valid configuration for TARDIS based on the constraints given in the default configuration. Both input data are normally given as a YAML dictionary with a consistent hierarchical structure, i.e. for every item in the user configuration there has to be a declaration in the default configuration at the same hierarchical level. This declaration can be either an unspecific empty level declaration like:
+
 - Main_level:
 	- Second_level:
 		- Third_level:
 			…
 or a declaration of a configuration item like:
+
 - item:
-        - property_type: int
-        - default: 1
-        - mandatory: True
-        - help:  ‘This is a doc string.'
-        
+    - property_type: int
+    - default: 1
+    - mandatory: True
+    - help:  ‘This is a doc string.'
+
 This contains always  the keywords ``help``, ``default``, ``mandatory``, and ``property_type``. The keyword help is  a doc-string which describes the corresponding item. "Default" specifies the default value which is used in case that no value for this item is specified in the corresponding user configuration item. If the keyword mandatory is ``True``, the item has to be specified in the user configuration. The keyword ``property_type`` is used to specify the type of the item. At the moment, the config parser knows the following types:
-- Int: The property type int is for integer like config items.
-- Float: The property type float is for float like config items.
-- String: The property type string is for string like config items.
-- Quantity: The property type quantity is for physical quantities with units given as string. The string contains value and unit separated by a whitespace E.g. 2 cm.
-- Range: The property type range specifies a range via start and end. Note: ``abs(start - end ) > 0``.
-- Quantity_range: Like property type range but with quantities as start and stop. The consistency of the units is checked.
+
+.. ::
+- **Int:** The property type int is for integer like config items.
+- **Float:** The property type float is for float like config items.
+- **String:** The property type string is for string like config items.
+- **Quantity:** The property type quantity is for physical quantities with units given as string. The string contains value and unit separated by a whitespace E.g. 2 cm.
+- **Range:** The property type range specifies a range via start and end.
+.. note:: ``abs(start - end ) > 0``.
+- **Quantity_range:** Like property type range but with quantities as start and stop. The consistency of the units is checked.
 
 
 Additionally to the four standard keywords the types integer, float, and quantity can have the keywords ``allowed_value`` and ``allowed_type``. ``allowed_value`` specifies the allowed values in a list, whereas ``allowed_type`` specifies a range of allowed values, such as “x>10”.
@@ -32,6 +37,7 @@ For more complex configurations with dependencies, you can use the containers th
 If the type declaration for this container is finished, you can specify all container items like normal items. Here is an example for a container configuration with two branches:
 
 .. source: yaml
+
 - container_example:
         - property_type: container-property
         - type:
@@ -61,18 +67,22 @@ If the type declaration for this container is finished, you can specify all cont
         - two_one:
             - quantity_range:
                 - property_type: quantity_range
-                - default: [1 m,10 cm] #[Start,End]
+                - default: [1 m,10 cm] *#[Start,End]*
                 - mandatory: False
                 - help:  Like property type range but with quantities as start and stop. The consistency of the units is checked.
 
 How to use
 ^^^^^^^^^^
                 
-To use the default parser create a new config object form the class ConfigurationValidator either from a dictionaries or from YAML files::
+To use the default parser create a new config object form the class ConfigurationValidator either from a dictionaries or from YAML files:
+::
 
 - My_config = ConfigurationValidator(default configuration dictionary, user configuration dictionary)
 
 or
+
+::
+
 - My_config = ConfigurationValidator.from_yaml (default configuration file, user configuration file).
 
 To access the configuration for TARDIS, use the method ``get_config``.


### PR DESCRIPTION
Fixing general formatting issues with the _**config validator**_ documentation 

**Description**
Changes have been made to the `rst` formatting done in the `config_validator` documentation.
This makes the documentation easier to read & understand. :)

**Motivation and context**
As the documentation is quite old, changes to the formatting must also be done so as to bring it at par to current standards.
Simple fixes for the formatting have been done ... Furthermore, I will be opening PR for all the documentation formatting that can be done. :)

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. 
  - Local Testing

**Screenshot**
![image](https://user-images.githubusercontent.com/66117751/116038041-8a3cc900-a686-11eb-8fa5-4f715b70a85c.png)
![image](https://user-images.githubusercontent.com/66117751/116038068-93c63100-a686-11eb-92e9-7bb3c1bc6425.png)


**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
