### PR TITLE
Enabling Repository on Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,1 @@
+../tardis_env3.yml

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-cd
-python setup.py develop
+python setup.py install

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd
+python setup.py develop

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python setup.py install
+python setup.py develop


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This allows for the TARDIS repository to be built on binder, which will in turn allow for the running of TARDIS online.

You can see the binder built on my fork [here](https://mybinder.org/v2/gh/smithis7/tardis/2nd-binder-attempt).

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
