### PR TITLE
better handling of pickle5 backport

### DIFF
--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -34,8 +34,9 @@ logger.addHandler(console_handler)
 logging.getLogger("py.warnings").addHandler(console_handler)
 
 # ----------------------------------------------------------------------------
-# pyne holds Python 3.7 on macOS, but refdata is pickled with protocol 5 (3.8) 
+# pyne holds Python 3.7 on macOS, but refdata is pickled with protocol 5 (3.8)
 
 if sys.version_info < (3, 8):
     import pickle5
+
     sys.modules["pickle"] = pickle5

--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -34,6 +34,8 @@ logger.addHandler(console_handler)
 logging.getLogger("py.warnings").addHandler(console_handler)
 
 # ----------------------------------------------------------------------------
-import pickle5
+# pyne holds Python 3.7 on macOS, but refdata is pickled with protocol 5 (3.8) 
 
-sys.modules["pickle"] = pickle5
+if sys.version_info < (3, 8):
+    import pickle5
+    sys.modules["pickle"] = pickle5

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -26,6 +26,7 @@ dependencies:
   - tqdm
   - beautifulsoup4
   - lxml
+  - pickle5
 
   # Analysis
   - jupyter
@@ -44,7 +45,7 @@ dependencies:
   - sphinx
   - nbconvert
   - numpydoc
-  - docutils>=0.16,<0.17
+  - docutils=0.16
   - nbformat
   - nbsphinx
   - sphinx_bootstrap_theme
@@ -75,4 +76,3 @@ dependencies:
       - dot2tex
       - sphinx-jsonschema
       - git+https://github.com/Naereen/dot2tex.git
-      - pickle5

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -60,7 +60,6 @@ dependencies:
   - pytest-html
   - pytest-cov
   - coverage
-  - requests
   - docopt
 
   # Code quality


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- `pyne` macOS deprecation is still giving us problems (now with @KevinCawley and the numba integration pipeline). I don't think this patch is enough to fix our problems, but provides a better handling of the hack.

- Moved `pickle5` from `pip` section of the environment file (solves #1564).

**Motivation and context**
See #1535. 

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
