### PR TITLE
Changing Note Format in Visualization Notebooks

### DIFF
--- a/docs/io/visualization/generating_widgets.ipynb
+++ b/docs/io/visualization/generating_widgets.ipynb
@@ -580,17 +580,12 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**Important:** The virtual packet logging capability must be active in order to produce virtual packets' spectrum in `Line Info Widget`. Thus, make sure to set `virtual_packet_logging: True` in your configuration file. It should be added under `virtual` property of `spectrum` property, as described in [configuration schema](https://tardis-sn.github.io/tardis/using/components/configuration/configuration.html#spectrum).\n",
+    "Note\n",
+    "    \n",
+    "The virtual packet logging capability must be active in order to produce virtual packets' spectrum in `Line Info Widget`. Thus, make sure to set `virtual_packet_logging: True` in your configuration file. It should be added under `virtual` property of `spectrum` property, as described in [configuration schema](https://tardis-sn.github.io/tardis/using/components/configuration/configuration.html#spectrum).\n",
     "\n",
     "</div>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -609,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.10"
   },
   "notify_time": "5",
   "toc": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
This is a small PR that just changes how notes are rendered in markdown cells. This allows sphinx to render the notes as sphinx notes.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Docs built locally and on GitHub. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Here are the two pages being edited -- see how the notes look:
https://smithis7.github.io/tardis/branch/note_doc/io/visualization/generating_widgets.html
https://smithis7.github.io/tardis/branch/note_doc/io/visualization/sdec_plot.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
