### PR TITLE
corrected the typos 'balenced out' and 'eatimators'

### DIFF
--- a/docs/physics/est_and_conv/index.rst
+++ b/docs/physics/est_and_conv/index.rst
@@ -10,13 +10,13 @@ interactions as well as the presence of extra energy from the light. Additionall
 both affect each other on different ways) frequently occur in physics. The solution is finding a steady-state for
 the plasma properties; that is, the actual plasma will be in a state such that the plasma state will not change as
 light propagates through it, because the effects of the light on the plasma and the effects of the plasma on the
-light have been "balenced out."
+light have been "balanced out."
 
 One of TARDIS's main goals is to determine this plasma state (as we need the actual plasma properties in order to
 get an accurate spectrum). This is done in an iterative process. After each :ref:`Monte Carlo iteration
 <montecarlo>` (which sends light through the supernova ejecta), TARDIS uses objects called estimators to determine
 how the propagating light affects the plasma state, after which the plasma state is updated (as will be demonstrated
-in the eatimators page linked below). We do this many times, and attempt to have the plasma state converge
+in the estimators page linked below). We do this many times, and attempt to have the plasma state converge
 to the steady-state we are looking for. In fact, all but the last Monte Carlo iteration is used for this purpose
 (after which TARDIS will have the needed plasma state for its last iteration which calculates the spectrum).
 


### PR DESCRIPTION
<!--Corrected 2 typos -->

**Description**
<!--- There were 2 typos in index.rst  file in est_and_conv folder from physics subfolder of docs -->

**Motivation and context**
<!--- It helps the user to understand the Estimators and Convergence¶ section clearly -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x ] None of the above. <!-- The change is regarding the correction of typos -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [  ] I have assigned and requested two reviewers for this pull request.
