### PR TITLE
Fix links in the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,4 +15,4 @@ As members of the community,
 
 This code of conduct has been adapted from the Astropy Code of Conduct, which in turn uses parts of the PSF code of conduct.
 
-**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](https://tardis-sn.github.io/tardis/team_and_governance/team.html) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](https://tardis-sn.github.io/tardis/team_and_governance/team.html); who is outside of the TARDIS collaboration and will treat reports confidentially).**
+**To report any violations of the code of conduct, please contact a member of the [TARDIS core team](https://tardis-sn.github.io/team/community_roles/index.html) (the email tardis.supernova.code@gmail.com is monitored by the core team) or the Ombudsperson (see the [team page](https://tardis-sn.github.io/team/community_roles/index.html); who is outside of the TARDIS collaboration and will treat reports confidentially).**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Moves links in the code of conduct from the documentation to the TARDIS website -- these pages were moved in the transition to the new website.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
You can look at the code of conduct on my branch to view the links.

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
