### PR TITLE
Reduce `damping_constant` under `t_inner` property in tardis_example.yml

### DIFF
--- a/docs/tardis_example.yml
+++ b/docs/tardis_example.yml
@@ -49,7 +49,7 @@ montecarlo:
     fraction: 0.8
     hold_iterations: 3
     t_inner:
-      damping_constant: 1.0
+      damping_constant: 0.5
 
 spectrum:
   start: 500 angstrom


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR reduces the `damping_constant` to 0.5 under the `t_inner` property in the tardis_example.yml file. 

**Description**
<!--- Describe your changes in detail -->
Reducing the `damping_constant` causes the simulation to converge faster, which looks better when the convergence plots show up. 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Fixes #1741 

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Before reducing `damping_constant`:
![image](https://user-images.githubusercontent.com/55894364/126140495-8b8895f4-c531-4aa5-bd07-4e4e84d0dd70.png)

After reducing `damping_constant`:
![image](https://user-images.githubusercontent.com/55894364/126140514-dcbe4756-7fdd-4444-93b7-73e1b8e9b0b4.png)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
