### PR TITLE
SDEC Visibility Fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,17 @@ exclude_patterns = ["_build", "_templates", "**.ipynb_checkpoints"]
 rst_epilog = """
 """
 
+# this forces the documentation to load MathJax v2, see here: https://github.com/spatialaudio/nbsphinx/issues/572#issuecomment-853389268
+mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+mathjax2_config = {
+    'tex2jax': {
+        'inlineMath': [['$', '$'], ['\\(', '\\)']],
+        'processEscapes': True,
+        'ignoreClass': 'document',
+        'processClass': 'math|output_area',
+    }
+}
+
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR causes SDEC plots to show up again. 

**Description**
<!--- Describe your changes in detail -->
`MathJax.Hub` doesn't exist anymore in MathJax v3, which is used in the documentation and causes plotly plots to not show up.
This PR removes the extra cell I added to load MathJax and changes `conf.py` to load MathJax v2 in the documentation. 
MathJax v2 doesn't give any errors when running `MathJax.Hub` and the plots show up. 
This is a temporary fix until a permanent solution is found. 
For reference, please see 
https://github.com/spatialaudio/nbsphinx/issues/572 
https://github.com/tardis-sn/tardis/pull/1531

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
resolves https://github.com/tardis-sn/tardis/issues/1585 

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->


**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Please see the preview [here](https://atharva-2001.github.io/tardis/branch/sdec_visibility_fix/using/visualization/sdec_plot.html)
| Before                                                                                                          | After                                                                                                           |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/55894364/120626603-71db7d80-c480-11eb-8be9-56520c851bca.png) | ![image](https://user-images.githubusercontent.com/55894364/120626714-90417900-c480-11eb-99bd-d26480d82dcc.png) |



**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [X] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [X] I have assigned and requested two reviewers for this pull request.
