### PR TITLE
Moved Montecarlo Numba Logging Configuration to `debug.yaml`

### DIFF
--- a/tardis/io/schemas/debug.yml
+++ b/tardis/io/schemas/debug.yml
@@ -19,4 +19,17 @@ properties:
     type: boolean
     default: false
     description: Allows for logging on the specified logging levels
+  debug_packets:
+    type: boolean
+    default: false
+    description: Decide whether to go into debugging mode. [EXPERIMENTAL FEATURE DO NOT RELY ON IT]
+  logger_buffer:
+    type: number
+    default: 1
+    description: Provides option to not log every line.
+  single_packet_seed:
+    type:
+      - number
+    default: -1
+    description: If debug_packets is true, this is the seed for the only packet.
 

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -64,19 +64,6 @@ properties:
     default: false
     description: Enables a more complete treatment of relativitic effects. This includes
       angle aberration as well as use of the fully general Doppler formula.
-  debug_packets:
-    type: boolean
-    default: false
-    description: Decide whether to go into debugging mode. [EXPERIMENTAL FEATURE DO NOT RELY ON IT]
-  logger_buffer:
-    type: number
-    default: 1
-    description: Provides option to not log every line.
-  single_packet_seed:
-    type:
-      - number
-    default: -1
-    description: If debug_packets is true, this is the seed for the only packet.
 
 required:
 - no_of_packets

--- a/tardis/io/tests/data/tardis_configv1_verysimple.yml
+++ b/tardis/io/tests/data/tardis_configv1_verysimple.yml
@@ -47,3 +47,6 @@ spectrum:
     start: 500 angstrom
     stop: 20000 angstrom
     num: 10000
+
+debug:
+    specific: false

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -603,9 +603,9 @@ class MontecarloRunner(HDFWriterMixin):
             spectrum_method=config.spectrum.method,
             disable_electron_scattering=config.plasma.disable_electron_scattering,
             packet_source=packet_source,
-            debug_packets=config.montecarlo.debug_packets,
-            logger_buffer=config.montecarlo.logger_buffer,
-            single_packet_seed=config.montecarlo.single_packet_seed,
+            debug_packets=config.debug.debug_packets,
+            logger_buffer=config.debug.logger_buffer,
+            single_packet_seed=config.debug.single_packet_seed,
             virtual_packet_logging=(
                 config.spectrum.virtual.virtual_packet_logging
                 | virtual_packet_logging

--- a/tardis/montecarlo/montecarlo_numba/tests/test_base.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_base.py
@@ -14,6 +14,7 @@ from tardis.simulation import Simulation
 def test_montecarlo_radial1d():
     assert False
 
+
 def test_montecarlo_main_loop(
     config_verysimple,
     atomic_dataset,
@@ -21,7 +22,7 @@ def test_montecarlo_main_loop(
     tmpdir,
     set_seed_fixture,
     random_call_fixture,
-    request
+    request,
 ):
 
     montecarlo_configuration.LEGACY_MODE_ENABLED = True
@@ -30,18 +31,19 @@ def test_montecarlo_main_loop(
     config_verysimple.montecarlo.last_no_of_packets = 1e5
     config_verysimple.montecarlo.no_of_virtual_packets = 0
     config_verysimple.montecarlo.iterations = 1
-    config_verysimple.montecarlo.single_packet_seed = 0
-    config_verysimple.plasma.line_interaction_type = 'macroatom'
+    config_verysimple.debug.single_packet_seed = 0
+    config_verysimple.plasma.line_interaction_type = "macroatom"
     del config_verysimple["config_dirname"]
 
     sim = Simulation.from_config(config_verysimple, atom_data=atomic_data)
     sim.run()
 
-
-    compare_fname = os.path.join(tardis_ref_path, "montecarlo_1e5_compare_data.h5")
+    compare_fname = os.path.join(
+        tardis_ref_path, "montecarlo_1e5_compare_data.h5"
+    )
     if request.config.getoption("--generate-reference"):
         sim.to_hdf(compare_fname, overwrite=True)
-        
+
     # Load compare data from refdata
     expected_nu = pd.read_hdf(
         compare_fname, key="/simulation/runner/output_nu"
@@ -55,7 +57,6 @@ def test_montecarlo_main_loop(
     expected_j_estimator = pd.read_hdf(
         compare_fname, key="/simulation/runner/j_estimator"
     ).values
-
 
     actual_energy = sim.runner.output_energy
     actual_nu = sim.runner.output_nu

--- a/tardis/plasma/tests/data/config_init_trad.yml
+++ b/tardis/plasma/tests/data/config_init_trad.yml
@@ -77,3 +77,6 @@ spectrum:
   start: 500 angstrom
   stop: 20000 angstrom
   num: 10000
+
+debug:
+  specific: false

--- a/tardis/plasma/tests/data/plasma_base_test_config.yml
+++ b/tardis/plasma/tests/data/plasma_base_test_config.yml
@@ -40,3 +40,6 @@ spectrum:
     start: 500 angstrom
     stop: 20000 angstrom
     num: 10000
+
+debug:
+    specific: false

--- a/tardis/scripts/debug/tardis_example_single.yml
+++ b/tardis/scripts/debug/tardis_example_single.yml
@@ -20,15 +20,12 @@ montecarlo:
       damping_constant: 1.0
     threshold: 0.05
     type: damped
-  debug_packets: true
   iterations: 2
   last_no_of_packets: 1000000.0
-  logger_buffer: 1
   no_of_packets: 40000.0
   no_of_virtual_packets: 0
   nthreads: 6
   seed: 23111963
-  single_packet_seed: 46
 plasma:
   disable_electron_scattering: false
   excitation: lte
@@ -43,3 +40,7 @@ supernova:
   luminosity_requested: 9.44 log_lsun
   time_explosion: 10 day
 tardis_config_version: v1.0
+debug:
+  debug_packets: true
+  logger_buffer: 1
+  single_packet_seed: 46


### PR DESCRIPTION
This PR aims to move the Montecarlo Numba Configuration to `debug.yaml` to keep consistency. This moves all the debugging parameters in a single config yaml part of the TARDIS Config YAML.

Fix #1732 

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
