### PR TITLE
Adding Luminosity Integral Explanation to Supernova Configuration

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -106,6 +106,8 @@ Maryam Patel <maryam.patel22@gmail.com> maryam <maryam.patel22@gmail.com>
 Maryam Patel <maryam.patel22@gmail.com> maryam patel <maryam.patel22@gmail.com>
 Maryam Patel <maryam.patel22@gmail.com> maryampatel <maryam.patel22@gmail.com>
 
+Matthew Bartnik <bartnikm@msu.edu>
+
 Michael Klauser <michael@klauser.biz>
 Michael Klauser <michael@klauser.biz> Michael.Klauser <michael@klauser.biz>
 Michael Klauser <michael@klauser.biz> Michael <mklauser@mpa-garching.mpg.de>

--- a/docs/io/configuration/components/supernova.rst
+++ b/docs/io/configuration/components/supernova.rst
@@ -4,11 +4,11 @@
 Supernova Configuration
 ***********************
 
-The supernova component of the configuration file contains some key information about the supernova being modeled, namelt the time since the supernova and the luminosity the user wishes TARDIS should output:
+The supernova component of the configuration file contains some key information about the supernova being modeled, namely the time since the supernova and the luminosity the user wishes TARDIS should output:
 
 .. jsonschema:: schemas/supernova.yml
 
-As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, hence why we set `luminosity_wavelength_start` to 0 and `luminosity_wavelength_end` to infinity.
+As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, hence why `luminosity_wavelength_start` is set to 0 and `luminosity_wavelength_end` to infinity. It is recommended to not change these parameters unless desired.
 
 During a run of TARDIS, we attempt to converge the output spectrum to match the requested luminosity
 (see :ref:`est_and_conv`).

--- a/docs/io/configuration/components/supernova.rst
+++ b/docs/io/configuration/components/supernova.rst
@@ -4,13 +4,13 @@
 Supernova Configuration
 ***********************
 
-The supernova component of the configuration file contains some key information about the supernova being modeled, namely the time since the supernova and the luminosity the user wishes TARDIS should output:
+The supernova component of the configuration file contains some key information about the supernova being modeled, namely the time since the supernova (which is used throughout TARDIS calculations) and the luminosity the user wishes TARDIS should output:
 
 .. jsonschema:: schemas/supernova.yml
 
-As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, attempting to converge the output spectrum to match the luminosity requested (see :ref:`est_and_conv`). The range over which TARDIS sums these energy packets is set from 0 to infinity via the `luminosity_wavelength_start` and `luminosity_wavelength_end`, respectively, to generate a spectrum whose luminosity is known across the entire spectrum by default. However, if in the event only the luminosity within a certain range of wavelengths is known, then `luminosity_wavelength_start` and `luminosity_wavelength_end` can be changed as necessary to reflect this, allowing TARDIS to attempt to create a spectrum whose luminosity within the set range will converge to the value defined in `luminosity_requested`.
+As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, attempting to converge the output spectrum to match `luminosity_requested` (see :ref:`est_and_conv`). `luminosity_requested` can be given in standard units, such as erg/s or J/s, or in logarithmic units such as log_lsun. The range over which TARDIS sums these energy packets is set by default from 0 to infinity via `luminosity_wavelength_start` and `luminosity_wavelength_end`, respectively, so as to generate a spectrum whose total luminosity across the entire spectrum is `luminosity_requested`. However, if in the event only the luminosity within a certain range of wavelengths is known, then `luminosity_wavelength_start` and `luminosity_wavelength_end` can be changed as necessary to reflect this, allowing TARDIS to attempt to create a spectrum whose luminosity within the set range will converge to the value defined in `luminosity_requested`.
 
-As an example, here is a sample code which will generate a specturm where only the luminosity of the visible light portion of the spectrum is given.
+As an example, here is a sample code which will generate a specturm where only the luminosity of the visible light portion of the spectrum is given. Here, the output spectrum will have a luminosity of approximately :math:`10^{9.44}L_{sun}` within the visible range.  
 
 .. code-block:: yaml
         
@@ -20,8 +20,4 @@ As an example, here is a sample code which will generate a specturm where only t
       luminosity_wavelength_start: 400 nm
       luminosity_wavelength_end: 700 nm
 
-.. warning::
-    If `luminosity_wavelength_start` and `luminosity_wavelength_end` are given in terms of frequency, 
-    the larger frequency should be set as the start and the lower frequency should be set as the end
-    since TARDIS will convert these into wavelengths.
 

--- a/docs/io/configuration/components/supernova.rst
+++ b/docs/io/configuration/components/supernova.rst
@@ -4,9 +4,11 @@
 Supernova Configuration
 ***********************
 
-The supernova component of the configuration file contains some key information about the supernova being modeled:
+The supernova component of the configuration file contains some key information about the supernova being modeled, namelt the time since the supernova and the luminosity the user wishes TARDIS should output:
 
 .. jsonschema:: schemas/supernova.yml
+
+As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, hence why we set `luminosity_wavelength_start` to 0 and `luminosity_wavelength_end` to infinity.
 
 During a run of TARDIS, we attempt to converge the output spectrum to match the requested luminosity
 (see :ref:`est_and_conv`).

