### PR TITLE
Adding Config Value Validation for Different Parameters via Config File

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -314,102 +314,139 @@ class Configuration(ConfigurationNameSpace, ConfigWriterMixin):
                 "relativity mode. "
             )
 
-        # Model Section Validation
-        model_section = validated_config_dict["model"]
+        if "csvy_model" in validated_config_dict.keys():
+            pass
+        elif "model" in validated_config_dict.keys():
 
-        if model_section["structure"]["type"] == "specific":
-            start_velocity = model_section["structure"]["velocity"]["start"]
-            stop_velocity = model_section["structure"]["velocity"]["stop"]
-            if stop_velocity.value < start_velocity.value:
+            # Model Section Validation
+            # Only Valid for Tardis Config File
+            # Not Valid for CSVY File Config
+            model_section = validated_config_dict["model"]
+
+            if model_section["structure"]["type"] == "specific":
+                start_velocity = model_section["structure"]["velocity"]["start"]
+                stop_velocity = model_section["structure"]["velocity"]["stop"]
+                if stop_velocity.value < start_velocity.value:
+                    raise ValueError(
+                        "Stop Velocity Cannot Be Less than Start Velocity. \n"
+                        f"Start Velocity = {start_velocity} \n"
+                        f"Stop Velocity = {stop_velocity}"
+                    )
+            elif model_section["structure"]["type"] == "file":
+                v_inner_boundary = model_section["structure"][
+                    "v_inner_boundary"
+                ]
+                v_outer_boundary = model_section["structure"][
+                    "v_outer_boundary"
+                ]
+                if v_outer_boundary.value < v_inner_boundary.value:
+                    raise ValueError(
+                        "Outer Boundary Velocity Cannot Be Less than Inner Boundary Velocity. \n"
+                        f"Inner Boundary Velocity = {v_inner_boundary} \n"
+                        f"Outer Boundary Velocity = {v_outer_boundary}"
+                    )
+            if "density" in model_section["structure"].keys():
+                if (
+                    model_section["structure"]["density"]["type"]
+                    == "exponential"
+                ):
+                    rho_0 = model_section["structure"]["density"]["rho_0"]
+                    v_0 = model_section["structure"]["density"]["v_0"]
+                    if not rho_0.value > 0:
+                        raise ValueError(
+                            f"Density Specified is Invalid, {rho_0}"
+                        )
+                    if not v_0.value > 0:
+                        raise ValueError(
+                            f"Velocity Specified is Invalid, {v_0}"
+                        )
+                    if "time_0" in model_section["structure"]["density"].keys():
+                        time_0 = model_section["structure"]["density"]["time_0"]
+                        if not time_0.value > 0:
+                            raise ValueError(
+                                f"Time Specified is Invalid, {time_0}"
+                            )
+                elif (
+                    model_section["structure"]["density"]["type"] == "power_law"
+                ):
+                    rho_0 = model_section["structure"]["density"]["rho_0"]
+                    v_0 = model_section["structure"]["density"]["v_0"]
+                    if not rho_0.value > 0:
+                        raise ValueError(
+                            f"Density Specified is Invalid, {rho_0}"
+                        )
+                    if not v_0.value > 0:
+                        raise ValueError(
+                            f"Velocity Specified is Invalid, {v_0}"
+                        )
+                    if "time_0" in model_section["structure"]["density"].keys():
+                        time_0 = model_section["structure"]["density"]["time_0"]
+                        if not time_0.value > 0:
+                            raise ValueError(
+                                f"Time Specified is Invalid, {time_0}"
+                            )
+                elif model_section["structure"]["density"]["type"] == "uniform":
+                    value = model_section["structure"]["density"]["value"]
+                    if not value.value > 0:
+                        raise ValueError(
+                            f"Density Value Specified is Invalid, {value}"
+                        )
+                    if "time_0" in model_section["structure"]["density"].keys():
+                        time_0 = model_section["structure"]["density"]["time_0"]
+                        if not time_0.value > 0:
+                            raise ValueError(
+                                f"Time Specified is Invalid, {time_0}"
+                            )
+
+            # SuperNova Section Validation
+            supernova_section = validated_config_dict["supernova"]
+
+            time_explosion = supernova_section["time_explosion"]
+            luminosity_wavelength_start = supernova_section[
+                "luminosity_wavelength_start"
+            ]
+            luminosity_wavelength_end = supernova_section[
+                "luminosity_wavelength_end"
+            ]
+            if not time_explosion.value > 0:
                 raise ValueError(
-                    "Stop Velocity Cannot Be Less than Start Velocity. \n"
-                    f"Start Velocity = {start_velocity} \n"
-                    f"Stop Velocity = {stop_velocity}"
+                    f"Time Of Explosion is Invalid, {time_explosion}"
                 )
