### PR TITLE
Removed Formatting from Existing Log Messages

### DIFF
--- a/tardis/io/atom_data/util.py
+++ b/tardis/io/atom_data/util.py
@@ -31,7 +31,7 @@ def resolve_atom_data_fname(fname):
     fpath = os.path.join(os.path.join(get_data_dir(), fname))
     if os.path.exists(fpath):
         logger.info(
-            f"\n\tAtom Data {fname} not found in local path.\n\tExists in TARDIS Data repo {fpath}"
+            f"Atom Data {fname} not found in local path.\n\tExists in TARDIS Data repo {fpath}"
         )
         return fpath
 

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -88,7 +88,7 @@ def assemble_plasma(config, model, atom_data=None):
         else:
             raise ValueError("No atom_data option found in the configuration.")
 
-        logger.info(f"\n\tReading Atomic Data from {atom_data_fname}")
+        logger.info(f"Reading Atomic Data from {atom_data_fname}")
 
         try:
             atom_data = AtomData.from_hdf(atom_data_fname)

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -322,7 +322,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
 
     def iterate(self, no_of_packets, no_of_virtual_packets=0, last_run=False):
         logger.info(
-            f"\n\tStarting iteration {(self.iterations_executed + 1):d} of {self.iterations:d}"
+            f"Starting iteration {(self.iterations_executed + 1):d} of {self.iterations:d}"
         )
         self.runner.run(
             self.model,
@@ -381,8 +381,8 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self.reshape_plasma_state_store(self.iterations_executed)
 
         logger.info(
-            f"\n\tSimulation finished in {self.iterations_executed:d} iterations "
-            f"\n\tSimulation took {(time.time() - start_time):.2f} s\n"
+            f"Simulation finished in {self.iterations_executed:d} iterations "
+            f"Simulation took {(time.time() - start_time):.2f} s\n"
         )
         self._call_back()
 
@@ -427,7 +427,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         plasma_state_log.columns.name = "Shell No."
 
         if is_notebook():
-            logger.info("\n\tPlasma stratification:")
+            logger.info("Plasma stratification:")
 
             # Displaying the DataFrame only when the logging level is NOTSET, DEBUG or INFO
             if logger.level <= logging.INFO:
@@ -451,16 +451,16 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             )
             for value in plasma_output.split("\n"):
                 output_df = output_df + "\t{}\n".format(value)
-            logger.info("\n\tPlasma stratification:")
+            logger.info("Plasma stratification:")
             logger.info(f"\n{output_df}")
 
         logger.info(
-            f"\n\tCurrent t_inner = {t_inner:.3f}\n\tExpected t_inner for next iteration = {next_t_inner:.3f}\n"
+            f"Current t_inner = {t_inner:.3f}\n\tExpected t_inner for next iteration = {next_t_inner:.3f}\n"
         )
 
     def log_run_results(self, emitted_luminosity, absorbed_luminosity):
         logger.info(
-            f"\n\tLuminosity emitted   = {emitted_luminosity:.3e}\n"
+            f"Luminosity emitted   = {emitted_luminosity:.3e}\n"
             f"\tLuminosity absorbed  = {absorbed_luminosity:.3e}\n"
             f"\tLuminosity requested = {self.luminosity_requested:.3e}\n"
         )


### PR DESCRIPTION
This PR aims to remove the `\n\t` formatting that was added to the logging message. This is in continuation to PR #1710

**Description**
These changes were added to make the logger more readable & presentable. But having figured out a method to have different log formatting for different levels of logging, these changes are redundant. 

**Motivation and context**
Changes the way the logging messages look.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
