### PR TITLE
Fix Hover Data in Plasma Convergence Plots

### DIFF
--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -316,13 +316,13 @@ class ConvergencePlots(object):
         customdata = len(x) * [
             "<br>"
             + "Emitted Luminosity: "
-            + f'{self.value_data["Absorbed"][-1]:.4g}'
+            + f'{self.value_data["Emitted"][-1]:.4g}'
             + "<br>"
             + "Requested Luminosity: "
             + f'{self.value_data["Requested"][-1]:.4g}'
             + "<br>"
             + "Absorbed Luminosity: "
-            + f'{self.value_data["Requested"][-1]:.4g}'
+            + f'{self.value_data["Absorbed"][-1]:.4g}'
         ]
 
         # add a radiation temperature vs shell velocity trace to the plasma plot


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The hover data in plasma plots did not show luminosity data correctly. This fixes that.

**Description**
<!--- Describe your changes in detail -->
This PR fixes this data:
![image](https://user-images.githubusercontent.com/55894364/129372305-90660aa5-e8bc-4ef2-8ff3-2f8ff5c9d107.png)


**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [X] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
