### PR TITLE
Flexible packet initial radius

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -29,6 +29,7 @@ from tardis.montecarlo.montecarlo_numba import njit_dict
 
 def montecarlo_radial1d(model, plasma, runner):
     packet_collection = PacketCollection(
+        runner.input_r,
         runner.input_nu,
         runner.input_mu,
         runner.input_energy,

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -67,7 +67,7 @@ class NumbaPlasma(object):
     ):
         """
         Plasma for the Numba code
-        
+
         Parameters
         ----------
         electron_density : numpy.ndarray
@@ -161,6 +161,7 @@ def numba_plasma_initialize(plasma, line_interaction_type):
 
 
 packet_collection_spec = [
+    ("packets_input_radius", float64[:]),
     ("packets_input_nu", float64[:]),
     ("packets_input_mu", float64[:]),
     ("packets_input_energy", float64[:]),
@@ -173,12 +174,14 @@ packet_collection_spec = [
 class PacketCollection(object):
     def __init__(
         self,
+        packets_input_radius,
         packets_input_nu,
         packets_input_mu,
         packets_input_energy,
         packets_output_nu,
         packets_output_energy,
     ):
+        self.packets_input_radius = packets_input_radius
         self.packets_input_nu = packets_input_nu
         self.packets_input_mu = packets_input_mu
         self.packets_input_energy = packets_input_energy
@@ -220,10 +223,18 @@ class VPacketCollection(object):
         self.nus = np.empty(temporary_v_packet_bins, dtype=np.float64)
         self.energies = np.empty(temporary_v_packet_bins, dtype=np.float64)
         self.number_of_vpackets = number_of_vpackets
-        self.last_interaction_in_nu = np.zeros(temporary_v_packet_bins, dtype=np.float64)
-        self.last_interaction_type = -1 * np.ones(temporary_v_packet_bins, dtype=np.int64)
-        self.last_interaction_in_id = -1 * np.ones(temporary_v_packet_bins, dtype=np.int64)
-        self.last_interaction_out_id = -1 * np.ones(temporary_v_packet_bins, dtype=np.int64)
+        self.last_interaction_in_nu = np.zeros(
+            temporary_v_packet_bins, dtype=np.float64
+        )
+        self.last_interaction_type = -1 * np.ones(
+            temporary_v_packet_bins, dtype=np.int64
+        )
+        self.last_interaction_in_id = -1 * np.ones(
+            temporary_v_packet_bins, dtype=np.int64
+        )
+        self.last_interaction_out_id = -1 * np.ones(
+            temporary_v_packet_bins, dtype=np.int64
+        )
         self.idx = 0
         self.rpacket_index = rpacket_index
         self.length = temporary_v_packet_bins
@@ -241,21 +252,31 @@ class VPacketCollection(object):
             temp_length = self.length * 2 + self.number_of_vpackets
             temp_nus = np.empty(temp_length, dtype=np.float64)
             temp_energies = np.empty(temp_length, dtype=np.float64)
-            temp_last_interaction_in_nu = np.empty(temp_length, dtype=np.float64)
+            temp_last_interaction_in_nu = np.empty(
+                temp_length, dtype=np.float64
+            )
             temp_last_interaction_type = np.empty(temp_length, dtype=np.int64)
             temp_last_interaction_in_id = np.empty(temp_length, dtype=np.int64)
             temp_last_interaction_out_id = np.empty(temp_length, dtype=np.int64)
             temp_nus[: self.length] = self.nus
             temp_energies[: self.length] = self.energies
-            temp_last_interaction_in_nu[: self.length] = self.last_interaction_in_nu
-            temp_last_interaction_type[: self.length] = self.last_interaction_type
-            temp_last_interaction_in_id[: self.length] = self.last_interaction_in_id
-            temp_last_interaction_out_id[: self.length] = self.last_interaction_out_id
+            temp_last_interaction_in_nu[
+                : self.length
+            ] = self.last_interaction_in_nu
+            temp_last_interaction_type[
+                : self.length
+            ] = self.last_interaction_type
+            temp_last_interaction_in_id[
+                : self.length
+            ] = self.last_interaction_in_id
+            temp_last_interaction_out_id[
+                : self.length
+            ] = self.last_interaction_out_id
 
             self.nus = temp_nus
             self.energies = temp_energies
             self.last_interaction_in_nu = temp_last_interaction_in_nu
-            self.last_interaction_type = temp_last_interaction_type 
+            self.last_interaction_type = temp_last_interaction_type
             self.last_interaction_in_id = temp_last_interaction_in_id
             self.last_interaction_out_id = temp_last_interaction_out_id
             self.length = temp_length

--- a/tardis/montecarlo/montecarlo_numba/tests/conftest.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/conftest.py
@@ -28,6 +28,7 @@ def nb_simulation_verysimple(config_verysimple, atomic_dataset):
 def verysimple_collection(nb_simulation_verysimple):
     runner = nb_simulation_verysimple.runner
     return PacketCollection(
+        runner.input_r,
         runner.input_nu,
         runner.input_mu,
         runner.input_energy,
@@ -99,6 +100,7 @@ def verysimple_3vpacket_collection(nb_simulation_verysimple):
 def verysimple_packet_collection(nb_simulation_verysimple):
     runner = nb_simulation_verysimple.runner
     return PacketCollection(
+        runner.input_r,
         runner.input_nu,
         runner.input_mu,
         runner.input_energy,

--- a/tardis/montecarlo/montecarlo_numba/tests/test_base.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_base.py
@@ -74,7 +74,9 @@ def test_montecarlo_main_loop(
 
     runner._initialize_geometry_arrays(model)
     runner._initialize_estimator_arrays(numba_plasma.tau_sobolev.shape)
-    runner._initialize_packets(model.t_inner.value, 100000, 0)
+    runner._initialize_packets(
+        model.t_inner.value, 100000, 0, model.r_inner[0].value
+    )
 
     # Init parameters
     montecarlo_configuration.v_packet_spawn_start_frequency = (
@@ -93,6 +95,7 @@ def test_montecarlo_main_loop(
 
     # Init packet collection from runner
     packet_collection = PacketCollection(
+        runner.input_r,
         runner.input_nu,
         runner.input_mu,
         runner.input_energy,
@@ -130,7 +133,7 @@ def test_montecarlo_main_loop(
     for i in range(len(packet_collection.packets_input_nu)):
         # Generate packet
         packet = r_packet.RPacket(
-            numba_model.r_inner[0],
+            packet_collection.packets_input_radius[i],
             packet_collection.packets_input_mu[i],
             packet_collection.packets_input_nu[i],
             packet_collection.packets_input_energy[i],

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -111,6 +111,29 @@ class BlackBodySimpleSource(BasePacketSource):
     """
 
     def create_packets(self, T, no_of_packets, rng, radius):
