### PR TITLE
fixed outdated pytest tardis command in documentation

### DIFF
--- a/docs/contributing/development/running_tests.rst
+++ b/docs/contributing/development/running_tests.rst
@@ -23,7 +23,7 @@ tests, you can run this with:
 
 .. code-block:: shell
 
-    > python setup.py test
+    > pytest tardis
 
 
 Running the more advanced unit tests requires TARDIS Reference data that can be
@@ -32,7 +32,7 @@ downloaded
 
 .. code-block:: shell
 
-    > python setup.py test --args="--tardis-refdata=/path/to/tardis-refdata/"
+    > pytest tardis --tardis-refdata=/path/to/tardis-refdata/
 
 Generating Plasma Reference
 ===========================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The documentation currently contains the old `python setup.py test` command. 
This PR replaces it with the new `pytest tardis` command.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
