### PR TITLE
fix compareWith parameter in release pipeline

### DIFF
--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -51,6 +51,6 @@ jobs:
           title: 'TARDIS v$(version)'
           isPreRelease: true
           addChangeLog: true
-          changeLogCompareToRelease: 'lastRelease'
+          changeLogCompareToRelease: 'lastNonDraftRelease'
           changeLogType: 'commitBased'
         displayName: 'Create GitHub Release'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
Pipeline failed because I introduced a not valid option in `compareWith` field of GitHub release task. Options for this parameter are undocumented, see: https://github.com/MicrosoftDocs/azure-devops-docs/issues/10920

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
