### PR TITLE
Auto-Generating Tutorials Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ MANIFEST
 # Sphinx
 docs/api
 docs/_build
-docs/tutorials.rst
 
 # Eclipse editor project files
 .project
@@ -64,3 +63,6 @@ pip-wheel-metadata/
 
 # Mac OSX
 .DS_Store
+
+# Generated docs pages
+docs/tutorials.rst

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ MANIFEST
 # Sphinx
 docs/api
 docs/_build
+docs/tutorials.rst
 
 # Eclipse editor project files
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,3 @@ pip-wheel-metadata/
 
 # Mac OSX
 .DS_Store
-
-# Generated docs pages
-docs/tutorials.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -398,3 +398,26 @@ with open(zenodo_path, "w") as f:
     f.write(zenodo_record)
 
 print(zenodo_record)
+
+# -- Creating tutorials.rst ---------------------------------------------------
+
+notebook_list = []
+
+walk = os.walk("io/")
+
+for root, dirs, fnames in walk:
+    for fname in fnames:
+        if fname.endswith(".ipynb") and "checkpoint" not in fname:
+            notebook_list.append("* :doc:`" + root + "/" + fname[:-6] + "`")
+
+notebook_string = ""
+
+for notebook in notebook_list:
+    notebook_string += "\n" + notebook
+
+title = "Tutorials\n*********\n"
+
+description = "\nThe following pages contain the TARDIS tutorials:\n"
+
+with open("tutorials.rst", mode="wt", encoding="utf-8") as f:
+    f.write(title + description + notebook_string)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -399,6 +399,7 @@ with open(zenodo_path, "w") as f:
 
 print(zenodo_record)
 
+
 # -- Creating tutorials.rst ---------------------------------------------------
 
 notebook_list = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -402,23 +402,15 @@ print(zenodo_record)
 
 # -- Creating tutorials.rst ---------------------------------------------------
 
-notebook_list = []
+notebooks = ""
 
-walk = os.walk("io/")
-
-for root, dirs, fnames in walk:
+for root, dirs, fnames in os.walk("io/"):
     for fname in fnames:
         if fname.endswith(".ipynb") and "checkpoint" not in fname:
-            notebook_list.append("* :doc:`" + root + "/" + fname[:-6] + "`")
-
-notebook_string = ""
-
-for notebook in notebook_list:
-    notebook_string += "\n" + notebook
+            notebooks += "\n* :doc:`" + root + "/" + fname[:-6] + "`"
 
 title = "Tutorials\n*********\n"
-
 description = "\nThe following pages contain the TARDIS tutorials:\n"
 
 with open("tutorials.rst", mode="wt", encoding="utf-8") as f:
-    f.write(title + description + notebook_string)
+    f.write(title + description + notebooks)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,6 +325,7 @@ def to_html_ext(path):
     """Convert extension in the file path to .html"""
     return os.path.splitext(path)[0] + ".html"
 
+
 def generate_tutorials_page(app):
     notebooks = ""
 
@@ -338,6 +339,7 @@ def generate_tutorials_page(app):
 
     with open("tutorials.rst", mode="wt", encoding="utf-8") as f:
         f.write(f"{title}\n{description}\n{notebooks}")
+
 
 def autodoc_skip_member(app, what, name, obj, skip, options):
     """Exclude specific functions/methods from the documentation"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,6 +325,19 @@ def to_html_ext(path):
     """Convert extension in the file path to .html"""
     return os.path.splitext(path)[0] + ".html"
 
+def generate_tutorials_page(app):
+    notebooks = ""
+
+    for root, dirs, fnames in os.walk("io/"):
+        for fname in fnames:
+            if fname.endswith(".ipynb") and "checkpoint" not in fname:
+                notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
+
+    title = "Tutorials\n*********\n"
+    description = "The following pages contain the TARDIS tutorials:"
+
+    with open("tutorials.rst", mode="wt", encoding="utf-8") as f:
+        f.write(f"{title}\n{description}\n{notebooks}")
 
 def autodoc_skip_member(app, what, name, obj, skip, options):
     """Exclude specific functions/methods from the documentation"""
@@ -355,8 +368,8 @@ def create_redirect_files(app, docname):
             with open(old_html_fpath, "w") as f:
                 f.write(new_content)
 
-
 def setup(app):
+    app.connect("builder-inited", generate_tutorials_page)
     app.connect("autodoc-skip-member", autodoc_skip_member)
     app.connect("build-finished", create_redirect_files)
 
@@ -398,19 +411,3 @@ with open(zenodo_path, "w") as f:
     f.write(zenodo_record)
 
 print(zenodo_record)
-
-
-# -- Creating tutorials.rst ---------------------------------------------------
-
-notebooks = ""
-
-for root, dirs, fnames in os.walk("io/"):
-    for fname in fnames:
-        if fname.endswith(".ipynb") and "checkpoint" not in fname:
-            notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
-
-title = "Tutorials\n*********\n"
-description = "The following pages contain the TARDIS tutorials:"
-
-with open("tutorials.rst", mode="wt", encoding="utf-8") as f:
-    f.write(f"{title}\n{description}\n{notebooks}")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -407,10 +407,10 @@ notebooks = ""
 for root, dirs, fnames in os.walk("io/"):
     for fname in fnames:
         if fname.endswith(".ipynb") and "checkpoint" not in fname:
-            notebooks += "\n* :doc:`" + root + "/" + fname[:-6] + "`"
+            notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
 
 title = "Tutorials\n*********\n"
-description = "\nThe following pages contain the TARDIS tutorials:\n"
+description = "The following pages contain the TARDIS tutorials:"
 
 with open("tutorials.rst", mode="wt", encoding="utf-8") as f:
-    f.write(title + description + notebooks)
+    f.write(f"{title}\n{description}\n{notebooks}")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,8 @@ Mission Statement
 
     installation
     quickstart/quickstart
-
+    tutorials
+    API <api/modules>
 
 
 .. toctree::
@@ -103,14 +104,6 @@ Mission Statement
     development/index
     CHANGELOG.md
     roadmap
-
-.. toctree::
-    :maxdepth: 2
-    :caption: API
-    :hidden:
-
-    api/modules
-
 
 
 .. toctree::


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
I have created a script that, when we build the documentation, generates an rst file that links to all of the TARDIS tutorials. I probably have not implemented the most elegant way to run the script, so if anyone has a better way of getting it to run please let me know.

While I was changing the sidebar, I moved the API section in the sidebar. I thought it would be rather silly to make that a PR on its own, and it *vaguely* had to do with this PR. ~~I made it its own commit, however, so if I need to remove that commit I will. I also added `ZENODO.rst` to `.gitignore` while I was adding `tutorials.rst` to `.gitignore` for the same reason.~~

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
My goal was to create a page that lists all of the tutorials in TARDIS, which will automatically update when we add in a new tutorial (noting that all of our tutorials are under `docs/io`).

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Documentation built locally and on GitHub. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
See built documentation:
https://smithis7.github.io/tardis/branch/tutorials_doc/index.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
