### PR TITLE
Option to make docs build in parallel

### DIFF
--- a/.github/workflows/documentation-build.yml
+++ b/.github/workflows/documentation-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build Sphinx Documentation
         shell: bash -l {0}
-        run: cd docs/; make html
+        run: cd docs/; make html CORES=auto
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/documentation-preview.yml
+++ b/.github/workflows/documentation-preview.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build documentation
         shell: bash -l {0}
-        run: cd docs/; make html
+        run: cd docs/; make html CORES=auto
 
       - name: Extract branch name
         shell: bash

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,7 +41,7 @@ clean:
 	-rm -rf generated
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j auto
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+CORES         = 1
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -41,7 +42,7 @@ clean:
 	-rm -rf generated
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j auto
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j $(CORES)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -31,7 +31,7 @@ To build TARDIS documentation locally, use the following commands:
 
     - If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
     - Use ``DISABLE_NBSPHINX=1 make html`` to disable notebook rendering (fast mode).
-    - Use ``make html CORES=<number of cores>`` to have the documentation build in parallel. Using ``make html CORES=auto`` uses all of your device's cores.
+    - Use ``make html CORES=<number of cores>`` to have the documentation build in parallel. Using ``make html CORES=auto`` instructs Sphinx to use all of your device's cores.
 
 After running this command, you can find the built docs (i.e. HTML webpages) in ``docs/_build/html``. Open the ``index.html`` in your browser to see how the documentation looks like with your edits. Navigate to page where you made changes or file that you added to check whether it looks as intended or not.
 

--- a/docs/development/documentation_guidelines.rst
+++ b/docs/development/documentation_guidelines.rst
@@ -31,6 +31,7 @@ To build TARDIS documentation locally, use the following commands:
 
     - If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
     - Use ``DISABLE_NBSPHINX=1 make html`` to disable notebook rendering (fast mode).
+    - Use ``make html CORES=<number of cores>`` to have the documentation build in parallel. Using ``make html CORES=auto`` uses all of your device's cores.
 
 After running this command, you can find the built docs (i.e. HTML webpages) in ``docs/_build/html``. Open the ``index.html`` in your browser to see how the documentation looks like with your edits. Navigate to page where you made changes or file that you added to check whether it looks as intended or not.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
See https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j

Now, `make html` allows a `CORES` argument to let you build the documentation in parallel. In the GitHub pipelines, we use `CORES=auto` which makes the documentation build with all available cores.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
The documentation build is very slow.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Documentation built locally and on GitHub.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Compare https://github.com/tardis-sn/tardis/actions/runs/1381526801 with https://github.com/smithis7/tardis/actions/runs/1387845143.

See the note: https://smithis7.github.io/tardis/branch/speed_up_doc/development/documentation_guidelines.html

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
