### PR TITLE
add flag to disable nbsphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,9 +58,6 @@ extensions = [
     "sphinxcontrib.apidoc",
 ]
 
-if os.getenv('DISABLE_NBSPHINX') == "1":
-    extensions.remove("nbsphinx")
-
 bibtex_bibfiles = ['tardis.bib']
 
 source_suffix = {
@@ -72,7 +69,10 @@ source_suffix = {
 numpydoc_show_class_members = False
 extensions += ["matplotlib.sphinxext.plot_directive", "sphinxcontrib.bibtex"]
 
-nbsphinx_execute = "auto"
+if os.getenv('DISABLE_NBSPHINX') == "1":
+    nbsphinx_execute = "never"
+else:
+    nbsphinx_execute = "auto"
 
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
@@ -82,6 +82,7 @@ nbsphinx_execute_arguments = [
 nbsphinx_prolog = """
 This notebook is available at 
 https://github.com/tardis-sn/tardis/tree/master/docs/{{ env.doc2path(env.docname, base=None) }}
+
 ----
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,9 @@ extensions = [
     "sphinxcontrib.apidoc",
 ]
 
+if os.getenv('DISABLE_NBSPHINX') == "1":
+    extensions.remove("nbsphinx")
+
 bibtex_bibfiles = ['tardis.bib']
 
 source_suffix = {

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -20,11 +20,9 @@ Besides this, the functions and classes in your code must always contain **docst
 Building documentation locally
 ==============================
 
-To build TARDIS documentation locally, you can use either of the following commands: ::
+To build TARDIS documentation locally, use the following commands:
 
-    python setup.py build_docs
-    
-or ::
+.. code ::
 
     cd docs
     make html
@@ -32,7 +30,7 @@ or ::
 .. note :: 
 
     - If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
-    - Prepend ``DISABLE_NBSPHINX=1`` to the build command to disable notebook rendering (fast mode).
+    - Use ``DISABLE_NBSPHINX=1 make html`` to disable notebook rendering (fast mode).
 
 After running this command, you can find the built docs (i.e. HTML webpages) in ``docs/_build``. Open the ``index.html`` in your browser to see how the documentation looks like with your edits. Navigate to page where you made changes or file that you added to check whether it looks as intended or not.
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -29,7 +29,10 @@ or ::
     cd docs
     make html
 
-.. note :: If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
+.. note :: 
+
+    - If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
+    - Prepend ``DISABLE_NBSPHINX=1`` to the build command to disable notebook rendering (fast mode).
 
 After running this command, you can find the built docs (i.e. HTML webpages) in ``docs/_build``. Open the ``index.html`` in your browser to see how the documentation looks like with your edits. Navigate to page where you made changes or file that you added to check whether it looks as intended or not.
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -14,9 +14,9 @@ to the Astropy team for designing it.
     issues
     git_workflow
     documentation_guidelines
+    documentation_preview
     running_tests
     code_quality
-    documentation_preview
     developer_faq
 
 TARDIS core team Instructions

--- a/docs/io/optional/custom_source.ipynb
+++ b/docs/io/optional/custom_source.ipynb
@@ -165,10 +165,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  },
-  "nbsphinx": {
-   "execute": "always",
-   "timeout": 600
   }
  },
  "nbformat": 4,

--- a/docs/io/output/physical_quantities.ipynb
+++ b/docs/io/output/physical_quantities.ipynb
@@ -273,11 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
-  },
-  "nbsphinx": {
-   "execute": "always",
-   "timeout": -1
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/docs/quickstart/quickstart.ipynb
+++ b/docs/quickstart/quickstart.ipynb
@@ -118,6 +118,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -133,11 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
-  },
-  "nbsphinx": {
-   "execute": "always",
-   "timeout": -1
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/docs/quickstart/quickstart.ipynb
+++ b/docs/quickstart/quickstart.ipynb
@@ -118,7 +118,6 @@
   }
  ],
  "metadata": {
-  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
I thought about a way to fast render the documentation. Made a small patch to `conf.py` and now prepending the variable `DISABLE_NBSPHINX=1` to the build command skips the notebook rendering.

Example:

```
cd docs/
DISABLE_NBSPHINX=1 make html
```

Then `sphinx` just render the `.rst` files.

Also I removed hardcoded metadata in notebooks. If we want to change this values we should do it through `conf.py` not harcoding them (by the way, the hardcoded values were the default ones). Using harcoded metadata leads to hard to debug problems.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
@jaladh-singhal's issue no. #1282

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

Locally. Please checkout to this PR and try it too.


**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
