### PR TITLE
add value error to ensure active virtual packet logging in SDECPlotter

### DIFF
--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -423,9 +423,11 @@ class SDECPlotter:
                 )
             )
         else:
-            raise ValueError(
-                "Virtual packet logging is inactive. "
-                "Please set config option virtual_packet_logging: True."
+            return cls(
+                dict(
+                    virtual=None,
+                    real=SDECData.from_simulation(sim, "real"),
+                )
             )
 
     @classmethod
@@ -572,6 +574,11 @@ class SDECPlotter:
             raise ValueError(
                 "Invalid value passed to packets_mode. Only "
                 "allowed values are 'virtual' or 'real'"
+            )
+
+        if packets_mode == "virtual" and self.data[packets_mode] is None:
+            raise ValueError(
+                "SDECPlotter doesn't have any data for virtual packets population and SDEC plot for the same was requested.\nEither set virtual_packet_logging: True in your configuration file to generate SDEC plot with virtual packets, or pass packets_mode=\"real\" in your function call to generate SDEC plot with real packets."
             )
 
         # Store the plottable range of each spectrum property which is

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -415,12 +415,18 @@ class SDECPlotter:
         -------
         SDECPlotter
         """
-        return cls(
-            dict(
-                virtual=SDECData.from_simulation(sim, "virtual"),
-                real=SDECData.from_simulation(sim, "real"),
+        if sim.runner.virt_logging:
+            return cls(
+                dict(
+                    virtual=SDECData.from_simulation(sim, "virtual"),
+                    real=SDECData.from_simulation(sim, "real"),
+                )
             )
-        )
+        else:
+            raise ValueError(
+                "Virtual packet logging is inactive. "
+                "Please set config option virtual_packet_logging: True."
+            )
 
     @classmethod
     def from_hdf(cls, hdf_fpath):

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -578,7 +578,7 @@ class SDECPlotter:
 
         if packets_mode == "virtual" and self.data[packets_mode] is None:
             raise ValueError(
-                "SDECPlotter doesn't have any data for virtual packets population and SDEC plot for the same was requested.\nEither set virtual_packet_logging: True in your configuration file to generate SDEC plot with virtual packets, or pass packets_mode=\"real\" in your function call to generate SDEC plot with real packets."
+                'SDECPlotter doesn\'t have any data for virtual packets population and SDEC plot for the same was requested.\nEither set virtual_packet_logging: True in your configuration file to generate SDEC plot with virtual packets, or pass packets_mode="real" in your function call to generate SDEC plot with real packets.'
             )
 
         # Store the plottable range of each spectrum property which is

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -578,7 +578,11 @@ class SDECPlotter:
 
         if packets_mode == "virtual" and self.data[packets_mode] is None:
             raise ValueError(
-                'SDECPlotter doesn\'t have any data for virtual packets population and SDEC plot for the same was requested.\nEither set virtual_packet_logging: True in your configuration file to generate SDEC plot with virtual packets, or pass packets_mode="real" in your function call to generate SDEC plot with real packets.'
+                "SDECPlotter doesn't have any data for virtual packets population and SDEC "
+                "plot for the same was requested. Either set virtual_packet_logging: True "
+                "in your configuration file to generate SDEC plot with virtual packets, or "
+                "pass packets_mode='real' in your function call to generate SDEC plot with "
+                "real packets."
             )
 
         # Store the plottable range of each spectrum property which is


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR allows SDECPlotter to raise error if `virtual_packet_logging` is not set to `True`.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Before this change, SDECPlotter can work even when `virtual_packet_logging` is not active. In this case, an index error is raised by function in `matplotlib` while calling the function `plotter.generate_plot_mlp()`, and the output is confusing. 
Since SDECPlotter requires `virtual_packet_logging`, it should ensure the option is set to true.
**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->
Before change:
![image](https://user-images.githubusercontent.com/80535029/120209311-1a12fb80-c261-11eb-983c-8341e1c9e1d1.png)

After change:
<img width="1070" alt="截屏2021-06-21 下午4 25 57" src="https://user-images.githubusercontent.com/80535029/122731035-78099080-d2ad-11eb-999b-389376d5fb14.png">

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
