### PR TITLE
Name plotly traces in SDEC plot

### DIFF
--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -1580,6 +1580,8 @@ class SDECPlotter:
                         width=1,
                     ),
                     name=f"{packets_mode.capitalize()} Spectrum",
+                    hovertemplate="(%{x:.2f}, %{y:.3g})",
+                    hoverlabel=dict(namelength=-1),
                 )
             )
 
@@ -1605,6 +1607,8 @@ class SDECPlotter:
                 y=observed_spectrum_flux,
                 name="Observed Spectrum",
                 line={"color": "black", "width": 1.2},
+                hoverlabel=dict(namelength=-1),
+                hovertemplate="(%{x:.2f}, %{y:.3g})",
             )
 
         # Plot photosphere
@@ -1615,6 +1619,8 @@ class SDECPlotter:
                 mode="lines",
                 line=dict(width=1.5, color="red", dash="dash"),
                 name="Blackbody Photosphere",
+                hoverlabel=dict(namelength=-1),
+                hovertemplate="(%{x:.2f}, %{y:.3g})",
             )
         )
 
@@ -1672,6 +1678,7 @@ class SDECPlotter:
                 name="No interaction",
                 fillcolor="#4C4C4C",
                 stackgroup="emission",
+                hovertemplate="(%{x:.2f}, %{y:.3g})",
             )
         )
 
@@ -1683,6 +1690,8 @@ class SDECPlotter:
                 name="Electron Scatter Only",
                 fillcolor="#8F8F8F",
                 stackgroup="emission",
+                hoverlabel=dict(namelength=-1),
+                hovertemplate="(%{x:.2f}, %{y:.3g})",
             )
         )
 
@@ -1696,6 +1705,7 @@ class SDECPlotter:
                     name="Other elements",
                     fillcolor="#C2C2C2",
                     stackgroup="emission",
+                    hovertemplate="(%{x:.2f}, %{y:.3g})",
                 )
             )
 
@@ -1711,12 +1721,13 @@ class SDECPlotter:
                         mode="none",
                         name=species_name + " Emission",
                         hovertemplate=f"<b>{species_name} Emission </b>"
-                        + "(%{x}, %{y})<extra></extra>",
+                        + "(%{x:.2f}, %{y:.3g})<extra></extra>",
                         fillcolor=self.to_rgb255_string(
                             self._color_list[species_counter]
                         ),
                         stackgroup="emission",
                         showlegend=False,
+                        hoverlabel=dict(namelength=-1),
                     )
                 )
             except:
@@ -1752,6 +1763,7 @@ class SDECPlotter:
                     fillcolor="#C2C2C2",
                     stackgroup="absorption",
                     showlegend=False,
+                    hovertemplate="(%{x:.2f}, %{y:.3g})",
                 )
             )
 
@@ -1767,12 +1779,13 @@ class SDECPlotter:
                         mode="none",
                         name=species_name + " Absorption",
                         hovertemplate=f"<b>{species_name} Absorption </b>"
-                        + "(%{x}, %{y})<extra></extra>",
+                        + "(%{x:.2f}, %{y:.3g})<extra></extra>",
                         fillcolor=self.to_rgb255_string(
                             self._color_list[species_counter]
                         ),
                         stackgroup="absorption",
                         showlegend=False,
+                        hoverlabel=dict(namelength=-1),
                     )
                 )
 

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -1700,14 +1700,18 @@ class SDECPlotter:
             )
 
         # Contribution from each element
-        for species_counter, identifier in enumerate(self.species):
+        for (species_counter, identifier), species_name in zip(
+            enumerate(self.species), self._species_name
+        ):
             try:
                 self.fig.add_trace(
                     go.Scatter(
                         x=self.emission_luminosities_df.index,
                         y=self.emission_luminosities_df[identifier],
                         mode="none",
-                        name="none",
+                        name=species_name + " Emission",
+                        hovertemplate=f"<b>{species_name} Emission </b>"
+                        + "(%{x}, %{y})<extra></extra>",
                         fillcolor=self.to_rgb255_string(
                             self._color_list[species_counter]
                         ),
@@ -1751,7 +1755,9 @@ class SDECPlotter:
                 )
             )
 
-        for species_counter, identifier in enumerate(self.species):
+        for (species_counter, identifier), species_name in zip(
+            enumerate(self.species), self._species_name
+        ):
             try:
                 self.fig.add_trace(
                     go.Scatter(
@@ -1759,7 +1765,9 @@ class SDECPlotter:
                         # to plot absorption luminosities along negative y-axis
                         y=self.absorption_luminosities_df[identifier] * -1,
                         mode="none",
-                        name="none",
+                        name=species_name + " Absorption",
+                        hovertemplate=f"<b>{species_name} Absorption </b>"
+                        + "(%{x}, %{y})<extra></extra>",
                         fillcolor=self.to_rgb255_string(
                             self._color_list[species_counter]
                         ),
@@ -1829,6 +1837,7 @@ class SDECPlotter:
                 x=self.plot_wavelength[scatter_point_idx],
                 y=[0],
                 mode="markers",
+                name="Colorbar",
                 showlegend=False,
                 hoverinfo="skip",
                 marker=dict(color=[0], opacity=0, **coloraxis_options),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR names a few traces in plotly SDEC plot and makes some style changes to the hover text.
Because this helps me write SDEC tests too, this should be merged before the SDEC tests PR #1752.

**Description**
<!--- Describe your changes in detail -->
The traces displaying element contributions in plotly SDEC plot were not named earlier. This names those traces and the colour bar, with making some style changes to the hover text, to make it more clearly visible.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
https://github.com/tardis-sn/tardis/issues/1670
https://github.com/tardis-sn/tardis/pull/1752#discussion_r755251608

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Before:
![image](https://user-images.githubusercontent.com/55894364/143425607-7a0fbee6-3ea2-4e20-8fc3-8ecfe53e4720.png)

After:
![image](https://user-images.githubusercontent.com/55894364/143425584-45d262eb-c9c6-4cab-ac0f-2bffe1841325.png)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] I have assigned and requested two reviewers for this pull request.
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
