### PR TITLE
Fixing bibliography in documentation build

### DIFF
--- a/docs/zreferences.rst
+++ b/docs/zreferences.rst
@@ -35,4 +35,3 @@ References
 ==========
 
 .. bibliography:: tardis.bib
-    :encoding: utf8

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -42,7 +42,7 @@ dependencies:
   - sphinx_bootstrap_theme
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc
-  - sphinxcontrib-bibtex
+  - sphinxcontrib-bibtex=1.0
   - sphinx-jsonschema
   - recommonmark
   - numpydoc

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -42,7 +42,7 @@ dependencies:
   - sphinx_bootstrap_theme
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc
-  - sphinxcontrib-bibtex=1.0
+  - sphinxcontrib-bibtex
   - sphinx-jsonschema
   - recommonmark
   - numpydoc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR makes the bibliography appear in the documentation again.

**Description**
<!--- Describe your changes in detail -->
In the environment file, sets `sphinxcontrib-bibtex` to version 1.0

EDIT: Instead of changing the environment file, this PR removes the utf8 encoding from `docs/zreferences.rst`.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
After the merge of #1567, the bibliography on the documentation went away (see https://tardis-sn.github.io/tardis/zreferences.html). 

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Documentation built locally and on github.

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->
The issue is fixed when I built the documentation on my fork with my changes: https://smithis7.github.io/tardis/branch/bibliography_issue/zreferences.html.

To make sure the issue appeared on my fork without the changes, I also built the documentation on my fork without my changes: https://smithis7.github.io/tardis/branch/control_doc/zreferences.html.

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
