### PR TITLE
Fixed the Failing Documentation for Tracking `RPacket` Feature 

### DIFF
--- a/docs/io/output/rpacket_tracking.ipynb
+++ b/docs/io/output/rpacket_tracking.ipynb
@@ -13,7 +13,7 @@
    "id": "c103617c",
    "metadata": {},
    "source": [
-    "**TARDIS** has the functionality to track the properties of the *RPackets* that are generated when running the Simulation. The `rpacket_tracker` can track all the interactions a packet undergoes & thus keeps a track of the various properties, a packet may have.<br>Currently, the `rpacket_tracker` tracks the properties of all the packets in the *Last Iteration of the Simulation*. "
+    "**TARDIS** has the functionality to track the properties of the *RPackets* that are generated when running the Simulation. The `rpacket_tracker` can track all the interactions a packet undergoes & thus keeps a track of the various properties, a packet may have.<br>Currently, the `rpacket_tracker` tracks the properties of all the rpackets in the *Last Iteration of the Simulation*. It generates a `List` that contains the individual instances of `RPacketCollection`{`Numba JITClass`}, for storing all the interaction properties as listed below."
    ]
   },
   {
@@ -40,6 +40,19 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4b0de6ca",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\">\n",
+    "\n",
+    "Warning\n",
+    "\n",
+    "Current implementation stores all the data for the interaction of the packets in a `list`, so it needs to accessed with a `list index` for each property for a particular `rpacket`. Examples for the same are shown as follows. \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1686d9f1",
    "metadata": {},
    "source": [
@@ -58,7 +71,7 @@
     "montecarlo:\n",
     "...\n",
     "tracking:\n",
-    "    r_packet_tracking: true\n",
+    "    track_rpacket: true\n",
     "```"
    ]
   },
@@ -67,7 +80,7 @@
    "id": "13b6420b",
    "metadata": {},
    "source": [
-    "The `montecarlo` section of the **YAML** file now has a `tracking` sub section which holds the configuration properties for the `rpacket_tracker` & the `initial_array_length` (discussed later in the tutorial)."
+    "The `montecarlo` section of the **YAML** file now has a `tracking` sub section which holds the configuration properties for the `track_rpacket` & the `initial_array_length` (discussed later in the tutorial)."
    ]
   },
   {
@@ -80,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "a0e975b6",
    "metadata": {},
    "outputs": [],
@@ -90,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "adbf5f75",
    "metadata": {},
    "outputs": [],
@@ -102,10 +115,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "975766e9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'track_rpacket': False, 'initial_array_length': 10}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Checking the `tracking` section via the Schema\n",
     "\n",
@@ -114,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b00bc2ca",
    "metadata": {},
    "outputs": [],
@@ -126,7 +150,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
+   "id": "3ece2c10",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'track_rpacket': True, 'initial_array_length': 10}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "config[\"montecarlo\"][\"tracking\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
    "id": "b25271d6",
    "metadata": {},
    "outputs": [],
