### PR TITLE
Change virtual spectrum spawn range start value to 1

### DIFF
--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -39,7 +39,7 @@ properties:
     properties:
       start:
         type: quantity
-        default: 0 angstrom
+        default: 1 angstrom
       end:
         type: quantity
         default: inf angstrom


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR fixes the following warning:
```py
[py.warnings][WARNING]  /home/atharva/miniconda3/envs/tardis/lib/python3.7/site-packages/astropy/units/equivalencies.py:124: RuntimeWarning: divide by zero encountered in double_scalars
  (si.m, si.Hz, lambda x: _si.c.value / x),
 (warnings.py:110)
```
by setting the `virtual_spectrum_spawn_range` in the montecarlo.yml file from 0 to 1.

**Description**
<!--- Describe your changes in detail -->
The error is caused due to [these lines](https://github.com/tardis-sn/tardis/blob/6a0b8db607b87d91ef8312906758f7d380103b47/tardis/montecarlo/montecarlo_numba/numba_interface.py#L355-L359) as mentioned [here](https://github.com/tardis-sn/tardis/issues/1724) 
```
    montecarlo_configuration.v_packet_spawn_end_frequency = (
        runner.virtual_spectrum_spawn_range.start.to(
            u.Hz, equivalencies=u.spectral()
        ).value
    )
```
because we are converting wavelength to frequency and the wavelength is zero. Any other number apart from 0 here should fix the warning. 
The same warning can be replicated using this code: 
```py
import astropy.units as u
a = 0 * u.AA
a.to(u.Hz, equivalencies=u.spectral()).value
```

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Resolves #1724 

**How has this been tested?**
- [X] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Removing this warning also allows progress bars to update seamlessly in the console, without having to disable the warnings. Earlier the console output was something like this:
![image](https://user-images.githubusercontent.com/55894364/132820688-3dc80f91-22fd-4050-a8b7-a014228a7a5f.png)

Now the progress bars update seamlessly because the warning is not displayed with each iteration. 

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
