### PR TITLE
 changed all files to import constants from only tardis

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -131,6 +131,8 @@ Ran Livneh <ran.livneh@weizmann.ac.il> Ran Livneh <livnehra@gmail.com>
 
 Sampark Sharma <samparksharma2000@gmail.com>
 
+Shilpi Prasad <shilpiprd@gmail.com>
+
 Sourav Singh <souravsingh@users.noreply.github.com>
 
 Srinath Rajagopalan <srinath132@gmail.com>

--- a/docs/physics/pyplot/plot_mu_in_out_packet.py
+++ b/docs/physics/pyplot/plot_mu_in_out_packet.py
@@ -1,5 +1,6 @@
 from pylab import *
-from astropy import units as u, constants as const
+from astropy import units as u
+from tardis import constants as const
 
 x, y = x, y = mgrid[1:1000, 1:1000]
 mu_in = x / 500.0 - 1

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -13,7 +13,7 @@ import requests
 import yaml
 from tqdm.auto import tqdm
 
-from tardis import constants
+from tardis import constants as const
 from astropy import units as u
 
 from tardis import __path__ as TARDIS_PATH
@@ -49,12 +49,12 @@ def quantity_from_str(text):
     value_str, unit_str = text.split(None, 1)
     value = float(value_str)
     if unit_str.strip() == "log_lsun":
-        value = 10 ** (value + np.log10(constants.L_sun.cgs.value))
+        value = 10 ** (value + np.log10(const.L_sun.cgs.value))
         unit_str = "erg/s"
 
     unit = u.Unit(unit_str)
     if unit == u.L_sun:
-        return value * constants.L_sun
+        return value * const.L_sun
 
     return u.Quantity(value, unit_str)
 

--- a/tardis/montecarlo/tests/test_spectrum.py
+++ b/tardis/montecarlo/tests/test_spectrum.py
@@ -2,7 +2,8 @@ import pytest
 import numpy as np
 import pandas as pd
 import os
-from astropy import units as u, constants as c
+from astropy import units as u
+from tardis import constants as c
 import astropy.tests.helper as test_helper
 from numpy.testing import assert_almost_equal
 from tardis.montecarlo.spectrum import (

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -2,7 +2,8 @@ import time
 import logging
 import numpy as np
 import pandas as pd
-from astropy import units as u, constants as const
+from astropy import units as u
+from tardis import constants as const
 from collections import OrderedDict
 from tardis import model
 


### PR DESCRIPTION
**Description**
<!--- Describe your changes in detail -->
Fixes #1672 
i used the grep command in linux to locate all files which had the word constants in it. 
Then i changed all files which imported constants from anywhere other than tardis. And changed them to  "from tardis import constants as const or c" whichever it was initially  imported as.


**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
This change does what was expected in this pr. Makes the code more reliable.

Also there was a file in ./tardis/analysis/opacities.py . It had "import astropy.constants as csts." I wasn't sure if i should change this so I didn't.
Also there was this another file in ./docs/development/developer_faq.rst
It explained as to where the constants are exported from . Since we're changing that to tardis I think this file should be changed too. I wasn't sure so I didn't.

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x ] None of the above. This is a documentation change.<!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
    - [x ] I have updated the documentation accordingly.
    - [ x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
