### PR TITLE
[DO NOT MERGE] re-render reference data with Python 3.7

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -26,7 +26,7 @@ dependencies:
   - tqdm
   - beautifulsoup4
   - lxml
-  - pickle5
+  #- pickle5
 
   # Analysis
   - jupyter


### PR DESCRIPTION
Discarded. Proceed to patch the reference data notebook in [tardis-refdata](https://github.com/tardis-sn/tardis-refdata).