### PR TITLE
add refdata repo selection in template

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -8,19 +8,15 @@
 #            This feature can be disabled only through the Azure Pipelines
 #            dashboard.
 
-trigger: none
+trigger:
+  tags:
+    include:
+    - '*'
 
 pr:
   branches:
     include:
     - '*'
-
-schedules:
-  - cron: '0 0 1 * *'
-    displayName: 'Monthly test'
-    branches:
-      include:
-        - master
 
 variables:
   system.debug: false
@@ -95,12 +91,12 @@ jobs:
          sshPublicKey: $(opensupernova_pubkey)
          sshKeySecureFile: openSupernovaKey
 
-      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-        - bash: echo "##vso[task.setvariable variable=subfolder]$(pr.number)"
+      - ${{ if eq(variables['Build.Reason'], 'IndividualCI') }}:
+        - bash: echo "##vso[task.setvariable variable=subfolder]releases"
           displayName: "Set subfolder name"
 
-      - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-        - bash: echo "##vso[task.setvariable variable=subfolder]scheduled"
+      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        - bash: echo "##vso[task.setvariable variable=subfolder]$(pr.number)"
           displayName: "Set subfolder name"
 
       - ${{ if eq(variables['Build.Reason'], 'Manual') }}:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -34,7 +34,8 @@ jobs:
     steps:
       - template: templates/default.yml
         parameters:
-          fetchRefdata: false  # See the comment below.
+          fetchRefdata: true
+          refdataRepo: 'github'
           useMamba: true
 
       - bash: |
@@ -42,20 +43,13 @@ jobs:
           $(package.manager) install bokeh=2.2 --channel conda-forge --no-update-deps --yes
         displayName: 'Install Bokeh'
 
-      # Azure Repos requires token auth for public repositories containing LFS objects (bug).
-      # Fetch reference data from Azure with a PAT until a fix arrives.
-      - bash: |
-          MY_PAT=$(azure_pat)
-          B64_PAT=$(printf ":$MY_PAT" | base64)
-          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata $(refdata.dir)
-          cd $(refdata.dir); git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs fetch --all
-        displayName: 'Fetch reference data repository'
-
       - bash: |
           cd $(refdata.dir)
-          git remote add upstream https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
+          git remote add upstream $(git remote get-url origin)
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
+          echo $(git remote get-url origin)
+          echo $(git remote get-url upstream)
         displayName: 'Set upstream remote'
 
       - bash: |

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -25,8 +25,8 @@ schedules:
 variables:
   system.debug: false
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
-  commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
+  commit.sha: '$(Build.SourceVersion)'
   #ref1.hash: ''
   #ref2.hash: ''
 
@@ -95,13 +95,25 @@ jobs:
          sshPublicKey: $(opensupernova_pubkey)
          sshKeySecureFile: openSupernovaKey
 
+      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+        - bash: echo "##vso[task.setvariable variable=subfolder]$(pr.number)"
+          displayName: "Set subfolder name"
+
+      - ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+        - bash: echo "##vso[task.setvariable variable=subfolder]scheduled"
+          displayName: "Set subfolder name"
+
+      - ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+        - bash: echo "##vso[task.setvariable variable=subfolder]manual"
+          displayName: "Set subfolder name"
+
       - bash: |
-          ssh azuredevops@opensupernova.org "mkdir -p /home/azuredevops/public_html/files/refdata-results/$(pr.number)"
+          ssh azuredevops@opensupernova.org "mkdir -p /home/azuredevops/public_html/files/refdata-results/$(subfolder)"
           scp $(refdata.dir)/notebooks/ref_data_compare.html azuredevops@opensupernova.org:/home/azuredevops/public_html/files/refdata-results/$(pr.number)/$(commit.sha).html
         displayName: 'Copy files to server'
         condition: succeededOrFailed()
 
-      # Run only if the pipeline is triggered by a pull request.
+      # Run if the pipeline is triggered by a pull request.
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - task: GitHubComment@0
           inputs:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -48,8 +48,6 @@ jobs:
           git remote add upstream $(git remote get-url origin)
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
-          echo $(git remote get-url origin)
-          echo $(git remote get-url upstream)
         displayName: 'Set upstream remote'
 
       - bash: |

--- a/azure-pipelines/release-version.yml
+++ b/azure-pipelines/release-version.yml
@@ -26,6 +26,7 @@ jobs:
       - template: templates/default.yml
         parameters:
           fetchRefdata: true
