### PR TITLE
Interact Button in Documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,8 +123,38 @@ nbsphinx_prolog = r"""
 {% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
 .. raw:: html
     
+    <style>
+        .launch-btn {
+            background-color: #2980B9;
+            border: none;
+            border-radius: 4px;
+            color: #fcfcfc;
+            font-family: inherit;
+            text-decoration: none;
+            padding: 3px 8px;
+            letter-spacing: 0.03em;
+            display: inline-block;
+            line-height: 1.5em;
+        }
+
+        .launch-btn:hover {
+            background-color: #1b6391;
+        }
+
+        .launch-btn:visited {
+            color: #fcfcfc;
+        }
+
+        .note-p {
+            margin-bottom: 0.4em;
+            line-height: 2em;
+        }
+    </style>
+    
     <div class="admonition note">
-      Click to interact with this notebook: <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}"><img alt="Interact Button" src="https://img.shields.io/badge/-Interact%20With%20This%20Notebook-red" style="vertical-align:text-bottom"></a></span>
+    <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch Interactive Version</a></p>
+    <p>And you can download it from
+<a class="reference external" href="https://github.com/tardis-sn/tardis/tree/master/docs/quickstart/quickstart.ipynb" target="_blank" rel="noopener noreferrer">GitHub</a></p>
     </div>
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -154,7 +154,7 @@ nbsphinx_prolog = r"""
     <div class="admonition note">
     <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch Interactive Version</a></p>
     <p>And you can download it from
-<a class="reference external" href="https://github.com/tardis-sn/tardis/tree/master/docs/quickstart/quickstart.ipynb" target="_blank" rel="noopener noreferrer">GitHub</a></p>
+    <a class="reference external" href="https://github.com/tardis-sn/tardis/tree/master/docs/quickstart/quickstart.ipynb" target="_blank" rel="noopener noreferrer">GitHub</a></p>
     </div>
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,7 +155,7 @@ nbsphinx_prolog = r"""
     <div class="admonition note">
     <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch Interactive Version</a></p>
     <p>And you can download it from
-    <a class="reference external" href="https://github.com/tardis-sn/tardis/tree/master/docs/quickstart/quickstart.ipynb" target="_blank" rel="noopener noreferrer">GitHub</a></p>
+    <a class="reference external" href="https://github.com/tardis-sn/tardis/tree/master/{{ docname|e }}" target="_blank" rel="noopener noreferrer">GitHub.</a></p>
     </div>
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,10 +119,13 @@ nbsphinx_execute_arguments = [
     "--InlineBackend.rc={'figure.dpi': 96}",
 ]
 
-nbsphinx_prolog = """
-This notebook is available at 
-https://github.com/tardis-sn/tardis/tree/master/docs/{{ env.doc2path(env.docname, base=None) }}
-
+nbsphinx_prolog = r"""
+{% set docname = 'docs/' + env.doc2path(env.docname, base=None) %}
+.. raw:: html
+    
+    <div class="admonition note">
+      Click to interact with this notebook: <span style="white-space: nowrap;"><a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}"><img alt="Interact Button" src="https://img.shields.io/badge/-Interact%20With%20This%20Notebook-red" style="vertical-align:text-bottom"></a></span>
+    </div>
 """
 
 if os.getenv("DISABLE_NBSPHINX") == "1":

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ nbsphinx_prolog = r"""
 
         .launch-btn:hover {
             background-color: #1b6391;
+            color: #fcfcfc;
         }
 
         .launch-btn:visited {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,9 +153,7 @@ nbsphinx_prolog = r"""
     </style>
     
     <div class="admonition note">
-    <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch Interactive Version</a></p>
-    <p>And you can download it from
-    <a class="reference external" href="https://github.com/tardis-sn/tardis/tree/master/{{ docname|e }}" target="_blank" rel="noopener noreferrer">GitHub.</a></p>
+    <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch interactive version</a></p>
     </div>
 """
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Adds a button in the documentation that allows you to launch binder.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
See this page for an example: https://smithis7.github.io/tardis/branch/interact_badge_doc/quickstart/quickstart.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
