### PR TITLE
Fix numba deprecation

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -6,7 +6,8 @@ import scipy.sparse as sp
 from scipy.interpolate import interp1d
 from astropy import units as u
 from tardis import constants as const
-from numba import njit, char, float64, int64, jitclass, typeof, byte, prange
+from numba import njit, char, float64, int64, typeof, byte, prange
+from numba.experimental import jitclass
 import pdb
 
 from tardis.montecarlo.montecarlo_numba.numba_config import SIGMA_THOMSON

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -26,7 +26,6 @@ dependencies:
   - tqdm
   - beautifulsoup4
   - lxml
-  - pickle5
 
   # Analysis
   - jupyter
@@ -75,3 +74,4 @@ dependencies:
       - dot2tex
       - sphinx-jsonschema
       - git+https://github.com/Naereen/dot2tex.git
+      - pickle5

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -10,7 +10,7 @@ dependencies:
   - scipy=1.5
   - pandas=1.0
   - astropy=3
-  - numba=.53.1
+  - numba=0.53.1
   - numexpr
 
   # Plasma

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -26,6 +26,7 @@ dependencies:
   - tqdm
   - beautifulsoup4
   - lxml
+  - pickle5
 
   # Analysis
   - jupyter
@@ -74,4 +75,3 @@ dependencies:
       - dot2tex
       - sphinx-jsonschema
       - git+https://github.com/Naereen/dot2tex.git
-      - pickle5

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -10,7 +10,7 @@ dependencies:
   - scipy=1.5
   - pandas=1.0
   - astropy=3
-  - numba=0.50
+  - numba
   - numexpr
 
   # Plasma

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -10,7 +10,7 @@ dependencies:
   - scipy=1.5
   - pandas=1.0
   - astropy=3
-  - numba
+  - numba=.53.1
   - numexpr
 
   # Plasma


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fixes an old dependency on numba and updates the env file accordingly.

**Description**
<!--- Describe your changes in detail -->
This fixes the old use of jitclass to be now imported from numba.experimental, as well as making the numba dependency no longer fixed for tardis. 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Getting tardis added to the numba-integratino-testing pipeline

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
