### PR TITLE
fix zenodo pipeline (2nd)

### DIFF
--- a/.github/workflows/update-zenodo-json.yml
+++ b/.github/workflows/update-zenodo-json.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: 3.6
 
       - name: Install Packages
-        run: pip install pandas==1.0.5 jupyter-client==6.1.2 nbconvert==5.3.1 tornado==4.2 orcid
+        run: pip install pandas==1.0.5 jupyter==1.0.0 jupyter-client==6.1.2 nbconvert==5.3.1 tornado==4.2 orcid
 
       - name: Run Notebook
         run: jupyter nbconvert gather_data.ipynb --to html --execute --ExecutePreprocessor.timeout=6000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

Add explicit `jupyter` dependency again.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

See #1787.

This pipeline can't be tested through a PR, because uses a secret token to clone the secret repository and that token is not shared with pull requests. That's make it hard to debug.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
