### PR TITLE
Changed Formatting for the logger based on Log Level

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -169,7 +169,7 @@ class AtomData(object):
                 try:
                     dataframes[name] = store[name]
                 except KeyError:
-                    logger.debug("Dataframe does not contain NAME column")
+                    logger.debug(f"Dataframe does not contain {name} column")
                     nonavailable.append(name)
 
             atom_data = cls(**dataframes)

--- a/tardis/io/atom_data/util.py
+++ b/tardis/io/atom_data/util.py
@@ -31,7 +31,7 @@ def resolve_atom_data_fname(fname):
     fpath = os.path.join(os.path.join(get_data_dir(), fname))
     if os.path.exists(fpath):
         logger.info(
-            f"Atom Data {fname} not found in local path.\n\tExists in TARDIS Data repo {fpath}"
+            f"\n\tAtom Data {fname} not found in local path.\n\tExists in TARDIS Data repo {fpath}"
         )
         return fpath
 

--- a/tardis/io/logger/colored_logger.py
+++ b/tardis/io/logger/colored_logger.py
@@ -28,11 +28,16 @@ class ColoredFormatter(logging.Formatter):
     Custom logger class for changing levels color
     """
 
+    non_debug = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
+    debug = "[$BOLD{name:20s}$RESET][{levelname:18s}]  {message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
+
     def __init__(self, msg, use_color=True):
-        logging.Formatter.__init__(self, msg)
+        logging.Formatter.__init__(self, msg, style="{")
         self.use_color = use_color
 
     def format(self, record):
+        non_debug = formatter_message(ColoredFormatter.non_debug, True)
+        debug = formatter_message(ColoredFormatter.debug, True)
         COLOR_SEQ = "\033[1;%dm"
         RESET_SEQ = "\033[0m"
         BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
@@ -49,6 +54,10 @@ class ColoredFormatter(logging.Formatter):
                 COLOR_SEQ % (30 + COLORS[levelname]) + levelname + RESET_SEQ
             )
             record.levelname = levelname_color
+        if record.levelno == logging.DEBUG:
+            self._style._fmt = debug
+        else:
+            self._style._fmt = non_debug
         return logging.Formatter.format(self, record)
 
 
@@ -57,7 +66,7 @@ class ColoredLogger(logging.Logger):
     Custom logger class with multiple destinations
     """
 
-    FORMAT = "[$BOLD%(name)-20s$RESET][%(levelname)-18s]  %(message)s ($BOLD%(filename)s$RESET:%(lineno)d)"
+    FORMAT = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
     COLOR_FORMAT = formatter_message(FORMAT, True)
 
     def __init__(self, name):

--- a/tardis/io/logger/colored_logger.py
+++ b/tardis/io/logger/colored_logger.py
@@ -6,6 +6,9 @@ Code for Custom Logger Classes (ColoredFormatter and ColorLogger) and its helper
 http://stackoverflow.com/questions/384076/how-can-i-color-python-logging-output
 """
 
+FORMAT = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
+DEBUG_FORMAT = "[$BOLD{name:20s}$RESET][{levelname:18s}]  {message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
+
 
 def formatter_message(message, use_color=True):
     """
@@ -28,16 +31,13 @@ class ColoredFormatter(logging.Formatter):
     Custom logger class for changing levels color
     """
 
-    non_debug = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
-    debug = "[$BOLD{name:20s}$RESET][{levelname:18s}]  {message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
-
-    def __init__(self, msg, use_color=True):
-        logging.Formatter.__init__(self, msg, style="{")
+    def __init__(self, use_color=True):
+        self.non_debug = formatter_message(FORMAT, True)
+        self.debug = formatter_message(DEBUG_FORMAT, True)
+        logging.Formatter.__init__(self, self.non_debug, style="{")
         self.use_color = use_color
 
     def format(self, record):
-        non_debug = formatter_message(ColoredFormatter.non_debug, True)
-        debug = formatter_message(ColoredFormatter.debug, True)
         COLOR_SEQ = "\033[1;%dm"
         RESET_SEQ = "\033[0m"
         BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
@@ -48,16 +48,19 @@ class ColoredFormatter(logging.Formatter):
             "CRITICAL": YELLOW,
             "ERROR": RED,
         }
+
         levelname = record.levelname
         if self.use_color and levelname in COLORS:
             levelname_color = (
                 COLOR_SEQ % (30 + COLORS[levelname]) + levelname + RESET_SEQ
             )
             record.levelname = levelname_color
+
         if record.levelno == logging.DEBUG:
-            self._style._fmt = debug
+            self._style._fmt = self.debug
         else:
-            self._style._fmt = non_debug
+            self._style._fmt = self.non_debug
+
         return logging.Formatter.format(self, record)
 
 
@@ -66,7 +69,6 @@ class ColoredLogger(logging.Logger):
     Custom logger class with multiple destinations
     """
 