-        elif model_section["structure"]["type"] == "file":
-            v_inner_boundary = model_section["structure"]["v_inner_boundary"]
-            v_outer_boundary = model_section["structure"]["v_outer_boundary"]
-            if v_outer_boundary.value < v_inner_boundary.value:
+            if (
+                luminosity_wavelength_start.value
+                > luminosity_wavelength_end.value
+            ):
                 raise ValueError(
-                    "Outer Boundary Velocity Cannot Be Less than Inner Boundary Velocity. \n"
-                    f"Inner Boundary Velocity = {v_inner_boundary} \n"
-                    f"Outer Boundary Velocity = {v_outer_boundary}"
+                    "Integral Limits for Luminosity Wavelength are Invalid, Start Limit > End Limit \n"
+                    f"Luminosity Wavelength Start : {luminosity_wavelength_start} \n"
+                    f"Luminosity Wavelength End : {luminosity_wavelength_end}"
                 )
 
-        if model_section["structure"]["density"]["type"] == "exponential":
-            time_0 = model_section["structure"]["density"]["time_0"]
-            rho_0 = model_section["structure"]["density"]["rho_0"]
-            v_0 = model_section["structure"]["density"]["v_0"]
-            if not time_0.value > 0:
-                raise ValueError(f"Time Specified is Invalid, {time_0}")
-            if not rho_0.value > 0:
-                raise ValueError(f"Density Specified is Invalid, {rho_0}")
-            if not v_0.value > 0:
-                raise ValueError(f"Velocity Specified is Invalid, {v_0}")
+            # Plasma Section Validation
+            plasma_section = validated_config_dict["plasma"]
 
-        if model_section["structure"]["density"]["type"] == "power_law":
-            time_0 = model_section["structure"]["density"]["time_0"]
-            rho_0 = model_section["structure"]["density"]["rho_0"]
-            v_0 = model_section["structure"]["density"]["v_0"]
-            if not time_0.value > 0:
-                raise ValueError(f"Time Specified is Invalid, {time_0}")
-            if not rho_0.value > 0:
-                raise ValueError(f"Density Specified is Invalid, {rho_0}")
-            if not v_0.value > 0:
-                raise ValueError(f"Velocity Specified is Invalid, {v_0}")
+            initial_t_inner = plasma_section["initial_t_inner"]
+            initial_t_rad = plasma_section["initial_t_rad"]
+            if not initial_t_inner.value >= -1:
+                raise ValueError(
+                    f"Initial Temperature of Inner Boundary Black Body is Invalid, {initial_t_inner}"
+                )
+            if not initial_t_rad.value >= -1:
+                raise ValueError(
+                    f"Initial Radiative Temperature is Invalid, {initial_t_inner}"
+                )
 
-        if model_section["structure"]["density"]["type"] == "uniform":
-            time_0 = model_section["structure"]["density"]["time_0"]
-            value = model_section["structure"]["density"]["value"]
-            if not time_0.value > 0:
-                raise ValueError(f"Time Specified is Invalid, {time_0}")
-            if not value.value > 0:
-                raise ValueError(f"Density Value Specified is Invalid, {value}")
+            # Spectrum Section Validation
+            spectrum_section = validated_config_dict["spectrum"]
 
