### PR TITLE
changes to environment

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -41,9 +41,9 @@ dependencies:
   - sphinx
   - sphinx_bootstrap_theme
   - sphinx_rtd_theme
+  - sphinx-jsonschema
   - sphinxcontrib-apidoc
   - sphinxcontrib-bibtex
-  - sphinx-jsonschema
   - recommonmark
   - numpydoc
   - nbconvert

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -35,6 +35,7 @@ dependencies:
   - qgrid
   - pyside2  # Qt GUI
 
+# --- Not required for conda-forge package and Numba integration pipeline ---
   # Documentation
   - sphinx
   - sphinx_bootstrap_theme

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -28,14 +28,12 @@ dependencies:
   - tqdm
 
   # Widgets & Visualization
-  - ipywidgets
-  - matplotlib
-  - qgrid
-  - plotly
-  - pyside2  # Qt GUI
-
-  # Analysis
   - jupyter
+  - matplotlib
+  - ipywidgets
+  - plotly
+  - qgrid
+  - pyside2  # Qt GUI
 
   # Documentation
   - sphinx

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -64,6 +64,5 @@ dependencies:
   - git-lfs
 
   - pip:
-      - sphinxcontrib-tikz
       - dokuwiki
       - dot2tex  # conda-forge package requires python>=3.8

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -10,7 +10,7 @@ dependencies:
   - scipy=1.5
   - pandas=1.0
   - astropy=3
-  - numba=0.53.1
+  - numba=0.53
   - numexpr
   - pyne=0.7=nomoab_openmc*  # Issue #1537
 

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3
+  - python=3.7
   - pip
   - numpy=1.19
   - scipy=1.5

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -33,7 +33,7 @@ dependencies:
   - ipywidgets
   - plotly
   - qgrid
-  - pyside2  # Qt GUI
+# - pyside2  # Qt GUI
 
 # --- Not required for conda-forge package and Numba integration pipeline ---
   # Documentation

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -36,6 +36,11 @@ dependencies:
 # - pyside2  # Qt GUI
 
 # --- Not required for conda-forge package and Numba integration pipeline ---
+
+  # tardis-sn/nuclear dependencies
+  - beautifulsoup4
+  - lxml
+
   # Documentation
   - sphinx
   - sphinx_bootstrap_theme


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- We agreed to pin Python minor version to have the same version in Linux and macOS independently of the conda dependency solving process. Currently it's 3.7 due to #1537 
- Removed unused `sphinxcontrib-tikz` extension, not activated in `conf.py`.
- Unpinned numba bugfix version. Not necessary to pin the bugfix unless it's really necessary.
- Moved Jupyter to Visualization section since it's required for the new viz module.
- Commented out `pyside2` since Qt GUI is not used and soon to be deprecated. Also gives problems, see #1608 
- Add previously removed `tardisnuclear` dependencies in a separate section. I removed them in the past because weren't used in TARDIS code, in the future please use a different section for packages that are not required by `tardis` package!.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Regular env update.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [x] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
