### PR TITLE
Changed the way `specific_log_level` flag works in the Logging Configuration

### DIFF
--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -102,15 +102,28 @@ def logging_state(log_level, tardis_config, specific_log_level):
             print(
                 "log_level is defined both in Functional Argument & YAML Configuration {debug section}"
             )
-            print(
-                f"log_level = {log_level.upper()} will be used for Log Level Determination\n"
+
+            logging_level = (
+                log_level if log_level else tardis_config["debug"]["log_level"]
             )
 
+            # Displays a message when both log_level & tardis["debug"]["log_level"] are specified
+            if log_level and tardis_config["debug"]["log_level"]:
+                print(
+                    "log_level is defined both in Functional Argument & YAML Configuration {debug section}"
+                )
+                print(
+                    f"log_level = {log_level.upper()} will be used for Log Level Determination\n"
+                )
+
     else:
+        # Adds empty `debug` section for the YAML
+        tardis_config["debug"] = {}
+
         if log_level:
             logging_level = log_level
         else:
-            tardis_config["debug"] = {"log_level": DEFAULT_LOG_LEVEL}
+            tardis_config["debug"]["log_level"] = DEFAULT_LOG_LEVEL
             logging_level = tardis_config["debug"]["log_level"]
 
         if specific_log_level:

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -30,6 +30,7 @@ LOGGING_LEVELS = {
     "CRITICAL": logging.CRITICAL,
 }
 DEFAULT_LOG_LEVEL = "CRITICAL"
+DEFAULT_SPECIFIC_STATE = False
 
 
 class FilterLog(object):

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -116,9 +116,7 @@ def logging_state(log_level, tardis_config, specific_log_level):
             tardis_config["debug"]["log_level"] = DEFAULT_LOG_LEVEL
             logging_level = tardis_config["debug"]["log_level"]
 
-        if specific_log_level:
-            specific_log_level = specific_log_level
-        else:
+        if not specific_log_level:
             tardis_config["debug"][
                 "specific_log_level"
             ] = DEFAULT_SPECIFIC_STATE

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -102,19 +102,9 @@ def logging_state(log_level, tardis_config, specific_log_level):
             print(
                 "log_level is defined both in Functional Argument & YAML Configuration {debug section}"
             )
-
-            logging_level = (
-                log_level if log_level else tardis_config["debug"]["log_level"]
+            print(
+                f"log_level = {log_level.upper()} will be used for Log Level Determination\n"
             )
-
-            # Displays a message when both log_level & tardis["debug"]["log_level"] are specified
-            if log_level and tardis_config["debug"]["log_level"]:
-                print(
-                    "log_level is defined both in Functional Argument & YAML Configuration {debug section}"
-                )
-                print(
-                    f"log_level = {log_level.upper()} will be used for Log Level Determination\n"
-                )
 
     else:
         # Adds empty `debug` section for the YAML
@@ -128,6 +118,11 @@ def logging_state(log_level, tardis_config, specific_log_level):
 
         if specific_log_level:
             specific_log_level = specific_log_level
+        else:
+            tardis_config["debug"][
+                "specific_log_level"
+            ] = DEFAULT_SPECIFIC_STATE
+            specific_log_level = tardis_config["debug"]["specific_log_level"]
 
     logging_level = logging_level.upper()
     if not logging_level in LOGGING_LEVELS:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The current implementation didn't cater to a bug that I have encountered recently. This PR aims to implement the functionality such that we are able to set the `specific` flag default value in the `debug` sub section of the `tardis_config.yml`.

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
