### PR TITLE
Adding functionality to Detect Running Environments for TARDIS Simulations

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -13,6 +13,7 @@ from pyne import nucname
 
 import tardis
 from tardis.io.util import get_internal_data_path
+from IPython import get_ipython
 
 k_B_cgs = constants.k_B.cgs.value
 c_cgs = constants.c.cgs.value
@@ -539,3 +540,25 @@ def convert_abundances_format(fname, delimiter=r"\s+"):
     # Assign header row
     df.columns = [nucname.name(i) for i in range(1, df.shape[1] + 1)]
     return df
+
+
+def check_simulation_env():
+    """
+    Checking the environment where the simulation is run
+
+    Returns
+    -------
+    True : if the environment is IPython Based
+    False : if the environment is Terminal or anything else
+    """
+    try:
+        shell = get_ipython().__class__.__name__
+    except NameError:
+        return False
+
+    if shell == "ZMQInteractiveShell":
+        return True
+    elif shell == "TerminalInteractiveShell":
+        return False
+    else:
+        return False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR adds the functionality to check the environment in which the TARDIS Simulation is run. 
Needs to be merged before the #1632 

**Description**
<!--- Describe your changes in detail -->
This PR aims to add a new function `check_simulation_env()` which checks if the simulation is being run in a IPython environment or any other environment such as a Terminal, etc. 
This function returns `True` in the former option & `False` in the latter. 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
This function is vital for the implementation of the Logging Formatting which is being done in #1632. It would allow us to control the output of the logging & would allow for better formatting for the logging output generated while running the simulation.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. --> Local Testing

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Check PR #1632 

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
