### PR TITLE
Renamed `log_state` to `log_level` for setting the logging level in the Logger

### DIFF
--- a/docs/io/optional/logging_configuration.ipynb
+++ b/docs/io/optional/logging_configuration.ipynb
@@ -96,7 +96,7 @@
    "id": "ac8d5088",
    "metadata": {},
    "source": [
-    "The `run_tardis()` function from the `tardis module` has two functional arguments:`log_state` & `specific`."
+    "The `run_tardis()` function from the `tardis module` has two functional arguments:`log_level` & `specific`."
    ]
   },
   {
@@ -105,7 +105,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\" role=\"alert\">\n",
-    "    Both <strong>log_state</strong> & <strong>specific</strong> are optional arguments for the <strong>run_tardis()</strong> function, however, if <strong>specific</strong> argument is used then, <strong>log_state</strong> must be set to a particular level.\n",
+    "    Both <strong>log_level</strong> & <strong>specific</strong> are optional arguments for the <strong>run_tardis()</strong> function, however, if <strong>specific</strong> argument is used then, <strong>log_level</strong> must be set to a particular level.\n",
     "</div>"
    ]
   },
@@ -114,7 +114,7 @@
    "id": "1176f370",
    "metadata": {},
    "source": [
-    "### `log_state`"
+    "### `log_level`"
    ]
   },
   {
@@ -122,7 +122,7 @@
    "id": "c3547b04",
    "metadata": {},
    "source": [
-    "The `log_state` argument can be passed in `run_tardis()` to set the logging level for the simulation. The input for this argument **must be** one of the following: **Notset, Debug, Info, Warning, Error** or **Critical**."
+    "The `log_level` argument can be passed in `run_tardis()` to set the logging level for the simulation. The input for this argument **must be** one of the following: **Notset, Debug, Info, Warning, Error** or **Critical**."
    ]
   },
   {
@@ -134,7 +134,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\", log_state=\"Info\")"
+    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Info\")"
    ]
   },
   {
@@ -142,7 +142,7 @@
    "id": "52e778bc",
    "metadata": {},
    "source": [
-    "By setting up the `log_state` parameter to **\"Info\"** in the above example, we can check that the logs are at the **\"Info\"** or higher logging level. "
+    "By setting up the `log_level` parameter to **\"Info\"** in the above example, we can check that the logs are at the **\"Info\"** or higher logging level. "
    ]
   },
   {
@@ -158,7 +158,7 @@
    "id": "56a5ef36",
    "metadata": {},
    "source": [
-    "The `specific` argument tells the logger to capture log messages set by the `log_state` parameter. It can only take *Boolean* values for input, which are `True` or `False`. Take for example the following:"
+    "The `specific` argument tells the logger to capture log messages set by the `log_level` parameter. It can only take *Boolean* values for input, which are `True` or `False`. Take for example the following:"
    ]
   },
   {
@@ -170,7 +170,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\", log_state=\"Debug\", specific=True)"
+    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Debug\", specific=True)"
    ]
   },
   {
@@ -198,7 +198,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\", log_state=\"Debug\", specific=False)"
+    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Debug\", specific=False)"
    ]
   },
   {
@@ -233,7 +233,7 @@
     "```YAML\n",
     "...\n",
     "debug:\n",
-    "  log_state: \"Info\"\n",
+    "  log_level: \"Info\"\n",
     "  specific : False\n",
     "```"
    ]
@@ -243,7 +243,7 @@
    "id": "85ea7ae2",
    "metadata": {},
    "source": [
-    "The `debug` schema includes the `log_state` & `specific` parameters."
+    "The `debug` schema includes the `log_level` & `specific` parameters."
    ]
   },
   {
@@ -252,7 +252,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\" role=\"alert\">\n",
-    "    The <strong>debug</strong> section of the <strong>YAML</strong> config file is <i>optional</i>. The <strong>log_state</strong> and the <strong>specific</strong> arguments are <i>optional</i> as well. If none of the parameters are defined, then the values of these parameter fall back on the <strong>default values</strong>.\n",
+    "    The <strong>debug</strong> section of the <strong>YAML</strong> config file is <i>optional</i>. The <strong>log_level</strong> and the <strong>specific</strong> arguments are <i>optional</i> as well. If none of the parameters are defined, then the values of these parameter fall back on the <strong>default values</strong>.\n",
     "</div>"
    ]
   },
