### PR TITLE
Rename cplots to convergence_plots

### DIFF
--- a/docs/io/visualization/convergence_plot.ipynb
+++ b/docs/io/visualization/convergence_plot.ipynb
@@ -13,9 +13,9 @@
    "id": "dc1a0c1f",
    "metadata": {},
    "source": [
-    "The Convergence Plots consist of two Plotly FigureWidget Subplots, the `plasma_plot` and the `t_inner_luminosities_plot`. The plots are stored in the `cplots` attribute of the simulation object `sim` and can be accessed using `sim.cplots.plasma_plot` and `sim.cplots.t_inner_luminosities_plot`.\n",
+    "The Convergence Plots consist of two Plotly FigureWidget Subplots, the `plasma_plot` and the `t_inner_luminosities_plot`. The plots are stored in the `convergence_plots` attribute of the simulation object `sim` and can be accessed using `sim.convergence_plots.plasma_plot` and `sim.convergence_plots.t_inner_luminosities_plot`.\n",
     "\n",
-    "The Convergence Plots are shown by default when you running TARDIS because `show_cplots` parameter of the `run_tardis()` function is set to `True`. If you don't want to do this, set it to `False`. "
+    "The Convergence Plots are shown by default when you running TARDIS because `show_convergence_plots` parameter of the `run_tardis()` function is set to `True`. If you don't want to do this, set it to `False`. "
    ]
   },
   {
@@ -27,7 +27,7 @@
     "\n",
     "Note\n",
     "    \n",
-    "You only need to include `export_cplots=True` in the `run_tardis` function when you want to share the notebook. The function shows the plot using the Plotly `notebook_connected` renderer, which helps display the plot online. You don't need to do it when running the notebook locally.\n",
+    "You only need to include `export_convergence_plots=True` in the `run_tardis` function when you want to share the notebook. The function shows the plot using the Plotly `notebook_connected` renderer, which helps display the plot online. You don't need to do it when running the notebook locally.\n",
     "\n",
     "</div>"
    ]
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "from tardis import run_tardis\n",
-    "sim = run_tardis('tardis_example.yml', export_cplots=True)"
+    "sim = run_tardis('tardis_example.yml', export_convergence_plots=True)"
    ]
   },
   {
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.cplots.plasma_plot.show(renderer=\"notebook_connected\")"
+    "sim.convergence_plots.plasma_plot.show(renderer=\"notebook_connected\")"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.cplots.t_inner_luminosities_plot.show(renderer=\"notebook_connected\")"
+    "sim.convergence_plots.t_inner_luminosities_plot.show(renderer=\"notebook_connected\")"
    ]
   },
   {
@@ -127,7 +127,7 @@
     "                         'rgb(248, 156, 116)',\n",
     "                         'rgb(220, 176, 242)',\n",
     "                         'rgb(135, 197, 95)'],\n",
-    "    export_cplots = True\n",
+    "    export_convergence_plots = True\n",
     ")"
    ]
   },
@@ -148,10 +148,10 @@
     "\n",
     "For sake of simplicity, all properties in the data dictionary are applied equally across all traces, meaning traces-specific properties can't be changed from the function. They however be changed after the simulation has finished, for example:\n",
     "```py\n",
-    "sim.cplots.t_inner_luminosities_plot.data[0].line.dash = \"dashdot\"\n",
+    "sim.convergence_plots.t_inner_luminosities_plot.data[0].line.dash = \"dashdot\"\n",
     "```\n",
     "\n",
-    "You can investigate more about the layout/data of any plots by calling `sim.cplots.t_inner_luminosities_plot.layout` or `sim.cplots.t_inner_luminosities_plot.data`. \n",
+    "You can investigate more about the layout/data of any plots by calling `sim.convergence_plots.t_inner_luminosities_plot.layout` or `sim.convergence_plots.t_inner_luminosities_plot.data`. \n",
     "\n",
     "Here is an example:"
    ]
