### PR TITLE
Fixing Quickstart Metadata

### DIFF
--- a/docs/quickstart/quickstart.ipynb
+++ b/docs/quickstart/quickstart.ipynb
@@ -134,10 +134,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
-  },
-  "nbsphinx": {
-   "execute": "always",
-   "timeout": -1
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Makes it so quickstart notebook does not run when `DISABLE_NBSPHINX=1`.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Fixing a mistake I made when working with #1711 

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Docs built locally on GitHub (see below). <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
After running `DISABLE_NBSPHINX=1 make html`, I got:
![image](https://user-images.githubusercontent.com/71480393/125834270-38000622-eefe-475d-9ccc-d08ddf660ddc.png)
See built documentation: https://smithis7.github.io/tardis/branch/patch-1/quickstart/quickstart.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
