### PR TITLE
Support for users passing tardis model to run_tardis()

### DIFF
--- a/tardis/base.py
+++ b/tardis/base.py
@@ -14,6 +14,7 @@ def run_tardis(
     virtual_packet_logging=False,
     log_state=None,
     specific=None,
+    model=None,
 ):
     """
     This function is one of the core functions to run TARDIS from a given
@@ -65,12 +66,21 @@ def run_tardis(
             )
             atom_data = atom_data
 
-    simulation = Simulation.from_config(
-        tardis_config,
-        packet_source=packet_source,
-        atom_data=atom_data,
-        virtual_packet_logging=virtual_packet_logging,
-    )
+    if not model is None:
+        simulation = Simulation.from_config(
+            tardis_config,
+            packet_source=packet_source,
+            atom_data=atom_data,
+            virtual_packet_logging=virtual_packet_logging,
+            model=model,
+        )
+    else:
+        simulation = Simulation.from_config(
+            tardis_config,
+            packet_source=packet_source,
+            atom_data=atom_data,
+            virtual_packet_logging=virtual_packet_logging,
+        )
     for cb in simulation_callbacks:
         simulation.add_callback(*cb)
 

--- a/tardis/io/schemas/model.yml
+++ b/tardis/io/schemas/model.yml
@@ -6,7 +6,9 @@ properties:
     oneOf:
     - $ref: 'model_definitions.yml#/definitions/structure/specific'
     - $ref: 'model_definitions.yml#/definitions/structure/file'
+    - $ref: 'model_definitions.yml#/definitions/structure/tardismodel'
   abundances:
     oneOf:
     - $ref: 'model_definitions.yml#/definitions/abundances/file'
     - $ref: 'model_definitions.yml#/definitions/abundances/uniform'
+    - $ref: 'model_definitions.yml#/definitions/abundances/tardismodel'

--- a/tardis/io/schemas/model_definitions.yml
+++ b/tardis/io/schemas/model_definitions.yml
@@ -116,6 +116,14 @@ definitions:
       required:
       - filename
       - filetype
+    tardismodel:
+      title: 'Pre-made TARDIS Model'
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          enum:
+          - tardismodel
     specific:
       $$target: 'model_definitions.yml#/definitions/structure/specific'
       title: 'Specific Structure'
@@ -164,6 +172,14 @@ definitions:
       required:
       - filetype
       - filename
+    tardismodel:
+      title: 'Pre-made TARDIS Model'
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          enum:
+          - tardismodel
     uniform:
       $$target: 'model_definitions.yml#/definitions/abundances/uniform'
       title: 'Uniform Abundance'

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -539,8 +539,14 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         # Allow overriding some config structures. This is useful in some
         # unit tests, and could be extended in all the from_config classmethods.
         if "model" in kwargs:
+            if not config.model.structure.type == 'tardismodel':
+                raise ValueError("Must set model structure type to tardismodel in config yml")
+            if not config.model.abundances.type == 'tardismodel':
+                raise ValueError("Must set model abundances type to tardismodel in config yml")
             model = kwargs["model"]
         else:
+            if config.model.structure.type == 'tardismodel' or config.model.abundances.type == 'tardismodel':
+                raise ValueError("Must pass a Radial1DModel object as kwarg to simulation.")
             if hasattr(config, "csvy_model"):
                 model = Radial1DModel.from_csvy(config)
             else:


### PR DESCRIPTION
**Description**
Users can now specify a TARDIS model as a kwarg in the run_tardis() function.  Support already existed to pass a model as a kwarg to the simulation object, but this functionality was not used because there was no corresponding support in run_tardis().

**Motivation and context**
It is now much easier to directly modify TARDIS models and run the corresponding simulation.  This will be useful for running grids.

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
