### PR TITLE
remove numexpr 

### DIFF
--- a/tardis/plasma/properties/ion_population.py
+++ b/tardis/plasma/properties/ion_population.py
@@ -4,7 +4,6 @@ import warnings
 import sys
 import numpy as np
 import pandas as pd
-import numexpr as ne
 
 from scipy import interpolate
 

--- a/tardis/plasma/properties/radiative_properties.py
+++ b/tardis/plasma/properties/radiative_properties.py
@@ -2,7 +2,6 @@ import logging
 
 import numpy as np
 import pandas as pd
-import numexpr as ne
 from astropy import units as u
 from tardis import constants as const
 from numba import jit, prange
@@ -89,7 +88,9 @@ class StimulatedEmissionFactor(ProcessingPlasmaProperty):
             metastability, lines_upper_level_index
         )
 
-        stimulated_emission_factor = 1 - ((g_lower * n_upper) / (g_upper * n_lower))
+        stimulated_emission_factor = 1 - (
+            (g_lower * n_upper) / (g_upper * n_lower)
+        )
         stimulated_emission_factor[n_lower == 0.0] = 0.0
         stimulated_emission_factor[
             np.isneginf(stimulated_emission_factor)


### PR DESCRIPTION
Many years ago - I used `numexpr` to speed up calculations - I don't think this is needed anymore. 