### PR TITLE
Fixing inconsistencies for `rst` formatting in Docs (Second Iteration)

### DIFF
--- a/docs/development/update_refdata.rst
+++ b/docs/development/update_refdata.rst
@@ -10,13 +10,13 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Activate your ``tardis`` conda environment.
 
-    .. code-block:: 
+    .. code-block:: none
     
         conda activate tardis
 
 #. Navigate to your ``tardis-refdata`` directory and type:
 
-    .. code-block:: 
+    .. code-block:: none
     
         git lfs install
         git lfs fetch upstream
@@ -24,13 +24,13 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Go to your ``tardis`` directory. Make sure you are working on the correct branch and generate new reference data using:
 
-    .. code-block:: 
+    .. code-block:: none
 
         python setup.py test --args="--tardis-refdata=<path to refdata repo on the right branch> --generate-reference"
 
 #. Re-run the tests to make sure it does not fail using:
 
-    .. code-block::
+    .. code-block:: none
 
         python setup.py test --args="--tardis-refdata=<path to refdata repo on the right branch>"
 
@@ -38,7 +38,7 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Open the ``ref_data_compare.ipynb`` file notebook and look for the cell with the following code:
 
-    .. code-block::
+    .. code-block:: none
 
         comparer = ReferenceComparer(ref2_hash='upstream/pr/24')
         
@@ -50,7 +50,7 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Switch back to the ``tardis`` directory. Open the ``.travis.yml`` file and change the following lines:
 
-    .. code-block::
+    .. code-block:: none
 
         - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/<your tardis-refdata PR number; not the TARDIS PR number>/head:<some descriptive name>; fi
         - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout <some descriptive name>; fi
@@ -63,7 +63,7 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Then change the ``.travis.yml`` in ``tardis`` directory to:
 
-    .. code-block::
+    .. code-block:: none
 
         - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
         - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi

--- a/docs/development/update_refdata.rst
+++ b/docs/development/update_refdata.rst
@@ -10,13 +10,13 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Activate your ``tardis`` conda environment.
 
-    .. code-block:: None
+    .. code-block:: 
     
         conda activate tardis
 
 #. Navigate to your ``tardis-refdata`` directory and type:
 
-    .. code-block:: None
+    .. code-block:: 
     
         git lfs install
         git lfs fetch upstream
@@ -24,13 +24,13 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Go to your ``tardis`` directory. Make sure you are working on the correct branch and generate new reference data using:
 
-    .. code-block:: None
+    .. code-block:: 
 
         python setup.py test --args="--tardis-refdata=<path to refdata repo on the right branch> --generate-reference"
 
 #. Re-run the tests to make sure it does not fail using:
 
-    .. code-block:: None
+    .. code-block::
 
         python setup.py test --args="--tardis-refdata=<path to refdata repo on the right branch>"
 
@@ -38,11 +38,11 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Open the ``ref_data_compare.ipynb`` file notebook and look for the cell with the following code:
 
-    .. code-block:: None
+    .. code-block::
 
         comparer = ReferenceComparer(ref2_hash='upstream/pr/24')
         
-   Replace '24' for the number of the last merged pull request showed `here <https://github.com/tardis-sn/tardis-refdata/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed>`_.
+    Replace '24' for the number of the last merged pull request showed `here <https://github.com/tardis-sn/tardis-refdata/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed>`_.
 
 #. Run all cells and check if there are any unexpected changes in the updated reference data respect the previous one.
 
@@ -50,10 +50,10 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Switch back to the ``tardis`` directory. Open the ``.travis.yml`` file and change the following lines:
 
-    .. code-block:: None
+    .. code-block::
 
         - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin pull/<your tardis-refdata PR number; not the TARDIS PR number>/head:<some descriptive name>; fi
-        - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout <some descriptive name>; fi```
+        - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout <some descriptive name>; fi
 
 #. Commit the ``.travis.yml`` to your pull request.
 
@@ -63,10 +63,10 @@ We assume that you have added the necessary changes to TARDIS and have an open p
 
 #. Then change the ``.travis.yml`` in ``tardis`` directory to:
 
-    .. code-block:: None
+    .. code-block::
 
         - if [[ $TEST_MODE == 'spectrum' ]]; then git fetch origin; fi
-        - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi```
+        - if [[ $TEST_MODE == 'spectrum' ]]; then git checkout origin/master; fi
 
 #. Ensure TARDIS pull request passes Travis-CI again and ping someone to merge your PR to the TARDIS master branch.
 

