### PR TITLE
add gh pages instruction

### DIFF
--- a/.github/workflows/documentation-preview.yml
+++ b/.github/workflows/documentation-preview.yml
@@ -2,13 +2,13 @@
 # - http://tardis-sn.github.io/tardis/development/continuous_integration.html
 # - https://tardis-sn.github.io/tardis/development/documentation_preview.html
 
-name: documentation-preview
+name: docs-preview
 
 on:
   push:
 
 jobs:
-  documentation_preview:
+  build:
   
     # This workflow will be triggered:
     #

--- a/.github/workflows/documentation-preview.yml
+++ b/.github/workflows/documentation-preview.yml
@@ -14,10 +14,15 @@ jobs:
     #
     # 1. Only on forks, never on main repository.
     # 2. If the branch name contains the word `doc`.
-    # 3. If the commit message includes the tag `[build docs]`.
+    # 3. If the commit message includes the a valid tag.
 
-    if: github.repository_owner != 'tardis-sn' && (contains(github.ref, 'doc') || contains(github.event.head_commit.message, '[build docs]'))
-  
+    if: github.repository_owner != 'tardis-sn' && (
+        contains(github.ref, 'doc') ||
+        contains(github.event.head_commit.message, '[build docs]') ||
+        contains(github.event.head_commit.message, '[build_docs]') ||
+        contains(github.event.head_commit.message, '[build doc]') ||
+        contains(github.event.head_commit.message, '[build_doc]'))
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/docs/development/documentation_preview.rst
+++ b/docs/development/documentation_preview.rst
@@ -4,11 +4,12 @@
 Documentation Preview
 *********************
 
-Most of the time it's enough to build the documentation locally and see how things are going. But sometimes 
-it's nice to share our changes and get some feedback from other collaborators. 
+To preview your changes to the documentation please:
 
-To preview your changes to the documentation first make sure you have GitHub Actions activated on your fork
-(see the Actions tab). Then, there are two ways to trigger the build:
+#. Enable GitHub Actions to run on your fork (see the *Actions* tab).
+#. Make sure your fork is deploying GitHub Pages inside the root of ``gh-pages`` branch (see the *Settings* tab).
+
+Then, there are two ways to trigger the build:
 
 #. If the branch you are working on contains the word ``doc`` in it, then every commit will trigger the build.
 #. Add the tag ``[build docs]`` on the commit message before pushing.

--- a/docs/development/documentation_preview.rst
+++ b/docs/development/documentation_preview.rst
@@ -7,11 +7,17 @@ Documentation Preview
 To preview your changes to the documentation please:
 
 #. Enable GitHub Actions to run on your fork (see the *Actions* tab).
-#. Make sure your fork is deploying GitHub Pages inside the root of ``gh-pages`` branch (see the *Settings* tab).
+#. Make sure your fork is deploying GitHub Pages inside the root of ``gh-pages`` branch (go to *Settings* -> *Pages*).
 
 Then, there are two ways to trigger the build:
 
-#. If the branch you are working on contains the word ``doc`` in it, then every commit will trigger the build.
-#. Add the tag ``[build docs]`` on the commit message before pushing.
+#. If the branch you are working on contains the word ``doc`` in it, then every commit pushed to that branch will trigger the build.
+#. If your commit message contains the ``[build docs]`` tag, then that commit will trigger the build.
+
+.. note::
+
+    If you forgot to folow any of the two ways described above, you always can trigger push an empty commit
+    as follows: ``git commit --allow-empty -m "[build docs]"``
+
 
 Your preview will be available at ``<username>.github.io/tardis/branch/<branch name>/index.html``.

--- a/docs/development/documentation_preview.rst
+++ b/docs/development/documentation_preview.rst
@@ -6,8 +6,8 @@ Documentation Preview
 
 To preview your changes to the documentation please:
 
-#. Enable GitHub Actions to run on your fork (see the *Actions* tab).
-#. Make sure your fork is deploying GitHub Pages inside the root of ``gh-pages`` branch (go to *Settings* -> *Pages*).
+#. Enable GitHub Actions in the *Actions* tab of your fork.
+#. Under *Settings -> Pages* in your fork, make sure GitHub Pages is being built from the ``gh-pages`` branch and the ``/ (root)`` folder.
 
 Then, there are two ways to trigger the build:
 
@@ -16,8 +16,7 @@ Then, there are two ways to trigger the build:
 
 .. note::
 
-    If you forgot to folow any of the two ways described above, you always can trigger push an empty commit
-    as follows: ``git commit --allow-empty -m "[build docs]"``
+    You always can trigger a new build by pushing an empty commit: ``git commit --allow-empty -m "[build docs]"``
 
 
 Your preview will be available at ``<username>.github.io/tardis/branch/<branch name>/index.html``.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
@DhruvSondhi had problems deploying his fork's documentation and realized this instruction was missing

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

See https://epassaro.github.io/tardis/branch/doc-preview-doc/development/documentation_preview.html

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
