### PR TITLE
[do not merge] compare-refdata with new atomic data

### DIFF
--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -27,7 +27,7 @@ variables:
   results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
-  #ref1.hash: ''
+  ref1.hash: 'upstream/master'
   ref2.hash: 'upstream/pr/46'
 
 pool:

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -57,7 +57,7 @@ jobs:
 
       - bash: |
           cd $(refdata.dir)
-          git remote add upstream https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata
+          git remote add upstream https://github.com/tardis-sn/tardis-refdata.git
           git fetch upstream
           git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
         displayName: 'Set upstream remote'

--- a/azure-pipelines/compare-refdata.yml
+++ b/azure-pipelines/compare-refdata.yml
@@ -28,7 +28,7 @@ variables:
   commit.sha: '$(Build.SourceVersion)'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
   #ref1.hash: ''
-  #ref2.hash: ''
+  ref2.hash: 'upstream/pr/46'
 
 pool:
   vmImage: 'ubuntu-latest'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

Compares reference data for these two atomic files:

- `upstream/master`: atomic file present at HEAD of **tardis-refdata** `master` branch (last updated on Aug 2017).
- `upstream/pr/46`: atomic file pushed to https://github.com/tardis-sn/tardis-refdata/pull/46 (branched from `upstream/master`).

[**Results here**](http://opensupernova.org/~azuredevops/files/refdata-results/1668/65bdb414e17a84c6e9102b0079de4c1e981c9f77.html)

---

Also, a detailed comparison between 2017 (SQL) and new atom data (Pandas) can be found [**here**](https://nbviewer.jupyter.org/gist/epassaro/8714f8ac63853d5f3d37ed836da6cb96).

> Keep in mind atom data produced with 2021 `carsus` SQL is identical to the data produced by the new `carsus` codebase. Changes between 2017 and 2021 data are the result of PRs merged in 2018.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Update atomic data soon.

**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

`compare-refdata` pipeline

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