-    FORMAT = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
     COLOR_FORMAT = formatter_message(FORMAT, True)
 
     def __init__(self, name):

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -7,12 +7,11 @@ from tardis.io.logger.colored_logger import ColoredFormatter, formatter_message
 
 warnings.filterwarnings("ignore", category=pyne.utils.QAWarning)
 
-FORMAT = "[$BOLD%(name)-20s$RESET][%(levelname)-18s]  %(message)s ($BOLD%(filename)s$RESET:%(lineno)d)"
+FORMAT = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
 COLOR_FORMAT = formatter_message(FORMAT, True)
 
 logging.captureWarnings(True)
 logger = logging.getLogger("tardis")
-logger.setLevel(logging.INFO)
 
 console_handler = logging.StreamHandler(sys.stdout)
 console_formatter = ColoredFormatter(COLOR_FORMAT)

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -7,14 +7,11 @@ from tardis.io.logger.colored_logger import ColoredFormatter, formatter_message
 
 warnings.filterwarnings("ignore", category=pyne.utils.QAWarning)
 
-FORMAT = "[$BOLD{name:20s}$RESET][{levelname:18s}]  \n\t{message:s} ($BOLD{filename:s}$RESET:{lineno:d})"
-COLOR_FORMAT = formatter_message(FORMAT, True)
-
 logging.captureWarnings(True)
 logger = logging.getLogger("tardis")
 
 console_handler = logging.StreamHandler(sys.stdout)
-console_formatter = ColoredFormatter(COLOR_FORMAT)
+console_formatter = ColoredFormatter()
 console_handler.setFormatter(console_formatter)
 
 logger.addHandler(console_handler)

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -89,7 +89,7 @@ def assemble_plasma(config, model, atom_data=None):
         else:
             raise ValueError("No atom_data option found in the configuration.")
 
-        logger.info(f"Reading Atomic Data from {atom_data_fname}")
+        logger.info(f"\n\tReading Atomic Data from {atom_data_fname}")
 
         try:
             atom_data = AtomData.from_hdf(atom_data_fname)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -356,7 +356,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
     def iterate(self, no_of_packets, no_of_virtual_packets=0, last_run=False):
         logger.info(
-            f"Starting iteration {(self.iterations_executed + 1):d} of {self.iterations:d}"
+            f"\n\tStarting iteration {(self.iterations_executed + 1):d} of {self.iterations:d}"
         )
         self.runner.run(
             self.model,
@@ -441,8 +441,8 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             self.cplots.update(export_cplots=self.export_cplots, last=True)
 
         logger.info(
-            f"Simulation finished in {self.iterations_executed:d} iterations "
-            f"Simulation took {(time.time() - start_time):.2f} s\n"
+            f"\n\tSimulation finished in {self.iterations_executed:d} iterations "
+            f"\n\tSimulation took {(time.time() - start_time):.2f} s\n"
         )
         self._call_back()
 
@@ -487,7 +487,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         plasma_state_log.columns.name = "Shell No."
 
         if is_notebook():
-            logger.info("Plasma stratification:")
+            logger.info("\n\tPlasma stratification:")
 
             # Displaying the DataFrame only when the logging level is NOTSET, DEBUG or INFO
             if logger.level <= logging.INFO:
@@ -511,16 +511,16 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             )
             for value in plasma_output.split("\n"):
                 output_df = output_df + "\t{}\n".format(value)
-            logger.info("Plasma stratification:")
+            logger.info("\n\tPlasma stratification:")
             logger.info(f"\n{output_df}")
 
         logger.info(
-            f"Current t_inner = {t_inner:.3f}\n\tExpected t_inner for next iteration = {next_t_inner:.3f}\n"
+            f"\n\tCurrent t_inner = {t_inner:.3f}\n\tExpected t_inner for next iteration = {next_t_inner:.3f}\n"
         )
 
     def log_run_results(self, emitted_luminosity, absorbed_luminosity):
         logger.info(
-            f"Luminosity emitted   = {emitted_luminosity:.3e}\n"
+            f"\n\tLuminosity emitted   = {emitted_luminosity:.3e}\n"
             f"\tLuminosity absorbed  = {absorbed_luminosity:.3e}\n"
             f"\tLuminosity requested = {self.luminosity_requested:.3e}\n"
         )


### PR DESCRIPTION
This PR aims to add Logging Formatting based on log level. Debug Level has different formatting due to the number of messages that would be printed to the `strerr`. All other logging level follow the existing formatting (with the `\n\t` formatting).

<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
