### PR TITLE
issue1875 attempt 2

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -102,7 +102,7 @@ class AtomData(object):
     macro_atom_references_all : pandas.DataFrame
     collision_data : pandas.DataFrame
     collision_data_temperatures : numpy.array
-    zeta_data : pandas.DataFrame
+    unfiltered_zeta_data : pandas.DataFrame
     synpp_refs : pandas.DataFrame
     symbol2atomic_number : OrderedDict
     atomic_number2symbol : OrderedDict
@@ -171,7 +171,7 @@ class AtomData(object):
                 except KeyError:
                     logger.debug("Dataframe does not contain NAME column")
                     nonavailable.append(name)
-
+            
             atom_data = cls(**dataframes)
 
             try:
@@ -266,7 +266,7 @@ class AtomData(object):
         self.macro_atom_data_all = macro_atom_data
         self.macro_atom_references_all = macro_atom_references
 
-        self.zeta_data = zeta_data
+        self.unfiltered_zeta_data = zeta_data
 
         self.collision_data = collision_data
         self.collision_data_temperatures = collision_data_temperatures

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -32,6 +32,7 @@ __all__ = [
     "LinesUpperLevelIndex",
     "AtomicMass",
     "IonizationData",
+    "FilteredZetaData",
     "ZetaData",
     "NLTEData",
     "PhotoIonizationData",
@@ -359,9 +360,11 @@ class ZetaData(BaseAtomicDataProperty):
         from the ionized state that go directly to the ground state.
     """
 
-    outputs = ("zeta_data",)
+    outputs = ("unfiltered_zeta_data",)
 
     def _filter_atomic_property(self, zeta_data, selected_atoms):
+        return zeta_data
+        """
         zeta_data["atomic_number"] = zeta_data.index.codes[0] + 1
         zeta_data["ion_number"] = zeta_data.index.codes[1] + 1
         zeta_data = zeta_data[zeta_data.atomic_number.isin(selected_atoms)]
@@ -406,10 +409,17 @@ class ZetaData(BaseAtomicDataProperty):
             updated_dataframe["ion_number"] = np.array(updated_index[1])
             updated_dataframe.fillna(1.0, inplace=True)
             return updated_dataframe
+        """
 
     def _set_index(self, zeta_data):
-        return zeta_data.set_index(["atomic_number", "ion_number"])
+        return zeta_data.rename_axis(["atomic_number", "ion_number"])
 
+class FilteredZetaData(ProcessingPlasmaProperty):
+    
+    outputs = ("zeta_data",)
+    
+    def calculate(self, unfiltered_zeta_data, ionization_data):
+        return unfiltered_zeta_data.reindex(ionization_data.index)
 
 class NLTEData(ProcessingPlasmaProperty):
     """

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -42,7 +42,7 @@ macro_atom_properties = PlasmaPropertyCollection(
     [BetaSobolev, TransitionProbabilities]
 )
 nebular_ionization_properties = PlasmaPropertyCollection(
-    [PhiSahaNebular, ZetaData, BetaElectron, RadiationFieldCorrection]
+    [PhiSahaNebular, FilteredZetaData, ZetaData, BetaElectron, RadiationFieldCorrection]
 )
 dilute_lte_excitation_properties = PlasmaPropertyCollection(
     [LevelBoltzmannFactorDiluteLTE]
@@ -61,6 +61,7 @@ helium_nlte_properties = PlasmaPropertyCollection(
     [
         HeliumNLTE,
         RadiationFieldCorrection,
+        FilteredZetaData,
         ZetaData,
         BetaElectron,
         LevelNumberDensityHeNLTE,


### PR DESCRIPTION
<Problem was: Class 'AtomData' in tarids/io/atom_data/base.py does not know "unfiltered_zeta_data". Changes made saved the notebook from crashing, but looking at the resulting spectra something must have been destroyed.>

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