@@ -293,7 +293,7 @@
    "id": "7f5f2d9f",
    "metadata": {},
    "source": [
-    "### `log_state`"
+    "### `log_level`"
    ]
   },
   {
@@ -301,7 +301,7 @@
    "id": "1389e902",
    "metadata": {},
    "source": [
-    "The `log_state` parameter, in the `debug` section of the config file, is similar in functionality to the `log_state` functional argument that can be passed via the `run_tardis()` function. The value of this parameter **must be** one of the following: **Notset, Debug, Info, Warning, Error** or **Critical**."
+    "The `log_level` parameter, in the `debug` section of the config file, is similar in functionality to the `log_level` functional argument that can be passed via the `run_tardis()` function. The value of this parameter **must be** one of the following: **Notset, Debug, Info, Warning, Error** or **Critical**."
    ]
   },
   {
@@ -309,7 +309,7 @@
    "id": "3bdd9972",
    "metadata": {},
    "source": [
-    "Let us see an example of the captured simulation logging output, when the `log_state` parameter is set to `\"Info\"` log level in the `tardis_config_logger.yml` config file."
+    "Let us see an example of the captured simulation logging output, when the `log_level` parameter is set to `\"Info\"` log level in the `tardis_config_logger.yml` config file."
    ]
   },
   {
@@ -319,7 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config[\"debug\"][\"log_state\"] = \"Info\""
+    "config[\"debug\"][\"log_level\"] = \"Info\""
    ]
   },
   {
@@ -366,7 +366,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config[\"debug\"][\"log_state\"] = \"Debug\"\n",
+    "config[\"debug\"][\"log_level\"] = \"Debug\"\n",
     "config[\"debug\"][\"specific\"] = True"
    ]
   },
@@ -423,7 +423,7 @@
    "id": "f32403c7",
    "metadata": {},
    "source": [
-    "If a user specifies both the parameters passed through the `log_state` & `log_state` in the **YAML** configuration file, then the `log_state` parameter *(Functional Argument)* takes precedence & is used to determine the logging level for the simulation logs."
+    "If a user specifies both the parameters passed through the `log_level` & `log_level` in the **YAML** configuration file, then the `log_level` parameter *(Functional Argument)* takes precedence & is used to determine the logging level for the simulation logs."
    ]
   },
   {
@@ -439,7 +439,7 @@
    "id": "863042a4",
    "metadata": {},
    "source": [
-    "Continuing from the previous example, the `config[\"debug\"][\"log_state\"]` is set to `Debug` via the **YAML** file. The user will also set the `log_state` {Functional Argument} to `Info`."
+    "Continuing from the previous example, the `config[\"debug\"][\"log_level\"]` is set to `Debug` via the **YAML** file. The user will also set the `log_level` {Functional Argument} to `Info`."
    ]
   },
   {
@@ -451,7 +451,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(config, log_state = \"Info\")"
+    "sim = run_tardis(config, log_level = \"Info\")"
    ]
   },
   {
@@ -461,10 +461,10 @@
    "source": [
     "A new message can be seen from the execution of the simulation,\n",
     "```\n",
-    "log_state is defined both in Functional Argument & YAML Configuration {debug section}\n",
-    "log_state = Info will be used for Log Level Determination\n",
+    "log_level is defined both in Functional Argument & YAML Configuration {debug section}\n",
+    "log_level = Info will be used for Log Level Determination\n",
     "```\n",
-    "that is informing the user which input log level value will determine the logging level. Thus, `log_state = \"Info\"` is used for logging the simulation output."
+    "that is informing the user which input log level value will determine the logging level. Thus, `log_level = \"Info\"` is used for logging the simulation output."
    ]
   },
   {
@@ -484,7 +484,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(config, log_state = \"Info\", specific = True)"
+    "sim = run_tardis(config, log_level = \"Info\", specific = True)"
    ]
   }
  ],

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -12,7 +12,7 @@ def run_tardis(
     packet_source=None,
     simulation_callbacks=[],
     virtual_packet_logging=False,
-    log_state=None,
+    log_level=None,
     specific=None,
 ):
     """
@@ -54,7 +54,7 @@ def run_tardis(
             )
             tardis_config = Configuration.from_config_dict(config)
 
-    logging_state(log_state, tardis_config, specific)
+    logging_state(log_level, tardis_config, specific)
 
     if atom_data is not None:
         try:

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -29,7 +29,7 @@ LOGGING_LEVELS = {
     "ERROR": logging.ERROR,
     "CRITICAL": logging.CRITICAL,
 }
-DEFAULT_LOG_STATE = "CRITICAL"
+DEFAULT_LOG_LEVEL = "CRITICAL"
 
 
 class FilterLog(object):
@@ -69,19 +69,19 @@ class FilterLog(object):
         return log_record.levelno == self.log_level
 
 
-def logging_state(log_state, tardis_config, specific):
+def logging_state(log_level, tardis_config, specific):
     """
     Function to set the logging configuration for the simulation output
     Called from within run_tardis()