@@ -195,7 +195,7 @@
     "            \n",
     "        },\n",
     "    },\n",
-    "    export_cplots = True)"
+    "    export_convergence_plots = True)"
    ]
   },
   {
@@ -214,7 +214,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -12,7 +12,7 @@ def run_tardis(
     packet_source=None,
     simulation_callbacks=[],
     virtual_packet_logging=False,
-    show_cplots=True,
+    show_convergence_plots=True,
     log_level=None,
     specific_log_level=None,
     **kwargs,
@@ -50,7 +50,7 @@ def run_tardis(
         If True, only show the log messages from a particular log level, set by `log_level`.
         If False, the logger shows log messages belonging to the level set and all levels above it in severity.
         The default value None means that the `specific_log_level` specified in the configuration file will be used.
-    show_cplots : bool, default: True, optional
+    show_convergence_plots : bool, default: True, optional
         Option to enable tardis convergence plots.
     **kwargs : dict, optional
         Optional keyword arguments including those
@@ -81,8 +81,8 @@ def run_tardis(
             )
             tardis_config = Configuration.from_config_dict(config)
 
-    if not isinstance(show_cplots, bool):
-        raise TypeError("Expected bool in show_cplots argument")
+    if not isinstance(show_convergence_plots, bool):
+        raise TypeError("Expected bool in show_convergence_plots argument")
 
     logging_state(log_level, tardis_config, specific_log_level)
 
@@ -100,7 +100,7 @@ def run_tardis(
         packet_source=packet_source,
         atom_data=atom_data,
         virtual_packet_logging=virtual_packet_logging,
-        show_cplots=show_cplots,
+        show_convergence_plots=show_convergence_plots,
         **kwargs,
     )
     for cb in simulation_callbacks:

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -99,7 +99,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
     luminosity_nu_start : astropy.units.Quantity
     luminosity_nu_end : astropy.units.Quantity
     luminosity_requested : astropy.units.Quantity
-    cplots_kwargs: dict
+    convergence_plots_kwargs: dict
     nthreads : int
         The number of threads to run montecarlo with
 
@@ -132,8 +132,8 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         luminosity_requested,
         convergence_strategy,
         nthreads,
-        show_cplots,
-        cplots_kwargs,
+        show_convergence_plots,
+        convergence_plots_kwargs,
     ):
 
         super(Simulation, self).__init__(iterations, model.no_of_shells)
@@ -168,17 +168,17 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 f"- input is {convergence_strategy.type}"
             )
 
-        if show_cplots:
-            self.cplots = ConvergencePlots(
-                iterations=self.iterations, **cplots_kwargs
+        if show_convergence_plots:
+            self.convergence_plots = ConvergencePlots(
+                iterations=self.iterations, **convergence_plots_kwargs
             )
 
-            if "export_cplots" in cplots_kwargs:
-                if not isinstance(cplots_kwargs["export_cplots"], bool):
-                    raise TypeError("Expected bool in export_cplots argument")
-                self.export_cplots = cplots_kwargs["export_cplots"]
+            if "export_convergence_plots" in convergence_plots_kwargs:
+                if not isinstance(convergence_plots_kwargs["export_convergence_plots"], bool):
+                    raise TypeError("Expected bool in export_convergence_plots argument")
+                self.export_convergence_plots = convergence_plots_kwargs["export_convergence_plots"]
             else:
-                self.export_cplots = False
+                self.export_convergence_plots = False
 
         self._callbacks = OrderedDict()
         self._cb_next_id = 0
@@ -307,19 +307,19 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         else:
             next_t_inner = self.model.t_inner
 
-        if hasattr(self, "cplots"):
-            self.cplots.fetch_data(
+        if hasattr(self, "convergence_plots"):
+            self.convergence_plots.fetch_data(
                 name="t_inner",
                 value=self.model.t_inner.value,
                 item_type="value",
             )
-            self.cplots.fetch_data(
+            self.convergence_plots.fetch_data(
                 name="t_rad", value=self.model.t_rad, item_type="iterable"
             )
-            self.cplots.fetch_data(
+            self.convergence_plots.fetch_data(
                 name="w", value=self.model.w, item_type="iterable"
             )
-            self.cplots.fetch_data(
+            self.convergence_plots.fetch_data(
                 name="velocity", value=self.model.velocity, item_type="iterable"
             )
 
@@ -377,18 +377,18 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         reabsorbed_luminosity = self.runner.calculate_reabsorbed_luminosity(
             self.luminosity_nu_start, self.luminosity_nu_end
         )
-        if hasattr(self, "cplots"):
-            self.cplots.fetch_data(
+        if hasattr(self, "convergence_plots"):
+            self.convergence_plots.fetch_data(
                 name="Emitted",
                 value=emitted_luminosity.value,
                 item_type="value",
             )
-            self.cplots.fetch_data(
+            self.convergence_plots.fetch_data(
                 name="Absorbed",
                 value=reabsorbed_luminosity.value,
                 item_type="value",
             )
-            self.cplots.fetch_data(
+            self.convergence_plots.fetch_data(
                 name="Requested",
                 value=self.luminosity_requested.value,
                 item_type="value",
@@ -413,8 +413,8 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             )
             self.iterate(self.no_of_packets)
             self.converged = self.advance_state()
-            if hasattr(self, "cplots"):
-                self.cplots.update()
+            if hasattr(self, "convergence_plots"):
+                self.convergence_plots.update()
             self._call_back()
             if self.converged:
                 if self.convergence_strategy.stop_if_converged:
@@ -432,13 +432,13 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         )
 
         self.reshape_plasma_state_store(self.iterations_executed)
-        if hasattr(self, "cplots"):
-            self.cplots.fetch_data(
+        if hasattr(self, "convergence_plots"):
+            self.convergence_plots.fetch_data(
                 name="t_inner",
                 value=self.model.t_inner.value,
                 item_type="value",
             )
-            self.cplots.update(export_cplots=self.export_cplots, last=True)
+            self.convergence_plots.update(export_convergence_plots=self.export_convergence_plots, last=True)
 
         logger.info(
             f"Simulation finished in {self.iterations_executed:d} iterations "
@@ -582,7 +582,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         config,
         packet_source=None,
         virtual_packet_logging=False,
-        show_cplots=True,
+        show_convergence_plots=True,
         **kwargs,
     ):
         """
@@ -629,16 +629,16 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 virtual_packet_logging=virtual_packet_logging,
             )
 
-        cplots_config_options = [
+        convergence_plots_config_options = [
             "plasma_plot_config",
             "t_inner_luminosities_config",
             "plasma_cmap",
             "t_inner_luminosities_colors",
-            "export_cplots",
+            "export_convergence_plots",
         ]
-        cplots_kwargs = {}
-        for item in set(cplots_config_options).intersection(kwargs.keys()):
-            cplots_kwargs[item] = kwargs[item]
+        convergence_plots_kwargs = {}
+        for item in set(convergence_plots_config_options).intersection(kwargs.keys()):
+            convergence_plots_kwargs[item] = kwargs[item]
 
         luminosity_nu_start = config.supernova.luminosity_wavelength_end.to(
             u.Hz, u.spectral()
@@ -663,7 +663,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             model=model,
             plasma=plasma,
             runner=runner,
-            show_cplots=show_cplots,
+            show_convergence_plots=show_convergence_plots,
             no_of_packets=int(config.montecarlo.no_of_packets),
             no_of_virtual_packets=int(config.montecarlo.no_of_virtual_packets),
             luminosity_nu_start=luminosity_nu_start,
@@ -672,5 +672,5 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             luminosity_requested=config.supernova.luminosity_requested.cgs,
             convergence_strategy=config.montecarlo.convergence_strategy,
             nthreads=config.montecarlo.nthreads,
-            cplots_kwargs=cplots_kwargs,
+            convergence_plots_kwargs=convergence_plots_kwargs,
         )

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -174,9 +174,15 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             )
 
             if "export_convergence_plots" in convergence_plots_kwargs:
-                if not isinstance(convergence_plots_kwargs["export_convergence_plots"], bool):
-                    raise TypeError("Expected bool in export_convergence_plots argument")
-                self.export_convergence_plots = convergence_plots_kwargs["export_convergence_plots"]
+                if not isinstance(
+                    convergence_plots_kwargs["export_convergence_plots"], bool
+                ):
+                    raise TypeError(
+                        "Expected bool in export_convergence_plots argument"
+                    )
+                self.export_convergence_plots = convergence_plots_kwargs[
+                    "export_convergence_plots"
+                ]
             else:
                 self.export_convergence_plots = False
 
@@ -438,7 +444,10 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 value=self.model.t_inner.value,
                 item_type="value",
             )
-            self.convergence_plots.update(export_convergence_plots=self.export_convergence_plots, last=True)
+            self.convergence_plots.update(
+                export_convergence_plots=self.export_convergence_plots,
+                last=True,
+            )
 
         logger.info(
             f"Simulation finished in {self.iterations_executed:d} iterations "
@@ -637,7 +646,9 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             "export_convergence_plots",
         ]
         convergence_plots_kwargs = {}
-        for item in set(convergence_plots_config_options).intersection(kwargs.keys()):
+        for item in set(convergence_plots_config_options).intersection(
+            kwargs.keys()
+        ):
             convergence_plots_kwargs[item] = kwargs[item]
 
         luminosity_nu_start = config.supernova.luminosity_wavelength_end.to(

--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -56,7 +56,7 @@ class ConvergencePlots(object):
     t_inner_luminosities_colors : str or list, optional
         String defining cmap for luminosity and inner boundary temperature plot.
         The list can be a list of colors in rgb, hex or css-names format as well.
-    export_cplots : bool, default: False, optional
+    export_convergence_plots : bool, default: False, optional
         If True, plots are displayed again using the `notebook_connected` renderer. This helps
         to display the plots in the documentation or in platforms like nbviewer.
 
@@ -390,13 +390,13 @@ class ConvergencePlots(object):
                 4
             ].hovertemplate = "<b>%{y:.2f}%</b> at X = %{x:,.0f}"
 
-    def update(self, export_cplots=False, last=False):
+    def update(self, export_convergence_plots=False, last=False):
         """
         Update the convergence plots every iteration.
 
         Parameters
         ----------
-        export_cplots : bool, default: False, optional
+        export_convergence_plots : bool, default: False, optional
             Displays the convergence plots again using plotly's `notebook_connected` renderer.
             This helps to display the plots in notebooks when shared on platforms like nbviewer.
             Please see https://plotly.com/python/renderers/ for more information.
@@ -423,7 +423,7 @@ class ConvergencePlots(object):
 
         # the display function expects a Widget, while
         # fig.show() returns None, which causes the TraitError.
-        if export_cplots:
+        if export_convergence_plots:
             with suppress(TraitError):
                 display(
                     widgets.VBox(

--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -12,9 +12,9 @@ from astropy import units as u
 @pytest.fixture(scope="module", params=[0, 1, 2])
 def convergence_plots(request):
     """Initialize ConvergencePlots class and build empty plots."""
-    cplots = ConvergencePlots(iterations=request.param)
-    cplots.build(display_plot=False)
-    return cplots
+    convergence_plots = ConvergencePlots(iterations=request.param)
+    convergence_plots.build(display_plot=False)
+    return convergence_plots
 
 
 @pytest.fixture()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR renames `cplots` to  `convergence_plots` everywhere in the code.

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
To verify, please check [this](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/atharva-2001/tardis%24%40rename_cplots+cplots&patternType=literal) and [this](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/atharva-2001/tardis%24%40rename_cplots+convergence_plots&patternType=literal).

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [X] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [X] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
