### PR TITLE
Fix line list sorting

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -347,7 +347,7 @@ class AtomData(object):
             )
         ]
 
-        self.lines.sort_values(by="wavelength", inplace=True)
+        self.lines.sort_values(by="nu", ascending=False, inplace=True)
 
         self.lines_index = pd.Series(
             np.arange(len(self.lines), dtype=int),


### PR DESCRIPTION
This PR sorts the line list by frequency instead of wavelength. This guarantees that the line list is in the correct order even if there are small inconsistencies in the atomic data.

**Motivation and context**
The atomic data from the Boyle 2017 paper crashes the code because there are differences of up to 4e-6 between the stored frequencies and the frequencies calculated from the wavelengths. As a result, the frequency can also increase along the line list (when sorting by wavelength) resulting in a nu_diff < 0 error.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