@@ -136,16 +181,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "f9e51fd3",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[\u001b[1mpy.warnings         \u001b[0m][\u001b[1;33mWARNING\u001b[0m]  /home/dhruvs/Repositories/tardis/tardis/plasma/properties/radiative_properties.py:92: RuntimeWarning: invalid value encountered in true_divide\n",
+      "  (g_lower * n_upper) / (g_upper * n_lower)\n",
+      " (\u001b[1mwarnings.py\u001b[0m:110)\n"
+     ]
+    }
+   ],
    "source": [
     "# Running the simulation from the config\n",
     "\n",
-    "sim = run_tardis(config, show_cplots=False)"
+    "sim = run_tardis(config, show_convergence_plots=False, show_progress_bars=False)"
    ]
   },
   {
@@ -158,12 +213,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "f8b3424f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "numba.typed.typedlist.List"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "sim.runner.rpacket_tracker"
+    "type(sim.runner.rpacket_tracker)"
    ]
   },
   {
@@ -171,7 +237,7 @@
    "id": "4771d92a",
    "metadata": {},
    "source": [
-    "It can be seen from the above code, that the `sim.runner.rpacket_tracker` is an instance of the `RPacketCollection` *Numba jitclass*. The `RPacketCollection` class has the following structure for the properties : {More information in the **TARDIS API** for `RPacketCollection` class}"
+    "It can be seen from the above code, that the `sim.runner.rpacket_tracker` is an instance of the `List` specifically *Numba Typed List*. The `RPacketCollection` class has the following structure for the properties : {More information in the **TARDIS API** for `RPacketCollection` class}"
    ]
   },
   {
@@ -195,11 +261,33 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "a3ea2f54",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100000"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(sim.runner.rpacket_tracker)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "411f2ef9",
    "metadata": {},
    "source": [
-    "To access these different properties, we may consider the following examples for the `rpacket_tracker`:"
+    "To access these different properties, we may consider the following examples for the `rpacket_tracker`:\n",
+    "<br>In this Example, we are trying to access the properties of the packet at index `10`.<br>In a similar way, we can check for any property for any packet in the range of packets for the last iteration."
    ]
   },
   {
@@ -207,17 +295,31 @@
    "id": "a4772b00",
    "metadata": {},
    "source": [
-    "- Accessing the `index` property for the packets:"
+    "- Accessing the `index` property for the packet {`10`}:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "de7b8877",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,\n",
+       "       10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,\n",
+       "       10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,\n",
+       "       10, 10])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "sim.runner.rpacket_tracker.index"
+    "sim.runner.rpacket_tracker[10].index"
    ]
   },
   {
@@ -225,17 +327,38 @@
    "id": "d81fbbf7",
    "metadata": {},
    "source": [
-    "- Accessing the `seed` property for the packets:"
+    "- Accessing the `seed` property for the packet {`10`}:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "39e2dbd2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
+       "       2729103521, 2729103521, 2729103521])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "sim.runner.rpacket_tracker.seed"
+    "sim.runner.rpacket_tracker[10].seed"
    ]
   },
   {
@@ -243,17 +366,30 @@
    "id": "7afe2110",
    "metadata": {},
    "source": [
-    "- Accessing the `status` property for the packets:"
+    "- Accessing the `status` property for the packet {`10`}:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "e82427ea",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+       "       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
+       "       0, 0, 0, 0, 0, 0, 0, 0, 1])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "sim.runner.rpacket_tracker.status"
+    "sim.runner.rpacket_tracker[10].status"
    ]
   },
   {
@@ -269,17 +405,28 @@
    "id": "c83dd906",
    "metadata": {},
    "source": [
-    "We can also see the total number of interactions all the packets had, with the following example:"
+    "We can also see the total number of interactions of index `10` packet under went, with the following example:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "090b1517",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "53"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "len(sim.runner.rpacket_tracker.index)"
+    "len(sim.runner.rpacket_tracker[10].shell_id)"
    ]
   },
   {
@@ -311,7 +458,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/io/output/rpacket_tracking.ipynb
+++ b/docs/io/output/rpacket_tracking.ipynb
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "a0e975b6",
    "metadata": {},
    "outputs": [],
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "adbf5f75",
    "metadata": {},
    "outputs": [],
@@ -115,21 +115,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "975766e9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'track_rpacket': False, 'initial_array_length': 10}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Checking the `tracking` section via the Schema\n",
     "\n",
@@ -138,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "b00bc2ca",
    "metadata": {},
    "outputs": [],
@@ -150,28 +139,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "3ece2c10",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'track_rpacket': True, 'initial_array_length': 10}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "config[\"montecarlo\"][\"tracking\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "b25271d6",
    "metadata": {},
    "outputs": [],
@@ -181,22 +159,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "f9e51fd3",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[\u001b[1mpy.warnings         \u001b[0m][\u001b[1;33mWARNING\u001b[0m]  /home/dhruvs/Repositories/tardis/tardis/plasma/properties/radiative_properties.py:92: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  (g_lower * n_upper) / (g_upper * n_lower)\n",
-      " (\u001b[1mwarnings.py\u001b[0m:110)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Running the simulation from the config\n",
     "\n",
@@ -213,21 +181,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "f8b3424f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "numba.typed.typedlist.List"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "type(sim.runner.rpacket_tracker)"
    ]
@@ -262,21 +219,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "a3ea2f54",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "100000"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(sim.runner.rpacket_tracker)"
    ]
@@ -300,24 +246,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "de7b8877",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,\n",
-       "       10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,\n",
-       "       10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,\n",
-       "       10, 10])"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim.runner.rpacket_tracker[10].index"
    ]
@@ -332,31 +264,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "39e2dbd2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521, 2729103521, 2729103521,\n",
-       "       2729103521, 2729103521, 2729103521])"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim.runner.rpacket_tracker[10].seed"
    ]
@@ -371,23 +282,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "e82427ea",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
-       "       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,\n",
-       "       0, 0, 0, 0, 0, 0, 0, 0, 1])"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "sim.runner.rpacket_tracker[10].status"
    ]
@@ -410,21 +308,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "090b1517",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "53"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(sim.runner.rpacket_tracker[10].shell_id)"
    ]

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -409,6 +409,7 @@ class RPacketCollection(object):
         self.nu = self.nu[: self.interact_id]
         self.mu = self.mu[: self.interact_id]
         self.energy = self.energy[: self.interact_id]
+        self.shell_id = self.shell_id[: self.interact_id]
 
 
 estimators_spec = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
After the merging of #1748, the documentation pipeline on master is failing as the documentation for the same was not updated to take into consideration the new changes done to the tracking functionality. This PR aims to fix this issue with the addition of a missing functionality. It adds the finalization of the `shell_id` array in the `RPacketCollection` Class.

**Description**
<!--- Describe your changes in detail -->
Same as above.

**Motivation and context**
Fixes the failing documentation pipeline after the recent merger.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.

**Check for the preview of the Documentation here :** https://dhruvsondhi.github.io/tardis/branch/rpacket_docs_fix/io/output/rpacket_tracking.html