-        # SuperNova Section Validation
-        supernova_section = validated_config_dict["supernova"]
-
-        time_explosion = supernova_section["time_explosion"]
-        luminosity_wavelength_start = supernova_section[
-            "luminosity_wavelength_start"
-        ]
-        luminosity_wavelength_end = supernova_section[
-            "luminosity_wavelength_end"
-        ]
-        if not time_explosion.value > 0:
-            raise ValueError(f"Time Of Explosion is Invalid, {time_explosion}")
-        if luminosity_wavelength_start.value > luminosity_wavelength_end.value:
-            raise ValueError(
-                "Integral Values for Luminosity Wavelength are Invalid, Start Limit > End Limit \n"
-                f"Luminosity Wavelength Start : {luminosity_wavelength_start} \n"
-                f"Luminosity Wavelength End : {luminosity_wavelength_end}"
-            )
-
-        # Plasma Section Validation
-        plasma_section = validated_config_dict["plasma"]
-
-        initial_t_inner = plasma_section["initial_t_inner"]
-        initial_t_rad = plasma_section["initial_t_rad"]
-        if not initial_t_inner.value >= -1:
-            raise ValueError(
-                f"Initial Temperature of Inner Boundary Black Body is Invalid, {initial_t_inner}"
-            )
-        if not initial_t_rad.value >= -1:
-            raise ValueError(
-                f"Initial Radiative Temperature is Invalid, {initial_t_inner}"
-            )
-
-        # Spectrum Section Validation
-        spectrum_section = validated_config_dict["spectrum"]
-
-        start = spectrum_section["start"]
-        stop = spectrum_section["stop"]
-        if start.value > stop.value:
-            raise ValueError(
-                "Start Value of Spectrum Cannot be Greater than Stop Value. \n"
-                f"Start : {start} \n"
-                f"Stop : {stop}"
-            )
+            start = spectrum_section["start"]
+            stop = spectrum_section["stop"]
+            if start.value > stop.value:
+                raise ValueError(
+                    "Start Value of Spectrum Cannot be Greater than Stop Value. \n"
+                    f"Start : {start} \n"
+                    f"Stop : {stop}"
+                )
 
         return cls(validated_config_dict)
 

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -313,6 +313,14 @@ class Configuration(ConfigurationNameSpace, ConfigWriterMixin):
                 "relativity mode. "
             )
 
+        # SuperNova Section Implementation
+        supernova_section = validated_config_dict["supernova"]
+        time_explosion = supernova_section["time_explosion"]
+        if not time_explosion.value > 0:
+            raise ValueError(
+                f"Time Of Explosion is an Invalid Time, {time_explosion}"
+            )
+
         return cls(validated_config_dict)
 
     def __init__(self, config_dict):

--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -319,8 +319,6 @@ class Configuration(ConfigurationNameSpace, ConfigWriterMixin):
         elif "model" in validated_config_dict.keys():
 
             # Model Section Validation
-            # Only Valid for Tardis Config File
-            # Not Valid for CSVY File Config
             model_section = validated_config_dict["model"]
 
             if model_section["structure"]["type"] == "specific":

--- a/tardis/io/schemas/csvy_model.yml
+++ b/tardis/io/schemas/csvy_model.yml
@@ -145,8 +145,11 @@ definitions:
   abundance:
     uniform:
       type: object
-      additionalProperties: true
       properties:
         type:
           enum:
           - uniform
+      additionalProperties:
+        type: number
+        minimum: 0
+        maximum: 1

--- a/tardis/io/schemas/model.yml
+++ b/tardis/io/schemas/model.yml
@@ -164,9 +164,11 @@ definitions:
       - filename
     uniform:
       type: object
-      additionalProperties: true
       properties:
         type:
           enum:
           - uniform
-
+      additionalProperties:
+        type: number
+        minimum: 0
+        maximum: 1

--- a/tardis/io/schemas/model.yml
+++ b/tardis/io/schemas/model.yml
@@ -70,7 +70,6 @@ definitions:
         exponent:
           type: number
           description: exponent for exponential density profile
-          minimum: 0
       required:
       - rho_0
       - v_0

--- a/tardis/io/schemas/model.yml
+++ b/tardis/io/schemas/model.yml
@@ -70,6 +70,7 @@ definitions:
         exponent:
           type: number
           description: exponent for exponential density profile
+          minimum: 0
       required:
       - rho_0
       - v_0

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -105,6 +105,7 @@ definitions:
           description: the fraction of shells that have to converge to the given  convergence
             threshold. For example, 0.8 means that 80% of shells have to converge
             to the threshold that convergence is established
+          minimum: 0
         hold_iterations:
           type: number
           multipleOf: 1.0
