### PR TITLE
Formatting Logging Output for Simulation

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -186,11 +186,11 @@ class AtomData(object):
             # ToDo: strore data sources as attributes in carsus
 
             logger.info(
-                f"Read Atom Data with UUID={atom_data.uuid1} and MD5={atom_data.md5}."
+                f"\n\tReading Atom Data with:\n\tUUID = {atom_data.uuid1}\n\tMD5  = {atom_data.md5} "
             )
             if nonavailable:
                 logger.info(
-                    f'Non provided atomic data: {", ".join(nonavailable)}'
+                    f'\n\tNon provided atomic data:\n\t{", ".join(nonavailable)}'
                 )
 
         return atom_data

--- a/tardis/io/atom_data/util.py
+++ b/tardis/io/atom_data/util.py
@@ -31,7 +31,7 @@ def resolve_atom_data_fname(fname):
     fpath = os.path.join(os.path.join(get_data_dir(), fname))
     if os.path.exists(fpath):
         logger.info(
-            f"Atom Data {fname} not found in local path. Exists in TARDIS Data repo {fpath}"
+            f"\n\tAtom Data {fname} not found in local path.\n\tExists in TARDIS Data repo {fpath}"
         )
         return fpath
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -1,4 +1,4 @@
-from numba import prange, njit, jit
+from numba import prange, njit
 import logging
 import numpy as np
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -1,4 +1,4 @@
-from numba import prange, njit
+from numba import prange, njit, jit
 import logging
 import numpy as np
 

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -88,7 +88,7 @@ def assemble_plasma(config, model, atom_data=None):
         else:
             raise ValueError("No atom_data option found in the configuration.")
 
-        logger.info("Reading Atomic Data from %s", atom_data_fname)
+        logger.info(f"\n\tReading Atomic Data from {atom_data_fname}")
 
         try:
             atom_data = AtomData.from_hdf(atom_data_fname)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -348,6 +348,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         """
         run the simulation
         """
+
         start_time = time.time()
         while self.iterations_executed < self.iterations - 1:
             self.store_plasma_state(
@@ -415,14 +416,16 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
         plasma_state_log = pd.DataFrame(
             index=np.arange(len(t_rad)),
-            columns=["t_rad", "next_t_rad", "w", "next_w"],
+            columns=["t_rad (K)", "next_t_rad (K)", "w", "next_w"],
         )
-        plasma_state_log["t_rad"] = t_rad
-        plasma_state_log["next_t_rad"] = next_t_rad
-        plasma_state_log["w"] = w
-        plasma_state_log["next_w"] = next_w
+        plasma_state_log["t_rad (K)"] = np.around(t_rad.value, decimals=3)
+        plasma_state_log["next_t_rad (K)"] = np.around(
+            next_t_rad.value, decimals=3
+        )
+        plasma_state_log["w"] = np.around(w, decimals=3)
+        plasma_state_log["next_w"] = np.around(next_w, decimals=3)
 
-        plasma_state_log.index.name = "Shell"
+        plasma_state_log.columns.name = "Shell"
 
         plasma_state_log = str(plasma_state_log[::log_sampling])
 
@@ -431,13 +434,15 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         )
 
         logger.info("Plasma stratification:\n%s\n", plasma_state_log)
-        logger.info(f"t_inner {t_inner:.3f} -- next t_inner {next_t_inner:.3f}")
+        logger.info(
+            f"\n\tCurrent t_inner = {t_inner:.3f}\n\tExpected t_inner for next iteration = {next_t_inner:.3f}\n"
+        )
 
     def log_run_results(self, emitted_luminosity, absorbed_luminosity):
         logger.info(
-            f"Luminosity emitted = {emitted_luminosity:.5e} "
-            f"Luminosity absorbed = {absorbed_luminosity:.5e} "
-            f"Luminosity requested = {self.luminosity_requested:.5e}"
+            f"\n\tLuminosity emitted   = {emitted_luminosity:.5e}\n"
+            f"\tLuminosity absorbed  = {absorbed_luminosity:.5e}\n"
+            f"\tLuminosity requested = {self.luminosity_requested:.5e}\n"
         )
 
     def _call_back(self):

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -10,7 +10,7 @@ from tardis.model import Radial1DModel
 from tardis.plasma.standard_plasmas import assemble_plasma
 from tardis.io.util import HDFWriterMixin
 from tardis.io.config_reader import ConfigurationError
