### PR TITLE
Fixing broken documentation

### DIFF
--- a/docs/io/visualization/convergence_plot.ipynb
+++ b/docs/io/visualization/convergence_plot.ipynb
@@ -48,7 +48,7 @@
     "download_atom_data('kurucz_cd23_chianti_H_He')\n",
     "\n",
     "# We run a simulation\n",
-    "sim = run_tardis('tardis_example.yml', export_cplots=True)"
+    "sim = run_tardis('tardis_example.yml', export_convergence_plots=True)"
    ]
   },
   {

--- a/docs/io/visualization/sdec_plot.ipynb
+++ b/docs/io/visualization/sdec_plot.ipynb
@@ -320,7 +320,7 @@
     "\n",
     "observed_spectrum_wavelength, observed_spectrum_flux = data.T\n",
     "observed_spectrum_wavelength = observed_spectrum_wavelength * u.AA\n",
-    "observed_spectrum_flux = observed_spectrum_flux *   u.erg / (u.s * u.cm**2 * u.AA)"
+    "observed_spectrum_flux = observed_spectrum_flux * u.erg / (u.s * u.cm**2 * u.AA)"
    ]
   },
   {
@@ -426,7 +426,7 @@
    },
    "outputs": [],
    "source": [
-    "plotter.generate_plot_ply()"
+    "#plotter.generate_plot_ply()"
    ]
   },
   {
@@ -447,7 +447,7 @@
    },
    "outputs": [],
    "source": [
-    "plotter.generate_plot_ply(packets_mode=\"real\")"
+    "#plotter.generate_plot_ply(packets_mode=\"real\")"
    ]
   },
   {
@@ -561,7 +561,7 @@
    "outputs": [],
    "source": [
     "# Interactive plot with virtual packets mode\n",
-    "hdf_plotter.generate_plot_ply()"
+    "#hdf_plotter.generate_plot_ply()"
    ]
   }
  ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- Has documentation reflect change from `export_cplot` to `export_convergence_plot`
- Comments out some plots in the SDEC notebook. **THIS IS A TEMPORARY FIX!!!!** The current page is too large which breaks the documentation build. We need to figure out a way to fix this, but this PR will just make it so the documentation will build while we figure out what to do with the SDEC notebook.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Docs build: https://github.com/smithis7/tardis/actions/runs/1340003382

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
