### PR TITLE
require time_0 to exist and be a astropy quantity

### DIFF
--- a/tardis/io/decay.py
+++ b/tardis/io/decay.py
@@ -6,10 +6,10 @@ from astropy import units as u
 class IsotopeAbundances(pd.DataFrame):
     """[summary]
 
-        Parameters
-        ----------
-        time_0 : astropy.units.Quantity
-            time where the given isotopes are defined
+    Parameters
+    ----------
+    time_0 : astropy.units.Quantity
+        time where the given isotopes are defined
     """
 
     _metadata = ["time_0"]

--- a/tardis/io/decay.py
+++ b/tardis/io/decay.py
@@ -4,16 +4,19 @@ from astropy import units as u
 
 
 class IsotopeAbundances(pd.DataFrame):
+    """[summary]
+
+        Parameters
+        ----------
+        time_0 : astropy.units.Quantity
+            time where the given isotopes are defined
+    """
 
     _metadata = ["time_0"]
+    def __init__(self, time_0, *args, **kwargs):
 
-    def __init__(self, *args, **kwargs):
-        if "time_0" in kwargs:
-            time_0 = kwargs["time_0"]
-            kwargs.pop("time_0")
-        else:
-            time_0 = 0 * u.d
         super(IsotopeAbundances, self).__init__(*args, **kwargs)
+        assert hasattr(time_0, 'unit')
         self.time_0 = time_0
 
     @property


### PR DESCRIPTION
The decay dataframe should really require a time of definition and not just assume `time_0 = 0 * u.day` if this is not given
We also make sure that time_0 is a quantity (using ducktyping). 


**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->


**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [x] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
