### PR TITLE
Pinning matplotlib to version 3.4

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -31,7 +31,7 @@ dependencies:
 
   # Widgets & Visualization
   - jupyter
-  - matplotlib
+  - matplotlib=3.4
   - ipywidgets
   - plotly
   - qgrid


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Pins matplotlib in the enviornment file to version 3.4.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
The new version of matplotlib broke the SDEC plot and thus the documentation.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Docs built on github.

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
