### PR TITLE
Renamed `specific` log flag to `specific_log_level` 

### DIFF
--- a/docs/io/optional/logging_configuration.ipynb
+++ b/docs/io/optional/logging_configuration.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\")"
+    "sim = run_tardis(\"tardis_config_logger.yml\", show_cplots=False)"
    ]
   },
   {
@@ -96,7 +96,7 @@
    "id": "ac8d5088",
    "metadata": {},
    "source": [
-    "The `run_tardis()` function from the `tardis module` has two functional arguments:`log_level` & `specific`."
+    "The `run_tardis()` function from the `tardis module` has two functional arguments:`log_level` & `specific_log_level`."
    ]
   },
   {
@@ -105,7 +105,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\" role=\"alert\">\n",
-    "    Both <strong>log_level</strong> & <strong>specific</strong> are optional arguments for the <strong>run_tardis()</strong> function, however, if <strong>specific</strong> argument is used then, <strong>log_level</strong> must be set to a particular level.\n",
+    "    Both <strong>log_level</strong> & <strong>specific_log_level</strong> are optional arguments for the <strong>run_tardis()</strong> function, however, if <strong>specific_log_level</strong> argument is used then, <strong>log_level</strong> must be set to a particular level.\n",
     "</div>"
    ]
   },
@@ -134,7 +134,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Info\")"
+    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Info\", show_cplots=False)"
    ]
   },
   {
@@ -150,7 +150,7 @@
    "id": "25277fe8",
    "metadata": {},
    "source": [
-    "### `specific`"
+    "### `specific_log_level`"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "id": "56a5ef36",
    "metadata": {},
    "source": [
-    "The `specific` argument tells the logger to capture log messages set by the `log_level` parameter. It can only take *Boolean* values for input, which are `True` or `False`. Take for example the following:"
+    "The `specific_log_level` argument tells the logger to capture log messages set by the `log_level` parameter. It can only take *Boolean* values for input, which are `True` or `False`. Take for example the following:"
    ]
   },
   {
@@ -170,7 +170,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Debug\", specific=True)"
+    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Debug\", specific_log_level=True, show_cplots=False)"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "id": "5c6ff57c",
    "metadata": {},
    "source": [
-    "It can be examined that, when we set `specific` to `True`, the log messages captured were only at the `DEBUG` log level.<br> This allows for logging only specified logging messages for inspection."
+    "It can be examined that, when we set `specific_log_level` to `True`, the log messages captured were only at the `DEBUG` log level.<br> This allows for logging only specified logging messages for inspection."
    ]
   },
   {
@@ -186,7 +186,7 @@
    "id": "5083321b",
    "metadata": {},
    "source": [
-    "The changes in the captured log messages can be seen when we set `specific` to `False`."
+    "The changes in the captured log messages can be seen when we set `specific_log_level` to `False`."
    ]
   },
   {
@@ -198,7 +198,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Debug\", specific=False)"
+    "sim = run_tardis(\"tardis_config_logger.yml\", log_level=\"Debug\", specific_log_level=False, show_cplots=False)"
    ]
   },
   {
@@ -206,7 +206,7 @@
    "id": "42ddc98b",
    "metadata": {},
    "source": [
-    "It can be examined in this example that when we kept `specific` to `False`, the captured log output includes all log messages from `DEBUG` and higher logging levels, which is the default behavior of the logger."
+    "It can be examined in this example that when we kept `specific_log_level` to `False`, the captured log output includes all log messages from `DEBUG` and higher logging levels, which is the default behavior of the logger."
    ]
   },
   {
@@ -234,7 +234,7 @@
     "...\n",
     "debug:\n",
     "  log_level: \"Info\"\n",
-    "  specific : False\n",
+    "  specific_log_level : False\n",
     "```"
    ]
   },
