### PR TITLE
Fixing `Team` Link redirection in Code Of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,4 +15,4 @@ As members of the community,
 
 This code of conduct has been adapted from the Astropy Code of Conduct, which in turn uses parts of the PSF code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](https://tardis-sn.github.io/tardis/team.html) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](https://tardis-sn.github.io/tardis/team.html); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](https://tardis-sn.github.io/tardis/team_and_governance/team.html) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](https://tardis-sn.github.io/tardis/team_and_governance/team.html); who is outside of the TARDIS collaboration and will treat reports confidentially).**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fixes link redirection to Teams on the **Code Of Conduct** page for TARDIS 

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. --> Local

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
