### PR TITLE
Cleaning up docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ MANIFEST
 # Sphinx
 docs/api
 docs/_build
+docs/ZENODO.rst
+docs/tutorials.rst
+docs/io/configuration/components/models/converters/density_parse.csv
+docs/io/configuration/components/models/converters/abund_parse.csv
 
 # Eclipse editor project files
 .project


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- Generates `ZENODO.rst` by hooking into sphinx.
- Adds generated files to `.gitignore`.
- Formatting `conf.py` with black.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Makes sure TARDIS is following best practices. See the discussion on #1757 for more context.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Docs built locally and on github.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
https://smithis7.github.io/tardis/branch/conf_format_doc/index.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->
Formatting.

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