--- a/docs/io/configuration/components/supernova.rst
+++ b/docs/io/configuration/components/supernova.rst
@@ -8,5 +8,20 @@ The supernova component of the configuration file contains some key information 
 
 .. jsonschema:: schemas/supernova.yml
 
-As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, attempting to converge the output spectrum to match the luminosity requested (see :ref:`est_and_conv`), hence why `luminosity_wavelength_start` is set to 0 and `luminosity_wavelength_end` to infinity as a defualt. These values, however, can be changed depending on which wavelengths one has a luminosity. For example, if the user only wishes to see luminosities within the visible light range, then one can change `luminosity_wavelength_start` to 400 nm and `luminosity_wavelength_end` to 700 nm to obtain a spectrum within the visible light range. If the user wishes to see the entire spectrum, however, it is recommended to leave these parameters at their default value.   
+As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, attempting to converge the output spectrum to match the luminosity requested (see :ref:`est_and_conv`). The range over which TARDIS sums these energy packets is set from 0 to infinity via the `luminosity_wavelength_start` and `luminosity_wavelength_end`, respectively, to generate a spectrum whose luminosity is known across the entire spectrum by default. However, if in the event only the luminosity within a certain range of wavelengths is known, then `luminosity_wavelength_start` and `luminosity_wavelength_end` can be changed as necessary to reflect this, allowing TARDIS to attempt to create a spectrum whose luminosity within the set range will converge to the value defined in `luminosity_requested`.
+
+As an example, here is a sample code which will generate a specturm where only the luminosity of the visible light portion of the spectrum is given.
+
+.. code-block:: yaml
+        
+    supernova:
+      luminosity_requested: 9.44 log_lsun
+      time_explosion: 13 day
+      luminosity_wavelength_start: 400 nm
+      luminosity_wavelength_end: 700 nm
+
+.. warning::
+    If `luminosity_wavelength_start` and `luminosity_wavelength_end` are given in terms of frequency, 
+    the larger frequency should be set as the start and the lower frequency should be set as the end
+    since TARDIS will convert these into wavelengths.
 

--- a/docs/io/configuration/components/supernova.rst
+++ b/docs/io/configuration/components/supernova.rst
@@ -8,7 +8,5 @@ The supernova component of the configuration file contains some key information 
 
 .. jsonschema:: schemas/supernova.yml
 
-As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, hence why `luminosity_wavelength_start` is set to 0 and `luminosity_wavelength_end` to infinity. It is recommended to not change these parameters unless necessary.
+As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, attempting to converge the output spectrum to match the luminosity requested (see :ref:`est_and_conv`), hence why `luminosity_wavelength_start` is set to 0 and `luminosity_wavelength_end` to infinity as a defualt. These values, however, can be changed depending on which wavelengths one has a luminosity. For example, if the user only wishes to see luminosities within the visible light range, then one can change `luminosity_wavelength_start` to 400 nm and `luminosity_wavelength_end` to 700 nm to obtain a spectrum within the visible light range. If the user wishes to see the entire spectrum, however, it is recommended to leave these parameters at their default value.   
 
-During a run of TARDIS, we attempt to converge the output spectrum to match the requested luminosity
-(see :ref:`est_and_conv`).

--- a/docs/io/configuration/components/supernova.rst
+++ b/docs/io/configuration/components/supernova.rst
@@ -8,7 +8,7 @@ The supernova component of the configuration file contains some key information 
 
 .. jsonschema:: schemas/supernova.yml
 
-As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, hence why `luminosity_wavelength_start` is set to 0 and `luminosity_wavelength_end` to infinity. It is recommended to not change these parameters unless desired.
+As luminosity (in units of energy/s) is computed by integrating over the spectral luminosity (in units of energy/s/wavelength), TARDIS sums over all discrete energy packets to compute luminosity when ran, hence why `luminosity_wavelength_start` is set to 0 and `luminosity_wavelength_end` to infinity. It is recommended to not change these parameters unless necessary.
 
 During a run of TARDIS, we attempt to converge the output spectrum to match the requested luminosity
 (see :ref:`est_and_conv`).

--- a/tardis/io/schemas/supernova.yml
+++ b/tardis/io/schemas/supernova.yml
@@ -9,6 +9,9 @@ properties:
   time_explosion:
     type: quantity
     description: time since explosion
+  distance:
+    type: quantity
+    description: distance to supernova - **THIS IS DEPRECATED AND NOT IN USE**
   luminosity_wavelength_start:
     type: quantity
     default: 0 angstrom

--- a/tardis/io/schemas/supernova.yml
+++ b/tardis/io/schemas/supernova.yml
@@ -9,9 +9,6 @@ properties:
   time_explosion:
     type: quantity
     description: time since explosion
-  distance:
-    type: quantity
-    description: distance to supernova - **THIS IS DEPRECATED AND NOT IN USE**
   luminosity_wavelength_start:
     type: quantity
     default: 0 angstrom


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
Added explanations for luminosity_wavelength_start and luminosity_wavelength_end parameters and made slight wording changes to the supernova configuration section of the documentation
<!--- Describe your changes in detail -->
**Motivation and context**
The original did not have an explanation for the luminosity integral limits being set to 0 and inf

<!--- Why is this change required? What problem does it solve? Link issues here -->
**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

https://bartnikm.github.io/tardis-bartnikm/branch/supernova_configuration/io/configuration/components/supernova.html
**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.