--- a/docs/using/components/configuration/config_validator.rst
+++ b/docs/using/components/configuration/config_validator.rst
@@ -8,6 +8,7 @@ The default config validator takes a user configuration and a default configurat
 	- Second_level:
 		- Third_level:
 			…
+
 or a declaration of a configuration item like:
 
 - item:
@@ -19,14 +20,16 @@ or a declaration of a configuration item like:
 This contains always  the keywords ``help``, ``default``, ``mandatory``, and ``property_type``. The keyword help is  a doc-string which describes the corresponding item. "Default" specifies the default value which is used in case that no value for this item is specified in the corresponding user configuration item. If the keyword mandatory is ``True``, the item has to be specified in the user configuration. The keyword ``property_type`` is used to specify the type of the item. At the moment, the config parser knows the following types:
 
 .. ::
+
 - **Int:** The property type int is for integer like config items.
 - **Float:** The property type float is for float like config items.
 - **String:** The property type string is for string like config items.
 - **Quantity:** The property type quantity is for physical quantities with units given as string. The string contains value and unit separated by a whitespace E.g. 2 cm.
 - **Range:** The property type range specifies a range via start and end.
-.. note:: ``abs(start - end ) > 0``.
-- **Quantity_range:** Like property type range but with quantities as start and stop. The consistency of the units is checked.
 
+.. note:: ``abs(start - end ) > 0``.
+
+- **Quantity_range:** Like property type range but with quantities as start and stop. The consistency of the units is checked.
 
 Additionally to the four standard keywords the types integer, float, and quantity can have the keywords ``allowed_value`` and ``allowed_type``. ``allowed_value`` specifies the allowed values in a list, whereas ``allowed_type`` specifies a range of allowed values, such as “x>10”.
 
@@ -75,6 +78,7 @@ How to use
 ^^^^^^^^^^
                 
 To use the default parser create a new config object form the class ConfigurationValidator either from a dictionaries or from YAML files:
+
 ::
 
 - My_config = ConfigurationValidator(default configuration dictionary, user configuration dictionary)

--- a/docs/using/parallelisation/index.rst
+++ b/docs/using/parallelisation/index.rst
@@ -28,7 +28,7 @@ To compile TARDIS for parallel execution::
 
 
 Numba Usage Guide
-===========
+=================
 
 The ``montecarlo`` section of the Configuration file accepts the parameter ``nthreads`` which sets the number of
 threads to be used for parallelisation. Setting the value of the parameter between 1 and the environment variable

--- a/docs/zreferences.rst
+++ b/docs/zreferences.rst
@@ -12,7 +12,7 @@ TARDIS Code papers
 * :cite:`Kerzendorf2014`
 
 Studies using TARDIS
-==================
+====================
 
 * :cite:`Smartt2017`
 * :cite:`Barna2017`

--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -38,7 +38,7 @@ class AtomData(object):
         A DataFrame containing the *ionization data* with:
             index : atomic_number, ion_number;
             columns : ionization_energy[eV].
-       It is important to note here is that `ion_number` describes the *final ion state*
+        It is important to note here is that `ion_number` describes the *final ion state*
             e.g. H I - H II is described with ion=1
     levels : pandas.DataFrame
         A DataFrame containing the *levels data* with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR aims to fix some of the inconsistencies are present in the current documentation.
Fixing this also removes some of the warnings that are present when building the documentation 😄 

**Description**
<!--- Describe your changes in detail -->
Some of the changes include small whitespace, tabs & newline additions
Others includes removing the `None` keyword from `.. code-block::` directives in `update_refdata.rst`, updating the underlines for some of the headings.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
This will fix some of the warnings that are present when building the documentation locally 😄 

**Documentation Preview** : https://dhruvsondhi.github.io/tardis/branch/docs_formatting_v2/

**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
