### PR TITLE
Add cmap option to specify the colormap of plot

### DIFF
--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -654,10 +654,9 @@ class CustomAbundanceWidget:
             self.fig.data[0].x = x
             width[0] = x_outer - x_inner
             self.fig.data[0].width = width
-    
+
     def update_line_color(self):
-        """Update line color in the plot according to colormap.
-        """
+        """Update line color in the plot according to colormap."""
         colorscale = transition_colors(self.no_of_elements, self.plot_cmap)
         for i in range(self.no_of_elements):
             self.fig.data[2 + i].line.color = colorscale[i]
@@ -1244,7 +1243,7 @@ class CustomAbundanceWidget:
         ipywidgets.widgets.widget_box.VBox
             A box that contains all the widgets in the GUI.
         """
-        #--------------Combine widget components--------------
+        # --------------Combine widget components--------------
         self.box_editor = ipw.HBox(
             [
                 ipw.VBox(self.input_items),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR aims to allow the user to set specific color scale in the plot.
This should be merged after restructuring (#1777). Please see the changes in commit 2bc2e69.

**Description**
<!--- Describe your changes in detail -->
- Add `cmap` option to `display()` method - It requires a string to specify the name of the color map. The default color scale is 'jet'.
- Add `plot_cmap` attribute to widget class because the colormap string is also used in add element method.
- Add docstrings for new attributes.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Default color scale:
<img width="726" alt="截屏2021-08-20 上午12 18 52" src="https://user-images.githubusercontent.com/80535029/130108622-1055bfab-ac81-446a-94d1-6fe6b38374fe.png">

Custom color scale:
<img width="679" alt="截屏2021-08-20 上午12 19 33" src="https://user-images.githubusercontent.com/80535029/130108743-021cf83f-9093-4245-9cd8-d61936be50da.png">

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