@@ -243,7 +243,7 @@
    "id": "85ea7ae2",
    "metadata": {},
    "source": [
-    "The `debug` schema includes the `log_level` & `specific` parameters."
+    "The `debug` schema includes the `log_level` & `specific_log_level` parameters."
    ]
   },
   {
@@ -252,7 +252,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-info\" role=\"alert\">\n",
-    "    The <strong>debug</strong> section of the <strong>YAML</strong> config file is <i>optional</i>. The <strong>log_level</strong> and the <strong>specific</strong> arguments are <i>optional</i> as well. If none of the parameters are defined, then the values of these parameter fall back on the <strong>default values</strong>.\n",
+    "    The <strong>debug</strong> section of the <strong>YAML</strong> config file is <i>optional</i>. The <strong>log_level</strong> and the <strong>specific_log_level</strong> arguments are <i>optional</i> as well. If none of the parameters are defined, then the values of these parameter fall back on the <strong>default values</strong>.\n",
     "</div>"
    ]
   },
@@ -332,7 +332,7 @@
    "outputs": [],
    "source": [
     "# Running the simulation by passing the config dictionary to `run_tardis()` function\n",
-    "sim = run_tardis(config)"
+    "sim = run_tardis(config, show_cplots=False)"
    ]
   },
   {
@@ -340,7 +340,7 @@
    "id": "3fadc651",
    "metadata": {},
    "source": [
-    "### `specific`"
+    "### `specific_log_level`"
    ]
   },
   {
@@ -348,7 +348,7 @@
    "id": "df50d2e1",
    "metadata": {},
    "source": [
-    "The `specific` parameter in the `debug` section of the schema is similar in functionality to the `specific` functional argument. It takes **Boolean** values, i.e., `True` or `False`. It is an optional parameter. "
+    "The `specific_log_level` parameter in the `debug` section of the schema is similar in functionality to the `specific_log_level` functional argument. It takes **Boolean** values, i.e., `True` or `False`. It is an optional parameter. "
    ]
   },
   {
@@ -356,7 +356,7 @@
    "id": "b71946ad",
    "metadata": {},
    "source": [
-    "Let us see an example when we set `specific` to `True` at the `Debug` level."
+    "Let us see an example when we set `specific_log_level` to `True` at the `Debug` level."
    ]
   },
   {
@@ -367,7 +367,7 @@
    "outputs": [],
    "source": [
     "config[\"debug\"][\"log_level\"] = \"Debug\"\n",
-    "config[\"debug\"][\"specific\"] = True"
+    "config[\"debug\"][\"specific_log_level\"] = True"
    ]
   },
   {
@@ -377,7 +377,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = run_tardis(config)"
+    "sim = run_tardis(config, show_cplots=False)"
    ]
   },
   {
@@ -385,7 +385,7 @@
    "id": "3e895aec",
    "metadata": {},
    "source": [
-    "Setting `specific` to `False` to check the actual output at the `DEBUG` level for the simulation logs."
+    "Setting `specific_log_level` to `False` to check the actual output at the `DEBUG` level for the simulation logs."
    ]
   },
   {
@@ -395,7 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config[\"debug\"][\"specific\"] = False"
+    "config[\"debug\"][\"specific_log_level\"] = False"
    ]
   },
   {
@@ -407,7 +407,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(config)"
+    "sim = run_tardis(config,show_cplots=False)"
    ]
   },
   {
@@ -451,7 +451,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(config, log_level = \"Info\")"
+    "sim = run_tardis(config, log_level = \"Info\", show_cplots=False)"
    ]
   },
   {
@@ -472,7 +472,7 @@
    "id": "9ff806bd",
    "metadata": {},
    "source": [
-    "In regards to the `specific` parameter, if any of the config input value is `True`, then `specific` will be set to `True` for the simulation output."
+    "In regards to the `specific_log_level` parameter, if any of the config input value is `True`, then `specific_log_level` will be set to `True` for the simulation output."
    ]
   },
   {
@@ -484,7 +484,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(config, log_level = \"Info\", specific = True)"
+    "sim = run_tardis(config, log_level = \"Info\", specific_log_level = True, show_cplots=False)"
    ]
   }
  ],