@@ -115,11 +116,13 @@ definitions:
           type: number
           default: 1.0
           description: damping constant
+          minimum: 0
         threshold:
           type: number
           default: 0.05
           description: specifies the threshold that is taken as convergence  (i.e.
             0.05 means that the value does not change more than 5%)
+          minimum: 0
         t_inner:
           type: object
           additionalProperties: false
@@ -128,10 +131,12 @@ definitions:
               type: number
               default: 0.5
               description: damping constant
+              minimum: 0
             threshold:
               type: number
               description: specifies the threshold that is taken as convergence  (i.e.
                 0.05 means that the value does not change more than 5%)
+              minimum: 0
         t_rad:
           type: object
           additionalProperties: false
@@ -140,10 +145,12 @@ definitions:
               type: number
               default: 0.5
               description: damping constant
+              minimum: 0
             threshold:
               type: number
               description: specifies the threshold that is taken as convergence  (i.e.
                 0.05 means that the value does not change more than 5%)
+              minimum: 0
           required:
           - threshold
         w:
@@ -154,10 +161,12 @@ definitions:
               type: number
               default: 0.5
               description: damping constant
+              minimum: 0
             threshold:
               type: number
               description: specifies the threshold that is taken as convergence  (i.e.
                 0.05 means that the value does not change more than 5%)
+              minimum: 0
           required:
           - threshold
         lock_t_inner_cycles:

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -1,5 +1,6 @@
 # tests for the config reader module
 import os
+from attr import validate
 import pytest
 import pandas as pd
 from numpy.testing import assert_almost_equal
@@ -44,10 +45,12 @@ def test_from_config_dict(tardis_config_verysimple):
         tardis_config_verysimple, validate=True, config_dirname="test"
     )
     assert conf.config_dirname == "test"
+
     assert_almost_equal(
         conf.spectrum.start.value,
         tardis_config_verysimple["spectrum"]["start"].value,
     )
