### PR TITLE
Reverse legend in Plasma Convergence Plots

### DIFF
--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -162,6 +162,7 @@ class ConvergencePlots(object):
             },
             height=450,
             legend_title_text="Iterations",
+            legend_traceorder="reversed",
             margin=dict(
                 l=10, r=135, b=25, t=25, pad=0
             ),  # reduce whitespace surrounding the plot and increase right indentation to align with the t_inner and luminosity plot


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR reverses the order of legends in Plasma Convergence plots so that the recent-most iteration shows up first. 

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->


**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
![Peek 2021-08-06 17-48](https://user-images.githubusercontent.com/55894364/128509597-adddfce9-72cc-4c5f-98f5-8d23f1e72e50.gif)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [X] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [X] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