--- a/docs/io/optional/tardis_config_logger.yml
+++ b/docs/io/optional/tardis_config_logger.yml
@@ -57,4 +57,4 @@ spectrum:
   num: 10000
 
 debug:
-  specific: False
+  specific_log_level: False

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -14,7 +14,7 @@ def run_tardis(
     virtual_packet_logging=False,
     show_cplots=True,
     log_level=None,
-    specific=None,
+    specific_log_level=None,
     **kwargs,
 ):
     """
@@ -45,11 +45,11 @@ def run_tardis(
         Set the level of the TARDIS logger (follows native python logging framework log levels).
         Use this parameter to override the `log_level` specified in the configuration file.
         The default value `None` means that the `log_level` specified in the configuration file will be used.
-    specific : bool, default: None, optional
+    specific_log_level : bool, default: None, optional
         Allows to set specific logging levels, overriding the value in the configuration file.
         If True, only show the log messages from a particular log level, set by `log_level`.
         If False, the logger shows log messages belonging to the level set and all levels above it in severity.
-        The default value None means that the `specific` specified in the configuration file will be used.
+        The default value None means that the `specific_log_level` specified in the configuration file will be used.
     show_cplots : bool, default: True, optional
         Option to enable tardis convergence plots.
     **kwargs : dict, optional
@@ -84,7 +84,7 @@ def run_tardis(
     if not isinstance(show_cplots, bool):
         raise TypeError("Expected bool in show_cplots argument")
 
-    logging_state(log_level, tardis_config, specific)
+    logging_state(log_level, tardis_config, specific_log_level)
 
     if atom_data is not None:
         try:

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -69,25 +69,27 @@ class FilterLog(object):
         return log_record.levelno == self.log_level
 
 
-def logging_state(log_level, tardis_config, specific):
+def logging_state(log_level, tardis_config, specific_log_level):
     """
     Function to set the logging configuration for the simulation output
     Called from within run_tardis()
-    Configured via functional arguments passed through run_tardis() - log_level & specific
-    Configured via YAML parameters under `debug` section - logging_level & specific_logging
+    Configured via functional arguments passed through run_tardis() - log_level & specific_log_level
+    Configured via YAML parameters under `debug` section - log_level & specific_log_level
 
     Parameters
     ----------
     log_level: str
         Allows to input the log level for the simulation
         Uses Python logging framework to determine the messages that will be output
