### PR TITLE
add docstr-coverage badge

### DIFF
--- a/.github/workflows/docstr-coverage.yml
+++ b/.github/workflows/docstr-coverage.yml
@@ -1,13 +1,18 @@
 name: docstr-coverage
 
 on:
+  push:
+    branches:
+    - master
+
   pull_request:
     branches:
-      - master
+    - master
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -35,3 +40,30 @@ jobs:
         if: ${{ failure() }}
         run: |
           git diff --name-only $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}) | xargs docstr-coverage --accept-empty
+
+  post:
+    runs-on: ubuntu-latest
+    if: github.repository_owner != 'tardis-sn' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+
+      - name: Install docstr-coverage
+        run: pip install docstr-coverage
+
+      - name: Get coverage (rounded)
+        run: echo "NEW_COV=$(printf "%.f" $(docstr-coverage -p))" >> $GITHUB_ENV
+
+      # Using jsonbin.org with tardis-bot GitHub account
+      - name: Post results
+        run: |
+          curl -X POST https://jsonbin.org/tardis-bot/badges/tardis/docstr-coverage -H 'authorization: token ${{ secrets.JSONBIN_APIKEY }}' -d "{ \"schemaVersion\": 1, \"label\": \"docstr-coverage\", \"message\": \"$NEW_COV%\", \"color\": \"orange\" }"
+
+      # Updated badge will be available at: https://img.shields.io/endpoint?url=https://jsonbin.org/tardis-bot/badges/tardis/docstr-coverage
+      # Could take some minutes!

--- a/.github/workflows/docstr-coverage.yml
+++ b/.github/workflows/docstr-coverage.yml
@@ -43,7 +43,7 @@ jobs:
 
   post:
     runs-on: ubuntu-latest
-    if: github.repository_owner != 'tardis-sn' && github.event_name == 'push'
+    if: github.repository_owner == 'tardis-sn' && github.event_name == 'push'
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ stars (*supernovae*).
 .. image:: https://github.com/tardis-sn/tardis/actions/workflows/documentation-build.yml/badge.svg
     :target: https://tardis-sn.github.io/tardis/index.html
 
-.. image:: https://dev.azure.com/tardis-sn/TARDIS/_apis/build/status/TARDIS%20tests?repoName=tardis-sn%2Ftardis&branchName=refs%2Fpull%2F1573%2Fmerge
-    :target: https://dev.azure.com/tardis-sn/TARDIS/_build/latest?definitionId=3&repoName=tardis-sn%2Ftardis&branchName=refs%2Fpull%2F1573%2Fmerge
+.. image:: https://dev.azure.com/tardis-sn/TARDIS/_apis/build/status/TARDIS%20tests?branchName=master
+    :target: https://dev.azure.com/tardis-sn/TARDIS/_build/latest?definitionId=6&branchName=master
 
 
 ******************************

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,9 @@ stars (*supernovae*).
 .. image:: https://codecov.io/gh/tardis-sn/tardis/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/tardis-sn/tardis
 
+.. image:: https://img.shields.io/endpoint?url=https://jsonbin.org/tardis-bot/badges/tardis/docstr-coverage
+    :target: https://github.com/tardis-sn/tardis/actions/workflows/docstr-coverage.yml?query=branch%3Amaster
+
 .. image:: https://img.shields.io/badge/DOI-10.5281%2Fzenodo.592480-blue
     :target: https://doi.org/10.5281/zenodo.592480
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**

Use [jsonbin.org](https://jsonbin.org) RESTFUL API and  [shields.io](https://shields.io) endpoint to create a badge for `docstr-coverage` workflow.

- The new job will run only when a new commit is pushed to `master` branch.
- The new job will NOT run on forks.
- The old job runs only when a new commit is pushed to a pull request.
- Fixed the Azure badge.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

Currently we don't have a way to see what's the result of `docstr-coverage` without running it.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

Tested on my fork. Results uploaded at: https://jsonbin.org/tardis-bot/badges/tardis/docstr-coverage

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply --> 
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
