### PR TITLE
Fix Virtual Packet Logging Bug

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -155,6 +155,8 @@ def montecarlo_main_loop(
     number_of_vpackets : int
         VPackets released per interaction
     packet_seeds : numpy.array
+    virtual_packet_logging : bool
+        Option to enable virtual packet logging.
     """
     output_nus = np.empty_like(packet_collection.packets_output_nu)
     last_interaction_types = (

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -85,6 +85,7 @@ def montecarlo_radial1d(
         runner.spectrum_frequency.value,
         number_of_vpackets,
         packet_seeds,
+        montecarlo_configuration.VPACKET_LOGGING,
         iteration=iteration,
         show_progress_bars=show_progress_bars,
         no_of_packets=no_of_packets,
@@ -134,6 +135,7 @@ def montecarlo_main_loop(
     spectrum_frequency,
     number_of_vpackets,
     packet_seeds,
+    virtual_packet_logging,
     iteration,
     show_progress_bars,
     no_of_packets,
@@ -262,7 +264,7 @@ def montecarlo_main_loop(
                 continue
             v_packets_energy_hist[idx] += vpackets_energy[j]
 
-    if montecarlo_configuration.VPACKET_LOGGING:
+    if virtual_packet_logging:
         for vpacket_collection in vpacket_collections:
             vpackets_nu = vpacket_collection.nus[: vpacket_collection.idx]
             vpackets_energy = vpacket_collection.energies[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Resolves https://github.com/tardis-sn/tardis/issues/1764

**Description**
<!--- Describe your changes in detail -->
The `montecarlo_configuration.VPACKET_LOGGING` in the `montecarlo_main_loop` function was being cached.
This prevented variables related to virtual packets from populating and raised an error. Passing `virtual_packet_logging` in the `montecarlo_main_loop` function fixes this.

https://github.com/tardis-sn/tardis/blob/f24be9aeae96c1f3b8af7e7fd91ac700a5d3c9d1/tardis/montecarlo/montecarlo_numba/base.py#L280-L328


**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Resolves https://github.com/tardis-sn/tardis/issues/1764 and partially solves failing SDEC tests problem https://github.com/tardis-sn/tardis/pull/1752 

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [ ] I have assigned and requested two reviewers for this pull request.
