### PR TITLE
force pyne nomoab_openmc version

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -12,7 +12,7 @@ dependencies:
   - astropy=3
   - numba=0.53.1
   - numexpr
-  - pyne=0.7  # Issue #1537
+  - pyne=0.7=nomoab_openmc*  # Issue #1537
 
   # Plasma
   - networkx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
macOS pipelines are failing despite `pyne` has not been updated in more than a year. For some reason, the environment is solved with a different `pyne` compilation than the one used until the last week.

This is related to [TEP013](https://github.com/tardis-sn/tep/pull/29).

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
