### PR TITLE
use conda-forge packages instead of pypi

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -54,11 +54,13 @@ dependencies:
   - nbformat
   - nbsphinx
   - docutils=0.16  # Issue #1522
+  - snakeviz
 
   # Test/Coverage
   - pytest
   - pytest-cov
   - pytest-html
+  - python-dokuwiki
   - coverage
 
   # Code quality
@@ -68,6 +70,4 @@ dependencies:
   - git-lfs
 
   - pip:
-      - dokuwiki
       - dot2tex  # conda-forge package requires python>=3.8
-      - snakeviz

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -60,7 +60,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-html
-  - python-dokuwiki
+  #- python-dokuwiki
   - coverage
 
   # Code quality

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -60,7 +60,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-html
-  #- python-dokuwiki
+  - python-dokuwiki
   - coverage
 
   # Code quality


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
Use `snakeviz` and `python-dokuwiki` from `conda-forge` channel.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
We don't want `pip` dependencies.

**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

See: https://epassaro.github.io/tardis/branch/conda-forge-dokuwiki/io/output/profiling_example.html?highlight=profile

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