+          refdataRepo: 'azure'
           useMamba: true
 
       - bash: |

--- a/azure-pipelines/run-unit-tests.yml
+++ b/azure-pipelines/run-unit-tests.yml
@@ -35,6 +35,7 @@ jobs:
         parameters:
           fetchDepth: 1
           fetchRefdata: true
+          refdataRepo: 'azure'
           useMamba: true
 
       - bash: |

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -21,9 +21,9 @@ parameters:
     type: number
     default: 0
 
-  - name: skipInstall
+  - name: tardisEnv
     type: boolean
-    default: false
+    default: true
 
 steps:
   - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
@@ -71,13 +71,13 @@ steps:
     - bash: conda install mamba -c conda-forge -y
       displayName: 'Install Mamba'
 
-  - ${{ if eq(parameters.skipInstall, false) }}:
+  - ${{ if eq(parameters.tardisEnv, true) }}:
     - bash: |
         cd $(tardis.dir)
         $(package.manager) env create -f tardis_env3.yml
       displayName: 'Setup environment'
 
-  - ${{ if eq(parameters.skipInstall, false) }}:
+  - ${{ if eq(parameters.tardisEnv, true) }}:
     - bash: |
         cd $(tardis.dir)
         source activate tardis

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -23,7 +23,7 @@ parameters:
 
   - name: skipInstall
     type: boolean
-    default: true
+    default: false
 
 steps:
   - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
@@ -45,21 +45,20 @@ steps:
         echo "##vso[task.setvariable variable=package.manager]mamba"
       displayName: 'Set package manager'
  
-  - ${{ if eq(parameters.skipinstall, true) }}:
-    - checkout: self
-      path: s/tardis
-      fetchDepth: ${{ parameters.fetchDepth }}
+  - checkout: self
+    path: s/tardis
+    fetchDepth: ${{ parameters.fetchDepth }}
 
-    - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'azure')) }}:
-      - checkout: git://TARDIS/tardis-refdata
-        lfs: true
-        displayName: 'Fetch reference data (Azure)'
+  - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'azure')) }}:
+    - checkout: git://TARDIS/tardis-refdata
+      lfs: true
+      displayName: 'Fetch reference data (Azure)'
 
-    - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'github')) }}:
-      - bash: |
-          git clone https://github.com/tardis-sn/tardis-refdata.git $(refdata.dir)
-          cd $(refdata.dir); git lfs fetch
-        displayName: 'Fetch reference data (GitHub)'
+  - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'github')) }}:
+    - bash: |
+        git clone https://github.com/tardis-sn/tardis-refdata.git $(refdata.dir)
+        cd $(refdata.dir); git lfs fetch
+      displayName: 'Fetch reference data (GitHub)'
 
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Add conda to PATH'
@@ -72,13 +71,13 @@ steps:
     - bash: conda install mamba -c conda-forge -y
       displayName: 'Install Mamba'
 
-  - ${{ if eq(parameters.skipinstall, true) }}:
+  - ${{ if eq(parameters.skipInstall, false) }}:
     - bash: |
         cd $(tardis.dir)
         $(package.manager) env create -f tardis_env3.yml
       displayName: 'Setup environment'
 
-  - ${{ if eq(parameters.skipinstall, true) }}:
+  - ${{ if eq(parameters.skipInstall, false) }}:
     - bash: |
         cd $(tardis.dir)
         source activate tardis

--- a/azure-pipelines/templates/default.yml
+++ b/azure-pipelines/templates/default.yml
@@ -2,21 +2,28 @@
 # http://tardis-sn.github.io/tardis/development/continuous_integration.html
 
 parameters:
-  - name: fetchDepth
-    type: number
-    default: 0
+  - name: useMamba
+    type: boolean
+    default: false
 
   - name: fetchRefdata
     type: boolean
     default: false
 
-  - name: useMamba
-    type: boolean
-    default: false
+  - name: refdataRepo
+    type: string
+    default: azure
+    values:
+      - azure
+      - github
+
+  - name: fetchDepth
+    type: number
+    default: 0
 
   - name: skipInstall
     type: boolean
-    default: false
+    default: true
 
 steps:
   - bash: echo "##vso[task.setvariable variable=shellopts]errexit"
@@ -38,14 +45,21 @@ steps:
         echo "##vso[task.setvariable variable=package.manager]mamba"
       displayName: 'Set package manager'
  