-from tardis.util.base import check_simulation_env
+from tardis.util.base import is_notebook
 from tardis.montecarlo import montecarlo_configuration as mc_config_module
 from IPython.display import display
 
@@ -426,7 +426,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         plasma_state_log["next_w"] = next_w
         plasma_state_log.columns.name = "Shell No."
 
-        if check_simulation_env():
+        if is_notebook():
             logger.info("\n\tPlasma stratification:")
             logger.info(
                 display(

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -322,7 +322,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
     def iterate(self, no_of_packets, no_of_virtual_packets=0, last_run=False):
         logger.info(
-            f"\n\tStarting iteration {(self.iterations_executed + 1):d}/{self.iterations:d}"
+            f"\n\tStarting iteration {(self.iterations_executed + 1):d} of {self.iterations:d}"
         )
         self.runner.run(
             self.model,
@@ -382,7 +382,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
         logger.info(
             f"\n\tSimulation finished in {self.iterations_executed:d} iterations "
-            f"and took {(time.time() - start_time):.2f} s"
+            f"\n\tSimulation took {(time.time() - start_time):.2f} s\n"
         )
         self._call_back()
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -12,6 +12,7 @@ from tardis.io.util import HDFWriterMixin
 from tardis.io.config_reader import ConfigurationError
 from tardis.montecarlo import montecarlo_configuration as mc_config_module
 from IPython.display import display
+from IPython import get_ipython
 
 # Adding logging support
 logger = logging.getLogger(__name__)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -427,7 +427,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         plasma_state_log.columns.name = "Shell No."
 
         if check_simulation_env():
-            logger.info(f"\n\tPlasma stratification:")
+            logger.info("\n\tPlasma stratification:")
             logger.info(
                 display(
                     plasma_state_log.iloc[::log_sampling].style.format("{:.3g}")
@@ -436,11 +436,13 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         else:
             output_df = ""
             plasma_output = plasma_state_log.iloc[::log_sampling].to_string(
-                float_format=lambda x: "{:.3g}".format(x), justify="center",
+                float_format=lambda x: "{:.3g}".format(x),
+                justify="center",
             )
             for value in plasma_output.split("\n"):
                 output_df = output_df + "\t{}\n".format(value)
-            logger.info(f"\n\tPlasma stratification:\n\n{output_df}")
+            logger.info("\n\tPlasma stratification:")
+            logger.info(f"\n{output_df}")
 
         logger.info(
             f"\n\tCurrent t_inner = {t_inner:.3f}\n\tExpected t_inner for next iteration = {next_t_inner:.3f}\n"

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -440,9 +440,9 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
     def log_run_results(self, emitted_luminosity, absorbed_luminosity):
         logger.info(
-            f"\n\tLuminosity emitted   = {emitted_luminosity:.5e}\n"
-            f"\tLuminosity absorbed  = {absorbed_luminosity:.5e}\n"
-            f"\tLuminosity requested = {self.luminosity_requested:.5e}\n"
+            f"\n\tLuminosity emitted   = {emitted_luminosity:.3e}\n"
+            f"\tLuminosity absorbed  = {absorbed_luminosity:.3e}\n"
+            f"\tLuminosity requested = {self.luminosity_requested:.3e}\n"
         )
 
     def _call_back(self):

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -425,11 +425,6 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         plasma_state_log["next_w"] = next_w
         plasma_state_log.columns.name = "Shell No."
 
-        # pd.set_option("display.precision", 3)
-        pd.set_option("display.expand_frame_repr", True)
-        pd.set_option("display.max_rows", None)
-        pd.set_option("display.max_columns", None)
-
         if self.check_notebook():
             logger.info(f"\n\tPlasma stratification:")
             logger.info(

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -10,9 +10,9 @@ from tardis.model import Radial1DModel
 from tardis.plasma.standard_plasmas import assemble_plasma
 from tardis.io.util import HDFWriterMixin
 from tardis.io.config_reader import ConfigurationError
+from tardis.util.base import check_simulation_env
 from tardis.montecarlo import montecarlo_configuration as mc_config_module
 from IPython.display import display
-from IPython import get_ipython
 
 # Adding logging support
 logger = logging.getLogger(__name__)
@@ -426,7 +426,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         plasma_state_log["next_w"] = next_w
         plasma_state_log.columns.name = "Shell No."
 
-        if self.check_notebook():
+        if check_simulation_env():
             logger.info(f"\n\tPlasma stratification:")
             logger.info(
                 display(
@@ -452,18 +452,6 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             f"\tLuminosity absorbed  = {absorbed_luminosity:.3e}\n"
             f"\tLuminosity requested = {self.luminosity_requested:.3e}\n"
         )
-
-    def check_notebook(self):
-        try:
-            shell = get_ipython().__class__.__name__
-            if shell == "ZMQInteractiveShell":
-                return True
-            elif shell == "TerminalInteractiveShell":
-                return False
-            else:
-                return False
-        except NameError:
-            return False
 
     def _call_back(self):
         for cb, args in self._callbacks.values():

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -1,6 +1,8 @@
 import os
 
 import pytest
+import logging
+
 from tardis.io.config_reader import Configuration
 from tardis.simulation import Simulation
 
@@ -153,3 +155,20 @@ def test_plasma_state_storer_reshape(
 
 #     assert_quantity_allclose(
 #             t_rad, simulation_compare_data['test1/t_rad'] * u.Unit('K'), atol=0.0 * u.Unit('K'))
+
+
+def test_logging_simulation(atomic_data_fname, caplog):
+    """
+    Testing the logs for simulations runs
+    """
+    config = Configuration.from_yaml(
+        "tardis/io/tests/data/tardis_configv1_verysimple.yml"
+    )
+    config["atom_data"] = atomic_data_fname
+
+    simulation = Simulation.from_config(config)
+
+    simulation.run()
+
+    for record in caplog.records:
+        assert record.levelno >= logging.INFO

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -542,23 +542,44 @@ def convert_abundances_format(fname, delimiter=r"\s+"):
     return df
 
 
-def check_simulation_env():
+def is_notebook():
     """
-    Checking the environment where the simulation is run
+    Checking the shell environment where the simulation is run is Jupyter based
 
     Returns
     -------
-    True : if the environment is IPython Based
-    False : if the environment is Terminal or anything else
+    True : if the shell environment is IPython Based
+    False : if the shell environment is Terminal or anything else
     """
     try:
-        shell = get_ipython().__class__.__name__
+        # Trying to import the ZMQInteractiveShell for Jupyter based environments
+        from ipykernel.zmqshell import ZMQInteractiveShell
     except NameError:
+        # If the class cannot be imported then we are automatically return False Value
+        # Raised due to Name Error with the imported Class
         return False
 
-    if shell == "ZMQInteractiveShell":
-        return True
-    elif shell == "TerminalInteractiveShell":
+    try:
+        # Trying to import Interactive Terminal based IPython shell
+        from IPython.core.interactiveshell import InteractiveShell
+    except NameError:
+        # If the class cannot be imported then we are automatically return False Value
+        # Raised due to Name Error with the imported Class
         return False
+
+    try:
+        # Trying to get the value of the shell via the get_ipython() method
+        shell = get_ipython()
+    except NameError:
+        # Returns False if the shell name cannot be inferred correctly
+        return False
+
+    # Checking if the shell instance is Jupyter based & if True, returning True
+    if isinstance(shell, ZMQInteractiveShell):
+        return True
+    # Checking if the shell instance is Terminal IPython based & if True, returning False
+    elif isinstance(shell, InteractiveShell):
+        return False
+    # All other shell instances are returned False
     else:
         return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR aims to change the Formatting of the current Logging done in the Notebook.
Implements decimal up to 3 places in Plasma Stratification values
Better formatted output for `luminosities` values as well as `t_inner` values 

**Description**
<!--- Describe your changes in detail -->
Some formatting changes have been done to the logging output for the simulation. Screenshots below differentiate the output, before & after the changes. 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Allows for a better, more digestible formatting for the logging output. Data is more readable & accessible to the User.

**Screenshots**

*Original Logger Output:*
![image](https://user-images.githubusercontent.com/66117751/121481019-54ab2f80-c9e9-11eb-860b-c759ffae6cb5.png)

*New Formatted Logger Output:*
![image](https://user-images.githubusercontent.com/66117751/122161552-8d3a8580-ce8f-11eb-9da8-fa88993b2d01.png)
*Jupyter Notebook*

![image](https://user-images.githubusercontent.com/66117751/122161480-6bd99980-ce8f-11eb-88dc-223976f89cb7.png)
![image](https://user-images.githubusercontent.com/66117751/122161413-4cdb0780-ce8f-11eb-97d4-5f189c8fa4c1.png)
*Terminal*

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
