### PR TITLE
Added support for passing Configuration object in run_tardis

### DIFF
--- a/tardis/base.py
+++ b/tardis/base.py
@@ -41,10 +41,13 @@ def run_tardis(
         except TypeError:
             atom_data = atom_data
 
-    try:
-        tardis_config = Configuration.from_yaml(config)
-    except TypeError:
-        tardis_config = Configuration.from_config_dict(config)
+    if isinstance(config, Configuration):
+        tardis_config = config
+    else:
+        try:
+            tardis_config = Configuration.from_yaml(config)
+        except TypeError:
+            tardis_config = Configuration.from_config_dict(config)
 
     simulation = Simulation.from_config(
         tardis_config,

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -16,8 +16,8 @@ def run_tardis(
 
     Parameters
     ----------
-    config : str or dict
-        filename of configuration yaml file or dictionary
+    config : str or dict or tardis.io.config_reader.Configuration
+        filename of configuration yaml file or dictionary or TARDIS Configuration object
     atom_data : str or tardis.atomic.AtomData
         if atom_data is a string it is interpreted as a path to a file storing
         the atomic data. Atomic data to use for this TARDIS simulation. If set to None, the

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -8,6 +8,20 @@ from astropy.tests.helper import assert_quantity_allclose
 from tardis.simulation.base import Simulation
 from tardis.io.config_reader import Configuration
 
+from tardis import run_tardis
+
+
+def test_run_tardis_from_config_obj(atomic_data_fname):
+    config = Configuration.from_yaml(
+        "tardis/io/tests/data/tardis_configv1_verysimple.yml"
+    )
+    config["atom_data"] = atomic_data_fname
+
+    try:
+        sim = run_tardis(config)
+    except Exception as e:
+        pytest.fail(str(e.args[0]))
+
 
 class TestRunnerSimple:
     """

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -12,6 +12,10 @@ from tardis import run_tardis
 
 
 def test_run_tardis_from_config_obj(atomic_data_fname):
+    """
+    Tests whether the run_tardis function can take in the Configuration object
+    as arguments
+    """
     config = Configuration.from_yaml(
         "tardis/io/tests/data/tardis_configv1_verysimple.yml"
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Merging this PR will allow for configuration objects to be passed in `run_tardis`.

```
config = Configuration.from_yaml('tardis_example.yml')
run_tardis(config)
```
Fixes #1294 

@wkerzendorf Kindly have a look.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
