### PR TITLE
fix pip install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,5 @@ exclude_lines =
 
 [options.entry_points]
 console_scripts =
-    tardis = tardis.scripts.tardis
     cmfgen2tardis = tardis.scripts.cmfgen2tardis:main
     tardis_test_runner = tardis.tests.integration_tests.runner:run_tests

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,10 @@ except Exception:
     version = '{version}'
 """.lstrip()
 
-setup(use_scm_version={'write_to': os.path.join('tardis', 'version.py'),
+# Pure Python scripts that are not entry points, required for `pip install`.
+scripts = ['tardis/scripts/tardis']
+
+setup(scripts=scripts,
+      use_scm_version={'write_to': os.path.join('tardis', 'version.py'),
                        'write_to_template': VERSION_TEMPLATE,
-                       'version_scheme': 'calver-by-date'})
+                       'version_scheme': 'calver-by-date'},)

--- a/tardis/scripts/tardis
+++ b/tardis/scripts/tardis
@@ -1,13 +1,25 @@
 #!/usr/bin/env python
-from tardis.io import config_reader
-
-from tardis.simulation import Simulation
-import numpy as np
-
-import logging
-import argparse
 
 import warnings
+import argparse
+import logging
+import numpy as np
+from tardis.io import config_reader
+from tardis.simulation import Simulation
+
+
+def get_virtual_spectrum():
+    # Catch warning when acessing invalid spectrum_virtual
+    with warnings.catch_warnings(record=True) as w:
+        spectrum = simulation.runner.spectrum_virtual
+
+        if len(w) > 0 and w[-1]._category_name == "UserWarning":
+            warnings.warn(
+                "Virtual spectrum is not available, using the "
+                "real packet spectrum instead."
+            )
+            spectrum = simulation.runner.spectrum
+    return spectrum
 
 
 tardis_description = """
@@ -80,44 +92,31 @@ if args.packet_log_file:
 tardis_config = config_reader.Configuration.from_yaml(args.config_fname)
 simulation = Simulation.from_config(tardis_config)
 
-
-def get_virtual_spectrum():
-    # Catch warning when acessing invalid spectrum_virtual
-    with warnings.catch_warnings(record=True) as w:
-        spectrum = simulation.runner.spectrum_virtual
-
-        if len(w) > 0 and w[-1]._category_name == "UserWarning":
-            warnings.warn(
-                "Virtual spectrum is not available, using the "
-                "real packet spectrum instead."
-            )
-            spectrum = simulation.runner.spectrum
-    return spectrum
-
-
 print("Saving the {} spectrum.".format(tardis_config.spectrum.method))
 
-# Believe it or not, that is a fancy switch-case statement
-# We need functions so that only one spectrum is accessed so we can catch
+# Believe it or not, that is a fancy switch-case statement. We need
+# functions so that only one spectrum is accessed so we can catch
 # the warning properly
+
 get_spectrum = {
     "real": lambda: simulation.runner.spectrum,
     "virtual": get_virtual_spectrum,
     "integrated": lambda: simulation.runner.spectrum_integrated,
 }[tardis_config.spectrum.method]
 
-
 if args.gdb:
     import os
 
     print(os.getpid())
     raw_input()  # Workaround to attach gdb
+
 if args.profile:
     import cProfile
 
     cProfile.runctx(
         "simulation.run()", locals(), globals(), filename=args.profiler_log_file
     )
+
 else:
     simulation.run()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**

Fixes the `pip install ...` command. Some examples:

- `pip install git+https://github.com/tardis-sn/tardis.git`
- `pip install .` (equivalent to `python setup.py install` )
- `pip install -e .` (equivalent to `python setup.py develop`)

To achieve this I needed to undo some changes made in #1674 related to the `tardis` script. Now that script is considered a pure Python script instead of an entry point.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

We had two `scripts` folder before APE 17 migration: 

- the`scripts/` (containing just the `tardis` UNIX script) 
- and `tardis/scripts` (Python entry points)

In #1674 made some changes to the `tardis` script to use it as an entry point. But seems that worked for `python setup.py develop`, but didn't worked for `pip install .` (required by the `conda-forge` packaging system, [see here](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=347242&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=841356e0-85bb-57d8-dbbc-852e683d1642&l=691)).

I reverted those changes plus some minor changes to make the script tidier.

You can try the result of `pip install .` on this branch and compare it with `master`.

Fixes #1211

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

Locally.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
