### PR TITLE
Fix for Issue "Kilonova-model crash when no recombination data available"

### DIFF
--- a/tardis/plasma/properties/ion_population.py
+++ b/tardis/plasma/properties/ion_population.py
@@ -164,23 +164,22 @@ class PhiSahaNebular(ProcessingPlasmaProperty):
     @staticmethod
     def get_zeta_values(zeta_data, ion_index, t_rad):
         """
-        OLD VERSION:
-        zeta_t_rad = zeta_data.columns.values.astype(np.float64)
-        zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
+        Attributes
+        ----------
+
         """
-        # SUGGESTION:
-        ion_index_in_zeta = ion_index.isin(zeta_data.index) # returns a boolean array, False means an index has not been found in the zeta data file
-        if False not in ion_index_in_zeta: 
+        ion_index_in_zeta = (
+            ion_index.isin(zeta_data.index)
+            if hasattr(ion_index, "isin")
+            else ion_index in zeta_data.index
+        )
+        if False not in ion_index_in_zeta:
             zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
             zeta_t_rad = zeta_data.columns.values.astype(np.float64)
-        else: # now zeta data found in the file -> zeta_data is empty
-            # for now: hard-coded dummy value, may better be added as a config parameter (-> how?)
-            dummy_zeta_val = 0.3
-            # for now, the following temp_values have to be included as zeta_data is empty -> is there a better solution?
-            temp_values = [2000.0,4000.0,6000.0,8000.0,10000.0,12000.0,14000.0,16000.0,18000.0,20000.0] 
-            zeta_data_copy = pd.DataFrame(dummy_zeta_val,columns=temp_values,index=ion_index)
-            zeta_values = zeta_data_copy.values.astype(np.float64)
-            zeta_t_rad = zeta_data_copy.columns.values.astype(np.float64)
+        else:
+            dummy_zeta_val = 1.0
+            zeta_t_rad = np.linspace(2000, 40000, 10, endpoint=True)
+            zeta_values = np.full(zeta_t_rad.shape, dummy_zeta_val).astype(np.float64)
         zeta = interpolate.interp1d(
             zeta_t_rad, zeta_values, bounds_error=False, fill_value=np.nan
         )(t_rad)

--- a/tardis/plasma/properties/ion_population.py
+++ b/tardis/plasma/properties/ion_population.py
@@ -168,16 +168,16 @@ class PhiSahaNebular(ProcessingPlasmaProperty):
         zeta_t_rad = zeta_data.columns.values.astype(np.float64)
         zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
         """
-        # NEW VERSION:
+        # SUGGESTION:
         ion_index_in_zeta = ion_index.isin(zeta_data.index) # returns a boolean array, False means an index has not been found in the zeta data file
-        if False not in ion_index_in_zeta:
+        if False not in ion_index_in_zeta: 
             zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
             zeta_t_rad = zeta_data.columns.values.astype(np.float64)
-        else:
-            # for now: hard-coded dummy value, may better be added as a config parameter
+        else: # now zeta data found in the file -> zeta_data is empty
+            # for now: hard-coded dummy value, may better be added as a config parameter (-> how?)
             dummy_zeta_val = 0.3
-            # the following temp_values have to be included as now I do not read the zeta_data file, obtaining the columns therefrom
-            temp_values = [2000.0,4000.0,6000.0,8000.0,10000.0,12000.0,14000.0,16000.0,18000.0,20000.0]
+            # for now, the following temp_values have to be included as zeta_data is empty -> is there a better solution?
+            temp_values = [2000.0,4000.0,6000.0,8000.0,10000.0,12000.0,14000.0,16000.0,18000.0,20000.0] 
             zeta_data_copy = pd.DataFrame(dummy_zeta_val,columns=temp_values,index=ion_index)
             zeta_values = zeta_data_copy.values.astype(np.float64)
             zeta_t_rad = zeta_data_copy.columns.values.astype(np.float64)

--- a/tardis/plasma/properties/ion_population.py
+++ b/tardis/plasma/properties/ion_population.py
@@ -163,8 +163,24 @@ class PhiSahaNebular(ProcessingPlasmaProperty):
 
     @staticmethod
     def get_zeta_values(zeta_data, ion_index, t_rad):
+        """
+        OLD VERSION:
         zeta_t_rad = zeta_data.columns.values.astype(np.float64)
         zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
+        """
+        # NEW VERSION:
+        ion_index_in_zeta = ion_index.isin(zeta_data.index) # returns a boolean array, False means an index has not been found in the zeta data file
+        if False not in ion_index_in_zeta:
+            zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
+            zeta_t_rad = zeta_data.columns.values.astype(np.float64)
+        else:
+            # the following two lines are not nice
+            dummy_zeta_val = 0.3
+            # the following temp_values have to be included as now I do not read the zeta_data file, obtaining the columns therefrom
+            temp_values = [2000.0,4000.0,6000.0,8000.0,10000.0,12000.0,14000.0,16000.0,18000.0,20000.0]
+            zeta_data_copy = pd.DataFrame(dummy_zeta_val,columns=temp_values,index=ion_index)
+            zeta_values = zeta_data_copy.values.astype(np.float64)
+            zeta_t_rad = zeta_data_copy.columns.values.astype(np.float64)
         zeta = interpolate.interp1d(
             zeta_t_rad, zeta_values, bounds_error=False, fill_value=np.nan
         )(t_rad)

--- a/tardis/plasma/properties/ion_population.py
+++ b/tardis/plasma/properties/ion_population.py
@@ -174,7 +174,7 @@ class PhiSahaNebular(ProcessingPlasmaProperty):
             zeta_values = zeta_data.loc[ion_index].values.astype(np.float64)
             zeta_t_rad = zeta_data.columns.values.astype(np.float64)
         else:
-            # the following two lines are not nice
+            # for now: hard-coded dummy value, may better be added as a config parameter
             dummy_zeta_val = 0.3
             # the following temp_values have to be included as now I do not read the zeta_data file, obtaining the columns therefrom
             temp_values = [2000.0,4000.0,6000.0,8000.0,10000.0,12000.0,14000.0,16000.0,18000.0,20000.0]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fix for issue #1829 

**Description**
New version: In the case if there is no zeta_data, a data frame with the required dimension is created and filled with dummy values for the zeta data. 

**Motivation and context**
If no such data was provided, TARDIS crashed.

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