+        """Generate black-body packet properties as arrays
+
+        Parameters
+        ----------
+        T : float64
+            Temperature
+        no_of_packets : int
+            Number of packets
+        rng : numpy random number generator
+        radius : float64
+            Initial packet radius
+
+        Returns
+        -------
+        array
+            Packet radii
+        array
+            Packet frequencies
+        array
+            Packet directions
+        array
+            Packet energies
+        """
         radii = np.ones(no_of_packets) * radius
         nus = self.create_blackbody_packet_nus(T, no_of_packets, rng)
         mus = self.create_zero_limb_darkening_packet_mus(no_of_packets, rng)

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -38,9 +38,9 @@ class BasePacketSource(abc.ABC):
     @staticmethod
     def create_uniform_packet_energies(no_of_packets, rng):
         """
-        Uniformly distribute energy in arbitrary units where the ensemble of 
-        packets has energy of 1. 
-        
+        Uniformly distribute energy in arbitrary units where the ensemble of
+        packets has energy of 1.
+
         Parameters
         ----------
         no_of_packets : int
@@ -73,7 +73,7 @@ class BasePacketSource(abc.ABC):
         .. math::
             x = -\\ln{(\\xi_1\\xi_2\\xi_3\\xi_4)}/l_{\\rm min}\\; .
         where :math:`x=h\\nu/kT`
-        
+
         Parameters
         ----------
         T : float
@@ -81,7 +81,7 @@ class BasePacketSource(abc.ABC):
         no_of_packets : int
         l_samples : int
             number of l_samples needed in the algorithm
-            
+
         Returns
         -------
             : numpy.ndarray
@@ -110,9 +110,10 @@ class BlackBodySimpleSource(BasePacketSource):
     part.
     """
 
-    def create_packets(self, T, no_of_packets, rng):
+    def create_packets(self, T, no_of_packets, rng, radius):
+        radii = np.ones(no_of_packets) * radius
         nus = self.create_blackbody_packet_nus(T, no_of_packets, rng)
         mus = self.create_zero_limb_darkening_packet_mus(no_of_packets, rng)
         energies = self.create_uniform_packet_energies(no_of_packets, rng)
 
-        return nus, mus, energies
+        return radii, nus, mus, energies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
The PacketCollection now includes the initial radius of packets. For the BlackBodySource this is just the inner radius of the ejecta.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Preparation for creating packets without the inner radius set explicitly to the model inner radius e.g. for nebular phase

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
