### PR TITLE
Close line handling issue #1307

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -111,11 +111,10 @@ def line_emission(r_packet, emission_line_id, time_explosion, numba_plasma):
     )
     r_packet.next_line_id = emission_line_id + 1
     nu_line = numba_plasma.line_list_nu[emission_line_id]
+    nu_next_line = numba_plasma.line_list_nu[emission_line_id + 1]
 
     if emission_line_id != (len(numba_plasma.line_list_nu) - 1):
-        test_for_close_line(
-            r_packet, emission_line_id + 1, nu_line, numba_plasma
-        )
+        r_packet.is_close_line = test_for_close_line(nu_line, nu_next_line)
 
     if montecarlo_configuration.full_relativity:
         r_packet.mu = angle_aberration_CMF_to_LF(

--- a/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
@@ -411,8 +411,8 @@ def test_test_for_close_line(
     packet, line_id, nu_line, verysimple_numba_plasma, expected
 ):
 
-    r_packet.test_for_close_line(
-        packet, line_id, nu_line, verysimple_numba_plasma
+    is_close_line = r_packet.test_for_close_line(
+        verysimple_numba_plasma.line_list_nu[line_id], nu_line
     )
 
-    assert packet.is_close_line == expected
+    assert is_close_line == expected

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -122,11 +122,10 @@ def trace_vpacket_within_shell(v_packet, numba_model, numba_plasma):
         )
 
         if cur_line_id != (len(numba_plasma.line_list_nu) - 1):
-            test_for_close_line(
-                v_packet,
-                cur_line_id,
-                numba_plasma.line_list_nu[cur_line_id - 1],
-                numba_plasma,
+            nu_prev_line = numba_plasma.line_list_nu[cur_line_id - 1]
+            v_packet.is_close_line = test_for_close_line(
+                nu_line,
+                nu_prev_line,
             )
 
         if distance_boundary <= distance_trace_line:
@@ -280,11 +279,9 @@ def trace_vpacket_volley(
         )
 
         if r_packet.next_line_id <= (len(numba_plasma.line_list_nu) - 1):
-            test_for_close_line(
-                v_packet,
-                r_packet.next_line_id,
+            v_packet.is_close_line = test_for_close_line(
+                numba_plasma.line_list_nu[r_packet.next_line_id],
                 numba_plasma.line_list_nu[r_packet.next_line_id - 1],
-                numba_plasma,
             )
 
         tau_vpacket = trace_vpacket(v_packet, numba_model, numba_plasma)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Updated logic in line loop in trace packet. Definitely too long and may not be entirely correct

Updated test close line to just return a boolean and use simpler inputs

Updated calls to test close line

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Current close line handling is not correct, tends to miss interactions

**How has this been tested?**
Current pipeline fails because the behaviour is different. Need to do a ref-data comparison.

- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
