### PR TITLE
Disable Convergence Plots by default

### DIFF
--- a/tardis/base.py
+++ b/tardis/base.py
@@ -12,10 +12,10 @@ def run_tardis(
     packet_source=None,
     simulation_callbacks=[],
     virtual_packet_logging=False,
-    show_convergence_plots=True,
+    show_convergence_plots=False,
     log_level=None,
     specific_log_level=None,
-    show_progress_bars=True,
+    show_progress_bars=False,
     **kwargs,
 ):
     """
@@ -51,9 +51,9 @@ def run_tardis(
         If True, only show the log messages from a particular log level, set by `log_level`.
         If False, the logger shows log messages belonging to the level set and all levels above it in severity.
         The default value None means that the `specific_log_level` specified in the configuration file will be used.
-    show_convergence_plots : bool, default: True, optional
+    show_convergence_plots : bool, default: False, optional
         Option to enable tardis convergence plots.
-    show_progress_bars : bool, default: True, optional
+    show_progress_bars : bool, default: False, optional
         Option to enable the progress bar.
     **kwargs : dict, optional
         Optional keyword arguments including those

--- a/tardis/base.py
+++ b/tardis/base.py
@@ -15,7 +15,7 @@ def run_tardis(
     show_convergence_plots=False,
     log_level=None,
     specific_log_level=None,
-    show_progress_bars=False,
+    show_progress_bars=True,
     **kwargs,
 ):
     """
@@ -53,7 +53,7 @@ def run_tardis(
         The default value None means that the `specific_log_level` specified in the configuration file will be used.
     show_convergence_plots : bool, default: False, optional
         Option to enable tardis convergence plots.
-    show_progress_bars : bool, default: False, optional
+    show_progress_bars : bool, default: True, optional
         Option to enable the progress bar.
     **kwargs : dict, optional
         Optional keyword arguments including those


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Disable progress bars and convergence plots by default. The log level is changed in https://github.com/tardis-sn/tardis/pull/1843. 

**Description**
<!--- Describe your changes in detail -->


**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
