### PR TITLE
force orphan gh-pages branch

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -22,13 +22,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup TARDIS Environment 
+      - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
         with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
             environment-file: tardis_env3.yml
             activate-environment: tardis
-            channels: conda-forge
-            mamba-version: "*"
+            use-mamba: true
 
       - name: Install TARDIS
         shell: bash -l {0}
@@ -44,3 +45,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html/
           publish_branch: gh-pages
+          force_orphan: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
Make `gh-pages` branch orphan. Will reduce repository size. GitHub Pages only renders the latest commit so this is fine.

**Motivation and context**
See https://github.com/tardis-sn/tardis/issues/1579

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