-    Configured via functional arguments passed through run_tardis() - log_state & specific
+    Configured via functional arguments passed through run_tardis() - log_level & specific
     Configured via YAML parameters under `debug` section - logging_level & specific_logging
     Parameters
     ----------
-    log_state: str
+    log_level: str
         Allows to input the log level for the simulation
         Uses Python logging framework to determine the messages that will be output
     specific: boolean
-        Allows to set specific logging levels. Logs of the `log_state` level would be output.
+        Allows to set specific logging levels. Logs of the `log_level` level would be output.
     """
 
     if "debug" in tardis_config:
@@ -90,24 +90,24 @@ def logging_state(log_state, tardis_config, specific):
         )
 
         logging_level = (
-            log_state if log_state else tardis_config["debug"]["log_state"]
+            log_level if log_level else tardis_config["debug"]["log_level"]
         )
 
-        # Displays a message when both log_state & tardis["debug"]["log_state"] are specified
-        if log_state and tardis_config["debug"]["log_state"]:
+        # Displays a message when both log_level & tardis["debug"]["log_level"] are specified
+        if log_level and tardis_config["debug"]["log_level"]:
             print(
-                "log_state is defined both in Functional Argument & YAML Configuration {debug section}"
+                "log_level is defined both in Functional Argument & YAML Configuration {debug section}"
             )
             print(
-                f"log_state = {log_state.upper()} will be used for Log Level Determination\n"
+                f"log_level = {log_level.upper()} will be used for Log Level Determination\n"
             )
 
     else:
-        if log_state:
-            logging_level = log_state
+        if log_level:
+            logging_level = log_level
         else:
-            tardis_config["debug"] = {"log_state": DEFAULT_LOG_STATE}
-            logging_level = tardis_config["debug"]["log_state"]
+            tardis_config["debug"] = {"log_level": DEFAULT_LOG_LEVEL}
+            logging_level = tardis_config["debug"]["log_level"]
 
         if specific:
             specific = specific
@@ -115,7 +115,7 @@ def logging_state(log_state, tardis_config, specific):
     logging_level = logging_level.upper()
     if not logging_level in LOGGING_LEVELS:
         raise ValueError(
-            f"Passed Value for log_state = {logging_level} is Invalid. Must be one of the following {list(LOGGING_LEVELS.keys())}"
+            f"Passed Value for log_level = {logging_level} is Invalid. Must be one of the following {list(LOGGING_LEVELS.keys())}"
         )
 
     # Getting the TARDIS logger & all its children loggers

--- a/tardis/io/logger/tests/test_logging.py
+++ b/tardis/io/logger/tests/test_logging.py
@@ -26,7 +26,7 @@ def test_logging_simulation(atomic_data_fname, caplog):
 
 # Testing Configuration of Logger via run_tardis() Function
 @pytest.mark.parametrize(
-    ["log_state", "specific"],
+    ["log_level", "specific"],
     [
         ("Info", False),
         ("INFO", False),
@@ -42,12 +42,12 @@ def test_logging_simulation(atomic_data_fname, caplog):
 class TestSimulationLogging:
     """
     Class implemented for testing the logging configuration available via run_tardis()
