### PR TITLE
configure codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  range: 60..100
+  round: down
+  precision: 2
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,4 @@ coverage:
       default:
         target: auto
         threshold: 0.5%
+    #patch: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -19,6 +19,7 @@ exclude_lines =
 omit =
     *__init__*
     *_astropy_init*
+    *version*
     *tests*
     *conftest*
     *setup_package*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
+# .coveragerc to control coverage.py
+
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -22,10 +22,11 @@ omit =
     *tests*
     *conftest*
     *setup_package*
-   
-    tardis/gui/*
-    tardis/stats/*
+
     tardis/analysis.py
+    tardis/gui/*
+    tardis/scripts/*
+    tardis/stats/*
    
 ignore_errors = True
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,48 +2,36 @@
 source = tardis
 
 [report]
+# Regexes for lines to exclude from consideration
 exclude_lines =
-   # Have to re-enable the standard pragma
-   pragma: no cover
+    # Have to re-enable the standard pragma
+    pragma: no cover
 
-   # Don't complain about packages we have installed
-   except ImportError
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
 
-   # Don't complain if tests don't hit assertions
-   raise AssertionError
-   raise NotImplementedError
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
 
-   # Don't complain about script hooks
-   def main\(.*\):
-
-   # Ignore branches that don't pertain to this version of Python
-   pragma: py{ignore_python_version}
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
 
 omit =
+    *__init__*
+    *_astropy_init*
+    *version*
+    *tests*
+    *conftest*
+    *setup_package*
    
-   # Tests should not appear in coveralls 
-   tardis/tests/*
-   tardis/plasma/tests/*
-   tardis/model/tests/*
-   tardis/montecarlo/tests/*
-   tardis/simulation/tests/*
-   tardis/io/tests/*
+    tardis/gui/*
+    tardis/stats/*
+    tardis/analysis.py
    
-   # Omit all setup_package.py files 
-   tardis/tests/setup_package.py
-   tardis/plasma/setup_package.py
-   tardis/montecarlo/setup_package.py
-   tardis/model/setup_package.py
-   tardis/simulation/setup_package.py
-   tardis/io/setup_package.py
+ignore_errors = True
 
-   tardis/gui/*
-   tardis/stats/*
-   tardis/analysis.py
-
-   # Omit all version and __init__.py files 
-   *version*
-   *__init__*
-   *_astropy_init*
-   
-
+[html]
+directory = coverage_html_report

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,3 @@
-[run]
-source = tardis
-
 [report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
@@ -22,7 +19,6 @@ exclude_lines =
 omit =
     *__init__*
     *_astropy_init*
-    *version*
     *tests*
     *conftest*
     *setup_package*

--- a/.coveragerc
+++ b/.coveragerc
@@ -28,7 +28,6 @@ omit =
 
     tardis/analysis.py
     tardis/gui/*
-    tardis/scripts/*
     tardis/stats/*
    
 ignore_errors = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -26,7 +26,6 @@ omit =
     *conftest*
     *setup_package*
 
-    tardis/analysis.py
     tardis/gui/*
     tardis/stats/*
    


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
- Minimum `codecov` configuration.
- Rewrote `.coveragerc` based on Coverage sample configuration file.

I found tests from `visualization` and `montecarlo_numba` were taken into account to measure coverage, that's not right!. Tests always are 100% covered (all tests lines are executed during tests, lol) so now we have a lower but more realistic coverage. This was discovered by using better wildcards. 

Summarizing, `coverage` moved from 73 to 60 files thanks to modifying `.coveragerc`:

- 1 `conftest.py` at the root of the package
- 1 `cmfgen2tardis.py` script
- 2 tests from `visualization`
- 8 tests from `montecarlo_numba` + 1 `conftests.py`



**Motivation and context**
Codecov is failing too often even while PRs are not changing source files.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropiate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
