### PR TITLE
add fetch depth param to Azure template

### DIFF
--- a/azure-pipelines/run-unit-tests.yml
+++ b/azure-pipelines/run-unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
           source activate tardis
           pip install pytest-azurepipelines
           pytest tardis --tardis-refdata=$(refdata.dir) --cov=tardis --cov-report=xml --cov-report=html
-        displayName: 'TARDIS test'
+        displayName: 'Run tests'
 
       - bash: bash <(curl -s https://codecov.io/bash)
         displayName: 'Upload to codecov.io'

--- a/azure-pipelines/run-unit-tests.yml
+++ b/azure-pipelines/run-unit-tests.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - template: templates/default.yml
         parameters:
+          fetchDepth: 1
           fetchRefdata: true
           useMamba: true
 

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -69,5 +69,5 @@ steps:
     - bash: |
         cd $(tardis.dir)
         source activate tardis
-        python setup.py build_ext --inplace
+        python setup.py install
       displayName: 'Build C extensions'

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -20,18 +20,18 @@ parameters:
 
 steps:
   - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
-    displayName: 'Set BASH exit on error'
+    displayName: 'Force BASH exit on error'
     condition: eq(variables['Agent.OS'], 'Linux')
 
   - bash: |
       echo "##vso[task.setvariable variable=tardis.dir]$(Build.SourcesDirectory)/tardis"
       echo "##vso[task.setvariable variable=refdata.dir]$(Build.SourcesDirectory)/tardis-refdata"
-    displayName: 'Set source directories'
+    displayName: 'Set environment variables'
 
   - ${{ if eq(parameters.useMamba, false) }}:
     - bash: |
         echo "##vso[task.setvariable variable=package.manager]conda"
-      displayName: 'Set package manager'
+      displayName: 'Set environment variables'
 
   - ${{ if eq(parameters.useMamba, true) }}:
     - bash: |
@@ -41,12 +41,11 @@ steps:
   - checkout: self
     path: s/tardis
     fetchDepth: ${{ parameters.fetchDepth }}
-    displayName: 'Fetch main repository'
 
   - ${{ if eq(parameters.fetchRefdata, true) }}:
     - checkout: git://TARDIS/tardis-refdata
       lfs: true
-      displayName: 'Fetch reference data repository'
+      displayName: 'Fetch reference data'
 
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Add conda to PATH'
@@ -57,17 +56,17 @@ steps:
 
   - ${{ if eq(parameters.useMamba, true) }}:
     - bash: conda install mamba -c conda-forge -y
-      displayName: 'Install package manager'
+      displayName: 'Install Mamba'
 
   - ${{ if eq(parameters.skipInstall, false) }}:
     - bash: |
         cd $(tardis.dir)
         $(package.manager) env create -f tardis_env3.yml
-      displayName: 'Install conda environment'
+      displayName: 'Setup environment'
 
   - ${{ if eq(parameters.skipInstall, false) }}:
     - bash: |
         cd $(tardis.dir)
         source activate tardis
         python setup.py install
-      displayName: 'Build C extensions'
+      displayName: 'Install package'

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -2,6 +2,10 @@
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 parameters:
+  - name: fetchDepth
+    type: number
+    default: 0
+
   - name: fetchRefdata
     type: boolean
     default: false
@@ -36,6 +40,7 @@ steps:
  
   - checkout: self
     path: s/tardis
+    fetchDepth: ${{ parameters.fetchDepth }}
     displayName: 'Fetch main repository'
 
   - ${{ if eq(parameters.fetchRefdata, true) }}:

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -233,16 +233,17 @@ to start a new pipeline use::
   steps:
     - template: templates/default.yml
       parameters:
-        fetchRefdata: true
+        useMamba: true
 
 **List of template parameters:**
 
-- ``fetchRefdata``: fetch the ``tardis-refdata`` repository from Azure Repos
-  (default is *false*).
-- ``useMamba``: use the ``mamba`` package manager instead of ``conda``
-  (default is *false*). 
-- ``skipInstall``: does not create the TARDIS environment
-  (default is *false*).
+- ``fetchDepth`` (*int*): the depth of commits to fetch from ``tardis`` repository,
+  default is ``0`` (no limit).
+- ``fetchRefdata`` (*bool*): fetch the ``tardis-refdata`` repository from Azure Repos,
+  default is ``false``.
+- ``useMamba`` (*bool*): use the ``mamba`` package manager instead of ``conda``,
+  default is ``false``. 
+- ``skipInstall`` (*bool*): does not create the TARDIS environment, default is ``false``.
 
 **List of predefined custom variables:**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Add the option to fetch `n` commits from the tip of `tardis` repo.

**Motivation and context**
Saves time and bandwidth per pipeline run.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
