### PR TITLE
Enabling virtual_packet_logging by default in the visualization folder

### DIFF
--- a/docs/io/visualization/generating_widgets.ipynb
+++ b/docs/io/visualization/generating_widgets.ipynb
@@ -391,7 +391,7 @@
    ],
    "source": [
     "from tardis import run_tardis\n",
-    "sim = run_tardis('tardis_example.yml')"
+    "sim = run_tardis('tardis_example.yml', virtual_packet_logging=True)"
    ]
   },
   {
@@ -595,7 +595,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -609,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.10"
   },
   "notify_time": "5",
   "toc": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR removes the symbolic link to tardis_example.yml in the visualization folder, and adds it with `virtual_packet_logging` enabled.

**Description**
<!--- Describe your changes in detail -->
To build the SDEC plot and the Line Info widget, one needs to enable `virtual_packet_logging` from the `run_tardis` function or edit the tardis_example.yml file in the docs folder. This enables `virtual_packet_logging` by default just for the visualization folder, easing the process for the user.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
https://github.com/tardis-sn/tardis/pull/1665#pullrequestreview-697583309

**How has this been tested?**
- [X] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