-    Tests Functional Arguments : log_state & specific
+    Tests Functional Arguments : log_level & specific
     Tests YAML Parameters : logging_level & specific_logging
     """
 
     def test_logging_config(
-        self, atomic_data_fname, caplog, log_state, specific
+        self, atomic_data_fname, caplog, log_level, specific
     ):
         config = Configuration.from_yaml(
             "tardis/io/tests/data/tardis_configv1_verysimple_logger.yml"
@@ -55,45 +55,45 @@ class TestSimulationLogging:
         config["atom_data"] = atomic_data_fname
 
         caplog.clear()
-        run_tardis(config=config, log_state=log_state, specific=specific)
+        run_tardis(config=config, log_level=log_level, specific=specific)
         for record in caplog.records:
             if specific == True:
-                assert record.levelno == LOGGING_LEVELS[log_state.upper()]
+                assert record.levelno == LOGGING_LEVELS[log_level.upper()]
             else:
-                assert record.levelno >= LOGGING_LEVELS[log_state.upper()]
+                assert record.levelno >= LOGGING_LEVELS[log_level.upper()]
 
     def test_logging_config_yaml(
-        self, atomic_data_fname, caplog, log_state, specific
+        self, atomic_data_fname, caplog, log_level, specific
     ):
         config = Configuration.from_yaml(
             "tardis/io/tests/data/tardis_configv1_verysimple_logger.yml"
         )
         config["atom_data"] = atomic_data_fname
-        config["debug"]["log_state"] = log_state
+        config["debug"]["log_level"] = log_level
         config["debug"]["specific"] = specific
 
         caplog.clear()
         run_tardis(config=config)
         for record in caplog.records:
             if specific == True:
-                assert record.levelno == LOGGING_LEVELS[log_state.upper()]
+                assert record.levelno == LOGGING_LEVELS[log_level.upper()]
             else:
-                assert record.levelno >= LOGGING_LEVELS[log_state.upper()]
+                assert record.levelno >= LOGGING_LEVELS[log_level.upper()]
 
     def test_logging_both_specified(
-        self, atomic_data_fname, caplog, log_state, specific
+        self, atomic_data_fname, caplog, log_level, specific
     ):
         config = Configuration.from_yaml(
             "tardis/io/tests/data/tardis_configv1_verysimple_logger.yml"
         )
         config["atom_data"] = atomic_data_fname
-        config["debug"]["log_state"] = log_state
+        config["debug"]["log_level"] = log_level
         config["debug"]["specific"] = specific
 
         caplog.clear()
-        run_tardis(config=config, log_state=log_state, specific=specific)
+        run_tardis(config=config, log_level=log_level, specific=specific)
         for record in caplog.records:
             if specific == True:
-                assert record.levelno == LOGGING_LEVELS[log_state.upper()]
+                assert record.levelno == LOGGING_LEVELS[log_level.upper()]
             else:
-                assert record.levelno >= LOGGING_LEVELS[log_state.upper()]
+                assert record.levelno >= LOGGING_LEVELS[log_level.upper()]

--- a/tardis/io/schemas/debug.yml
+++ b/tardis/io/schemas/debug.yml
@@ -2,7 +2,7 @@ $$target: debug.yml
 type: object
 additionalProperties: false
 properties:
-  log_state:
+  log_level:
     type: string
     default: "Critical"
     description: Sets the logging Level for the logger


### PR DESCRIPTION
This PR aims to rename `log_state` to `log_level` for better understanding of the option available in the `run_tardis()` function.

**Description**
Renamed the `log_state` variable to `log_level` everywhere. `log_level` makes more sense as through this variable we are setting the log level for the `TARDIS` Logger. This allows for an intuitive understanding of the option available via the `run_tardis()` function.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->Renaming/Restructuring

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
