### PR TITLE
Fix changelog action workflow

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -6,7 +6,7 @@ name: changelog
 on:
   push:
     tags:
-    - 'release-*'
+      - 'release-*'
 
   workflow_dispatch:  # Manual trigger
 
@@ -35,5 +35,9 @@ jobs:
       - name: Push changes
         run: |
           git add CHANGELOG.md
-          git commit -m "Post-release updates [auto]"
-          git push
+          git commit --amend --no-edit
+          GIT_TAG_MESSAGE=$(git tag -l --format='%(contents)' ${{ github.ref_name }})
+          git tag -d ${{ github.ref_name }}
+          git tag -a ${{ github.ref_name }} -m "$GIT_TAG_MESSAGE"
+          git checkout master
+          git push --tags --force


### PR DESCRIPTION
Modify the git flow in the changelog action workflow

**Description**
This PR aims to solve the detached head issue raised by github actions when the tag triggers the workflow. The action first deletes the tag in the runner. Then the tag is recreated to point to the new commit. The change is then force pushed to origin.

**Motivation and context**
Fix for issue #1871 

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Tested by pushing tags to my fork

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
