### PR TITLE
Renamed `RPacketCollection` Class to `RPacketTracker`

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -135,7 +135,7 @@ class MontecarloRunner(HDFWriterMixin):
         self.virt_packet_initial_rs = np.ones(2) * -1.0
         self.virt_packet_initial_mus = np.ones(2) * -1.0
 
-        # Setting up the Tracking array for TrackedRPacketCollection
+        # Setting up the Tracking array for storing all the RPacketTracker instances
         self.rpacket_tracker = None
 
         # set up logger based on config

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -135,7 +135,7 @@ class MontecarloRunner(HDFWriterMixin):
         self.virt_packet_initial_rs = np.ones(2) * -1.0
         self.virt_packet_initial_mus = np.ones(2) * -1.0
 
-        # Setting up the Tracking array for RPacketCollection
+        # Setting up the Tracking array for TrackedRPacketCollection
         self.rpacket_tracker = None
 
         # set up logger based on config

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -11,7 +11,7 @@ from tardis.montecarlo.montecarlo_numba.utils import MonteCarloException
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
     PacketCollection,
     VPacketCollection,
-    RPacketCollection,
+    RPacketTracker,
     NumbaModel,
     numba_plasma_initialize,
     Estimators,
@@ -78,7 +78,7 @@ def montecarlo_radial1d(
         virt_packet_last_interaction_type,
         virt_packet_last_line_interaction_in_id,
         virt_packet_last_line_interaction_out_id,
-        tracked_rpackets,
+        tracked_rpackets_collection,
     ) = montecarlo_main_loop(
         packet_collection,
         numba_model,
@@ -129,7 +129,7 @@ def montecarlo_radial1d(
 
     # Condition for Checking if RPacket Tracking is enabled
     if montecarlo_configuration.RPACKET_TRACKING:
-        runner.rpacket_tracker = tracked_rpackets
+        runner.rpacket_tracker = tracked_rpackets_collection
 
 
 @njit(**njit_dict)
@@ -196,9 +196,9 @@ def montecarlo_main_loop(
         )
 
     # Configuring the Tracking for R_Packets
-    tracked_rpackets = List()
+    tracked_rpackets_collection = List()
     for i in range(len(output_nus)):
-        tracked_rpackets.append(RPacketCollection())
+        tracked_rpackets_collection.append(RPacketTracker())
 
     # Arrays for vpacket logging
     virt_packet_nus = []
@@ -236,7 +236,7 @@ def montecarlo_main_loop(
             i,
         )
         vpacket_collection = vpacket_collections[i]
-        rpacket_collection = tracked_rpackets[i]
+        tracked_rpacket = tracked_rpackets_collection[i]
 
         single_packet_loop(
             r_packet,
@@ -244,7 +244,7 @@ def montecarlo_main_loop(
             numba_plasma,
             estimators,
             vpacket_collection,
-            rpacket_collection,
+            tracked_rpacket,
         )
 
         output_nus[i] = r_packet.nu
@@ -331,8 +331,8 @@ def montecarlo_main_loop(
             )
 
     if montecarlo_configuration.RPACKET_TRACKING:
-        for rpacket_collection in tracked_rpackets:
-            rpacket_collection.finalize_array()
+        for tracked_rpacket in tracked_rpackets_collection:
+            tracked_rpacket.finalize_array()
 
     packet_collection.packets_output_energy[:] = output_energies[:]
     packet_collection.packets_output_nu[:] = output_nus[:]
@@ -351,5 +351,5 @@ def montecarlo_main_loop(
         virt_packet_last_interaction_type,
         virt_packet_last_line_interaction_in_id,
         virt_packet_last_line_interaction_out_id,
-        tracked_rpackets,
+        tracked_rpackets_collection,
     )

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -78,7 +78,7 @@ def montecarlo_radial1d(
         virt_packet_last_interaction_type,
         virt_packet_last_line_interaction_in_id,
         virt_packet_last_line_interaction_out_id,
-        tracked_rpackets_collection,
+        rpacket_trackers,
     ) = montecarlo_main_loop(
         packet_collection,
         numba_model,
@@ -129,7 +129,7 @@ def montecarlo_radial1d(
 
     # Condition for Checking if RPacket Tracking is enabled
     if montecarlo_configuration.RPACKET_TRACKING:
-        runner.rpacket_tracker = tracked_rpackets_collection
+        runner.rpacket_tracker = rpacket_trackers
 
 
 @njit(**njit_dict)
@@ -196,9 +196,9 @@ def montecarlo_main_loop(
         )
 
     # Configuring the Tracking for R_Packets
-    tracked_rpackets_collection = List()
+    rpacket_trackers = List()
     for i in range(len(output_nus)):
-        tracked_rpackets_collection.append(RPacketTracker())
+        rpacket_trackers.append(RPacketTracker())
 
     # Arrays for vpacket logging
     virt_packet_nus = []
@@ -236,7 +236,7 @@ def montecarlo_main_loop(
             i,
         )
         vpacket_collection = vpacket_collections[i]
-        tracked_rpacket = tracked_rpackets_collection[i]
+        tracked_rpacket = rpacket_trackers[i]
 
         single_packet_loop(
             r_packet,
@@ -331,8 +331,8 @@ def montecarlo_main_loop(
             )
 
     if montecarlo_configuration.RPACKET_TRACKING:
-        for tracked_rpacket in tracked_rpackets_collection:
-            tracked_rpacket.finalize_array()
+        for rpacket_tracker in rpacket_trackers:
+            rpacket_tracker.finalize_array()
 
     packet_collection.packets_output_energy[:] = output_energies[:]
     packet_collection.packets_output_nu[:] = output_nus[:]
@@ -351,5 +351,5 @@ def montecarlo_main_loop(
         virt_packet_last_interaction_type,
         virt_packet_last_line_interaction_in_id,
         virt_packet_last_line_interaction_out_id,
-        tracked_rpackets_collection,
+        rpacket_trackers,
     )

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -320,7 +320,7 @@ rpacket_collection_spec = [
 
 
 @jitclass(rpacket_collection_spec)
-class RPacketCollection(object):
+class RPacketTracker(object):
     """
     Numba JITCLASS for storing the information for each interaction a RPacket instance undergoes.
 

--- a/tardis/montecarlo/tests/test_montecarlo.py
+++ b/tardis/montecarlo/tests/test_montecarlo.py
@@ -53,8 +53,8 @@ import tardis.montecarlo.montecarlo_numba.r_packet as r_packet
 import tardis.montecarlo.montecarlo_numba.utils as utils
 import tardis.montecarlo.montecarlo_configuration as mc
 from tardis import constants as const
-from tardis.montecarlo.montecarlo_numba.numba_interface import Estimators
-from tardis.montecarlo.montecarlo_numba.numba_interface import RPacketCollection
+from tardis.montecarlo.montecarlo_numba.numba_interface import Estimators, RPacketTracker
+from tardis.montecarlo.montecarlo_numba.numba_interface import RPacketTracker
 from tardis.montecarlo.montecarlo_numba import macro_atom
 
 from tardis.montecarlo.montecarlo_numba.frame_transformations import (
@@ -839,7 +839,7 @@ def test_rpacket_tracking(index, seed, r, nu, mu, energy):
     # Setup Montecarlo_Configuration.INITIAL_TRACKING_ARRAY_LENGTH
     mc.INITIAL_TRACKING_ARRAY_LENGTH = 10
 
-    tracked_rpacket_properties = RPacketCollection()
+    tracked_rpacket_properties = RPacketTracker()
     test_rpacket = r_packet.RPacket(
         index=index,
         seed=seed,


### PR DESCRIPTION
This PR aims to rename `RPacketCollection` to `RPacketTracker` Class.
Multiple variable names has also been changed to reflect this renaming.

In continuation of PR #1776.

<!--- Provide a general summary of your changes in the title above -->

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] None of the above.  -- Renaming of existing feature <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