+
     assert_almost_equal(
         conf.spectrum.stop.value,
         tardis_config_verysimple["spectrum"]["stop"].value,
@@ -68,3 +71,78 @@ def test_config_hdf(hdf_file_path, tardis_config_verysimple):
     actual = pd.read_hdf(hdf_file_path, key="/simulation/config")
     expected = expected.get_properties()["config"]
     assert actual[0] == expected[0]
+
+
+def test_model_section_config(tardis_config_verysimple):
+    conf = Configuration.from_config_dict(
+        tardis_config_verysimple, validate=True, config_dirname="test"
+    )
+
+    assert conf.model.structure.density.type == "branch85_w7"
+
+    tardis_config_verysimple["model"]["structure"]["velocity"][
+        "start"
+    ] = "2.0e4 km/s"
+    tardis_config_verysimple["model"]["structure"]["velocity"][
+        "stop"
+    ] = "1.1e4 km/s"
+    with pytest.raises(ValueError) as ve:
+        if (
+            conf.model.structure.velocity.start
+            < conf.model.structure.velocity.stop
+        ):
+            raise ValueError("Stop Value must be greater than Start Value")
+    assert ve.type is ValueError
+
+
+def test_supernova_section_config(tardis_config_verysimple):
+    conf = Configuration.from_config_dict(
+        tardis_config_verysimple, validate=True, config_dirname="test"
+    )
+    tardis_config_verysimple["supernova"]["time_explosion"] = "-10 day"
+    tardis_config_verysimple["supernova"][
+        "luminosity_wavelength_start"
+    ] = "15 angstrom"
+    tardis_config_verysimple["supernova"][
+        "luminosity_wavelength_end"
+    ] = "0 angstrom"
+    with pytest.raises(ValueError) as ve:
+        if conf.supernova.time_explosion.value > 0:
+            raise ValueError("Time of Explosion cannot be negative")
+    assert ve.type is ValueError
+
+    with pytest.raises(ValueError) as ve:
+        if (
+            conf.supernova.luminosity_wavelength_start.value
+            < conf.supernova.luminosity_wavelength_end.value
+        ):
+            raise ValueError(
+                "End Limit must be greater than Start Limit for Luminosity"
+            )
+    assert ve.type is ValueError
+
+
+def test_plasma_section_config(tardis_config_verysimple):
+    conf = Configuration.from_config_dict(
+        tardis_config_verysimple, validate=True, config_dirname="test"
+    )
+    tardis_config_verysimple["plasma"]["initial_t_inner"] = "-100 K"
+    tardis_config_verysimple["plasma"]["initial_t_rad"] = "-100 K"
+    with pytest.raises(ValueError) as ve:
+        if (conf.plasma.initial_t_inner.value >= -1) and (
+            conf.plasma.initial_t_rad.value >= -1
+        ):
+            raise ValueError("Initial Temperatures are Invalid")
+    assert ve.type is ValueError
+
+
+def test_spectrum_section_config(tardis_config_verysimple):
+    conf = Configuration.from_config_dict(
+        tardis_config_verysimple, validate=True, config_dirname="test"
+    )
+    tardis_config_verysimple["spectrum"]["start"] = "2500 angstrom"
+    tardis_config_verysimple["spectrum"]["stop"] = "500 angstrom"
+    with pytest.raises(ValueError) as ve:
+        if not conf.spectrum.stop.value < conf.spectrum.start.value:
+            raise ValueError("Start Value must be less than Stop Value")
+    assert ve.type is ValueError

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -74,6 +74,21 @@ def test_config_hdf(hdf_file_path, tardis_config_verysimple):
 
 
 def test_model_section_config(tardis_config_verysimple):
+    """
+    Configuration Validation Test for Model Section of the Tardis Config YAML File
+
+    Validates:
+        Density: branch85_w7
+        Velocity (Start < End)
+
+    Parameter
+    ---------
+        `tardis_config_verysimple` : YAML File
+
+    Result
+    ------
+        Assertion based on validation for specified values
+    """
     conf = Configuration.from_config_dict(
         tardis_config_verysimple, validate=True, config_dirname="test"
     )
@@ -96,6 +111,21 @@ def test_model_section_config(tardis_config_verysimple):
 
 
 def test_supernova_section_config(tardis_config_verysimple):
+    """
+    Configuration Validation Test for Supernova Section of the Tardis Config YAML File
+
+    Validates:
+        Time of Explosion (Must always be positive)
+        Luminosity Wavelength Limits (Start < End)
+
+    Parameter
+    ---------
+        `tardis_config_verysimple` : YAML File
+
+    Result
+    ------
+        Assertion based on validation for specified values
+    """
     conf = Configuration.from_config_dict(
         tardis_config_verysimple, validate=True, config_dirname="test"
     )
@@ -123,6 +153,21 @@ def test_supernova_section_config(tardis_config_verysimple):
 
 
 def test_plasma_section_config(tardis_config_verysimple):
+    """
+    Configuration Validation Test for Plasma Section of the Tardis Config YAML File
+
+    Validates:
+        Initial temperature inner (must be greater than -1K)
+        Initial radiative temperature (must be greater than -1K)
+
+    Parameter
+    ---------
+        `tardis_config_verysimple` : YAML File
+
+    Result
+    ------
+        Assertion based on validation for specified values
+    """
     conf = Configuration.from_config_dict(
         tardis_config_verysimple, validate=True, config_dirname="test"
     )
@@ -137,6 +182,20 @@ def test_plasma_section_config(tardis_config_verysimple):
 
 
 def test_spectrum_section_config(tardis_config_verysimple):
+    """
+    Configuration Validation Test for Plasma Section of the Tardis Config YAML File
+
+    Validates:
+        Spectrum Start & End Limits (Start < End)
+
+    Parameter
+    ---------
+        `tardis_config_verysimple` : YAML File
+
+    Result
+    ------
+        Assertion based on validation for specified values
+    """
     conf = Configuration.from_config_dict(
         tardis_config_verysimple, validate=True, config_dirname="test"
     )


### PR DESCRIPTION
This PR aims to implement **config validation** for _values_ that are passed through the `.yml` file.
This Implements #1343 

**Description**
This PR aims to implement validation for values that can be passed through the tardis configuration file. 
These are aimed at Density & Abundances in the current iteration.

**Motivation and context**
The tardis configuration file allows for non-realistic values to be passed without raising any errors. This PR aims to fix this & implement validation for the values so as to allow only real physics values to be added

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
None at current status :)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I will update the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
