### PR TITLE
disable changelog in release pipeline

### DIFF
--- a/.azure-pipelines/release-version.yml
+++ b/.azure-pipelines/release-version.yml
@@ -62,4 +62,5 @@ jobs:
           title: 'TARDIS v$(newtag)'
           releaseNotesSource: 'inline'
           releaseNotes: 'This release has been made automatically through our continous delivery pipeline. For a complete list of changes see [CHANGELOG.md](https://github.com/tardis-sn/tardis/blob/master/CHANGELOG.md).'
+          addChangeLog: false
         displayName: 'Create GitHub Release'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

One of the changes of #1775 was to keep a unique changelog, keeping the `github-changes` npm package over the one from the Azure Release Task. But it's still present in the release body description.

The release task does not work as described in [Azure docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azure-devops#arguments) (again). `addChangelog` is said to be optional, but keeps appearing after removing from the configuration schema:

```
(Optional)  If set to true, a list of changes (commits and issues) between this and the last published release will be 
generated and appended to release notes.
```

Anyway, the release notes are not appended. I think it's worth trying to explicitly remove the `addChangelog` option, but probably the problem is on Azure's side.

Opened an issue there: https://github.com/MicrosoftDocs/azure-devops-docs/issues/11256

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots, and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