-    specific: boolean
+    specific_log_level: boolean
         Allows to set specific logging levels. Logs of the `log_level` level would be output.
     """
 
     if "debug" in tardis_config:
-        specific = (
-            tardis_config["debug"]["specific"] if specific is None else specific
+        specific_log_level = (
+            tardis_config["debug"]["specific_log_level"]
+            if specific_log_level is None
+            else specific_log_level
         )
 
         logging_level = (
@@ -110,8 +112,8 @@ def logging_state(log_level, tardis_config, specific):
             tardis_config["debug"] = {"log_level": DEFAULT_LOG_LEVEL}
             logging_level = tardis_config["debug"]["log_level"]
 
-        if specific:
-            specific = specific
+        if specific_log_level:
+            specific_log_level = specific_log_level
 
     logging_level = logging_level.upper()
     if not logging_level in LOGGING_LEVELS:
@@ -134,7 +136,7 @@ def logging_state(log_level, tardis_config, specific):
             for logger in tardis_loggers:
                 logger.removeFilter(filter)
 
-    if specific:
+    if specific_log_level:
         filter_log = FilterLog(LOGGING_LEVELS[logging_level])
         for logger in tardis_loggers:
             logger.addFilter(filter_log)

--- a/tardis/io/logger/tests/test_logging.py
+++ b/tardis/io/logger/tests/test_logging.py
@@ -26,7 +26,7 @@ def test_logging_simulation(atomic_data_fname, caplog):
 
 # Testing Configuration of Logger via run_tardis() Function
 @pytest.mark.parametrize(
-    ["log_level", "specific"],
+    ["log_level", "specific_log_level"],
     [
         ("Info", False),
         ("INFO", False),
@@ -47,7 +47,7 @@ class TestSimulationLogging:
     """
 
     def test_logging_config(
-        self, atomic_data_fname, caplog, log_level, specific
+        self, atomic_data_fname, caplog, log_level, specific_log_level
     ):
         config = Configuration.from_yaml(
             "tardis/io/tests/data/tardis_configv1_verysimple_logger.yml"
@@ -55,45 +55,53 @@ class TestSimulationLogging:
         config["atom_data"] = atomic_data_fname
 
         caplog.clear()
-        run_tardis(config=config, log_level=log_level, specific=specific)
+        run_tardis(
+            config=config,
+            log_level=log_level,
+            specific_log_level=specific_log_level,
+        )
         for record in caplog.records:
-            if specific == True:
+            if specific_log_level == True:
                 assert record.levelno == LOGGING_LEVELS[log_level.upper()]
             else:
                 assert record.levelno >= LOGGING_LEVELS[log_level.upper()]
 
     def test_logging_config_yaml(
-        self, atomic_data_fname, caplog, log_level, specific
+        self, atomic_data_fname, caplog, log_level, specific_log_level
     ):
         config = Configuration.from_yaml(
             "tardis/io/tests/data/tardis_configv1_verysimple_logger.yml"
         )
         config["atom_data"] = atomic_data_fname
         config["debug"]["log_level"] = log_level
-        config["debug"]["specific"] = specific
+        config["debug"]["specific_log_level"] = specific_log_level
 
         caplog.clear()
         run_tardis(config=config)
         for record in caplog.records:
-            if specific == True:
+            if specific_log_level == True:
                 assert record.levelno == LOGGING_LEVELS[log_level.upper()]
             else:
                 assert record.levelno >= LOGGING_LEVELS[log_level.upper()]
 
     def test_logging_both_specified(
-        self, atomic_data_fname, caplog, log_level, specific
+        self, atomic_data_fname, caplog, log_level, specific_log_level
     ):
         config = Configuration.from_yaml(
             "tardis/io/tests/data/tardis_configv1_verysimple_logger.yml"
         )
         config["atom_data"] = atomic_data_fname
         config["debug"]["log_level"] = log_level
-        config["debug"]["specific"] = specific
+        config["debug"]["specific_log_level"] = specific_log_level
 
         caplog.clear()
-        run_tardis(config=config, log_level=log_level, specific=specific)
+        run_tardis(
+            config=config,
+            log_level=log_level,
+            specific_log_level=specific_log_level,
+        )
         for record in caplog.records:
-            if specific == True:
+            if specific_log_level == True:
                 assert record.levelno == LOGGING_LEVELS[log_level.upper()]
             else:
                 assert record.levelno >= LOGGING_LEVELS[log_level.upper()]

--- a/tardis/io/schemas/debug.yml
+++ b/tardis/io/schemas/debug.yml
@@ -15,7 +15,7 @@ properties:
           - "Warning"
           - "Error"
           - "Critical"
-  specific:
+  specific_log_level:
     type: boolean
     default: false
     description: Allows for logging on the specified logging levels

--- a/tardis/io/tests/data/tardis_configv1_verysimple_logger.yml
+++ b/tardis/io/tests/data/tardis_configv1_verysimple_logger.yml
@@ -43,4 +43,4 @@ spectrum:
     num: 10000
 
 debug:
-    specific: False
+    specific_log_level: False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The `specific` log flag has been rename to `specific_log_level` for clarity

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
