### PR TITLE
filter deprecation warnings (pytest)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ astropy_header = true
 # doctest_plus = disabled
 text_file_format = rst
 # addopts = --doctest
+filterwarnings =
+    ignore::DeprecationWarning
 
 # The following coverage configuration works only with `tox`. We keep our 
 # coverage configuration in `.coveragerc`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Filter deprecation warnings in `pytest` output.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Improves readability. The main idea behind keeping the deprecation warnings was to fix them before those changes break the package, but nobody is currently doing that.

NOTE: before migrating to the new AstroPy package template we used `addopts = -p no:warnings` that suppressed ALL warnings.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