-  - checkout: self
-    path: s/tardis
-    fetchDepth: ${{ parameters.fetchDepth }}
+  - ${{ if eq(parameters.skipinstall, true) }}:
+    - checkout: self
+      path: s/tardis
+      fetchDepth: ${{ parameters.fetchDepth }}
 
-  - ${{ if eq(parameters.fetchRefdata, true) }}:
-    - checkout: git://TARDIS/tardis-refdata
-      lfs: true
-      displayName: 'Fetch reference data'
+    - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'azure')) }}:
+      - checkout: git://TARDIS/tardis-refdata
+        lfs: true
+        displayName: 'Fetch reference data (Azure)'
+
+    - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'github')) }}:
+      - bash: |
+          git clone https://github.com/tardis-sn/tardis-refdata.git $(refdata.dir)
+          cd $(refdata.dir); git lfs fetch
+        displayName: 'Fetch reference data (GitHub)'
 
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
     displayName: 'Add conda to PATH'
@@ -58,13 +72,13 @@ steps:
     - bash: conda install mamba -c conda-forge -y
       displayName: 'Install Mamba'
 
-  - ${{ if eq(parameters.skipInstall, false) }}:
+  - ${{ if eq(parameters.skipinstall, true) }}:
     - bash: |
         cd $(tardis.dir)
         $(package.manager) env create -f tardis_env3.yml
       displayName: 'Setup environment'
 
-  - ${{ if eq(parameters.skipInstall, false) }}:
+  - ${{ if eq(parameters.skipinstall, true) }}:
     - bash: |
         cd $(tardis.dir)
         source activate tardis

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -31,11 +31,9 @@ jobs:
     steps:
       - template: templates/default.yml
         parameters:
-          fetchRefdata: false  # We don't want to fetch from the mirror
+          fetchRefdata: true
+          refdataRepo: 'github'
           useMamba: true
-
-      - bash: git clone https://github.com/tardis-sn/tardis-refdata $(refdata.dir)
-        displayName: 'Fetch reference data repository'
 
       - bash: |
           cd $(tardis.dir)

--- a/azure-pipelines/update-refdata.yml
+++ b/azure-pipelines/update-refdata.yml
@@ -33,7 +33,6 @@ jobs:
         parameters:
           fetchRefdata: false  # We don't want to fetch from the mirror
           useMamba: true
-          skipInstall: false
 
       - bash: git clone https://github.com/tardis-sn/tardis-refdata $(refdata.dir)
         displayName: 'Fetch reference data repository'

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -256,7 +256,7 @@ to start a new pipeline use::
   default is ``false``.
 - ``useMamba`` (*bool*): use the ``mamba`` package manager instead of ``conda``,
   default is ``false``. 
-- ``skipInstall`` (*bool*): does not create the TARDIS environment, default is ``false``.
+- ``tardisEnv`` (*bool*): setup the TARDIS environment, default is ``true``.
 
 **List of predefined custom variables:**
 

--- a/docs/development/continuous_integration.rst
+++ b/docs/development/continuous_integration.rst
@@ -254,6 +254,8 @@ to start a new pipeline use::
   default is ``0`` (no limit).
 - ``fetchRefdata`` (*bool*): fetch the ``tardis-refdata`` repository from Azure Repos,
   default is ``false``.
+- ``refdataRepo`` (*option*): source of the ``tardis-refdata`` repository,
+  options are ``azure`` (default) or ``github``.
 - ``useMamba`` (*bool*): use the ``mamba`` package manager instead of ``conda``,
   default is ``false``. 
 - ``tardisEnv`` (*bool*): setup the TARDIS environment, default is ``true``.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- Change default pipeline template to allow selection of `tardis-refdata` repo source between `azure` or `github`.
- Change `scheduled` trigger in `compare-refdata` pipeline. Instead run when a new `tag` is pushed (new release).
- Simplify `compare-refdata` and `update-refdata` pipelines by using `github` source.
- Rename `skipInstall` step to `tardisEnv`.
- Add more subfolders to OpenSupernova result page (for manual builds and releases).
- Update documentation.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Trying to test new atomic data (#1668) realized the reference data mirror does not suit the use case of comparing PRs made to `tardis-refdata` (for example `upstream/pr/46`). That happens because the mirror does not contain information about the PRs. 

Then I added a new parameter to the `default` template to select the source of reference data. The `compare-refdata`  and `update-refdata` pipelines use `github` source by default (thanks to new GH sponsorship we have free LFS quota). This solves the above described scenario, and simplifies the pipeline in many ways.


**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. --> `compare-refdata` pipeline.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [x] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
