### PR TITLE
Fix PyTest fixtures and updated mainloop to properly compile

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -138,7 +138,7 @@ def tardis_ref_data(tardis_ref_path, generate_reference):
         yield store
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def tardis_config_verysimple():
     return yaml_load_config_file(
         "tardis/io/tests/data/tardis_configv1_verysimple.yml"
@@ -163,6 +163,13 @@ def config_verysimple():
     config = Configuration.from_yaml(path)
     return config
 
+
+@pytest.fixture(scope="function")
+def config_montecarlo_1e5_verysimple():
+    filename = "tardis_configv1_verysimple.yml"
+    path = os.path.abspath(os.path.join("tardis/io/tests/data/", filename))
+    config = Configuration.from_yaml(path)
+    return config
 
 @pytest.fixture(scope="session")
 def simulation_verysimple(config_verysimple, atomic_dataset):

--- a/tardis/model/tests/test_base.py
+++ b/tardis/model/tests/test_base.py
@@ -387,7 +387,6 @@ class TestModelState:
 def to_hdf_buffer(hdf_file_path, simulation_verysimple):
     simulation_verysimple.model.to_hdf(hdf_file_path, overwrite=True)
 
-
 model_scalar_attrs = ["t_inner"]
 
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -63,7 +63,7 @@ def montecarlo_radial1d(
     packet_seeds = montecarlo_configuration.packet_seeds
 
     number_of_vpackets = montecarlo_configuration.number_of_vpackets
-
+    if iteration == 0: montecarlo_main_loop.recompile() # Make sure we update
     (
         v_packets_energy_hist,
         last_interaction_type,

--- a/tardis/montecarlo/montecarlo_numba/tests/test_base.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_base.py
@@ -33,7 +33,6 @@ def test_montecarlo_main_loop(
     config_montecarlo_1e5_verysimple.plasma.line_interaction_type = 'macroatom'
     del config_montecarlo_1e5_verysimple["config_dirname"]
 
-    print(config_montecarlo_1e5_verysimple)
     sim = Simulation.from_config(config_montecarlo_1e5_verysimple, atom_data=atomic_data)
     sim.run()
 

--- a/tardis/montecarlo/montecarlo_numba/tests/test_base.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_base.py
@@ -30,16 +30,15 @@ def test_montecarlo_main_loop(
     config_montecarlo_1e5_verysimple.montecarlo.last_no_of_packets = 1e5
     config_montecarlo_1e5_verysimple.montecarlo.no_of_virtual_packets = 0
     config_montecarlo_1e5_verysimple.montecarlo.iterations = 1
-    config_montecarlo_1e5_verysimple.montecarlo.single_packet_seed = 0
     config_montecarlo_1e5_verysimple.plasma.line_interaction_type = 'macroatom'
     del config_montecarlo_1e5_verysimple["config_dirname"]
 
+    print(config_montecarlo_1e5_verysimple)
     sim = Simulation.from_config(config_montecarlo_1e5_verysimple, atom_data=atomic_data)
     sim.run()
 
     compare_fname = os.path.join(tardis_ref_path, "montecarlo_1e5_compare_data.h5")
     if request.config.getoption("--generate-reference"):
-        print("WRITING TO HDF!")
         sim.to_hdf(compare_fname, overwrite=True)
         
     # Load compare data from refdata

--- a/tardis/montecarlo/montecarlo_numba/tests/test_base.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_base.py
@@ -15,7 +15,7 @@ def test_montecarlo_radial1d():
     assert False
 
 def test_montecarlo_main_loop(
-    config_verysimple,
+    config_montecarlo_1e5_verysimple,
     atomic_dataset,
     tardis_ref_path,
     tmpdir,
@@ -27,19 +27,19 @@ def test_montecarlo_main_loop(
     montecarlo_configuration.LEGACY_MODE_ENABLED = True
     # Setup model config from verysimple
     atomic_data = deepcopy(atomic_dataset)
-    config_verysimple.montecarlo.last_no_of_packets = 1e5
-    config_verysimple.montecarlo.no_of_virtual_packets = 0
-    config_verysimple.montecarlo.iterations = 1
-    config_verysimple.montecarlo.single_packet_seed = 0
-    config_verysimple.plasma.line_interaction_type = 'macroatom'
-    del config_verysimple["config_dirname"]
+    config_montecarlo_1e5_verysimple.montecarlo.last_no_of_packets = 1e5
+    config_montecarlo_1e5_verysimple.montecarlo.no_of_virtual_packets = 0
+    config_montecarlo_1e5_verysimple.montecarlo.iterations = 1
+    config_montecarlo_1e5_verysimple.montecarlo.single_packet_seed = 0
+    config_montecarlo_1e5_verysimple.plasma.line_interaction_type = 'macroatom'
+    del config_montecarlo_1e5_verysimple["config_dirname"]
 
-    sim = Simulation.from_config(config_verysimple, atom_data=atomic_data)
+    sim = Simulation.from_config(config_montecarlo_1e5_verysimple, atom_data=atomic_data)
     sim.run()
-
 
     compare_fname = os.path.join(tardis_ref_path, "montecarlo_1e5_compare_data.h5")
     if request.config.getoption("--generate-reference"):
+        print("WRITING TO HDF!")
         sim.to_hdf(compare_fname, overwrite=True)
         
     # Load compare data from refdata


### PR DESCRIPTION
added in a special fixture for the montecarlo_1e5 model tests as to a void mixing config fixtures.  Set the montecarlo_main_loop to recompile itself on the first iteration ot set proper config options

<!--- Provide a general summary of your changes in the title above -->
Test for numba 1e5 model was failing when run on it's own but not when run as part of the test suite.  This was caused by the single packet seed setting incorrectly setting every packet to the same seed, which was removed.  This indicated a larger problem where the montecarlo main loop was not properly being updated with the config changes after subsequent runs, so a change was added to recompile the main loop on the first iteration of each tardis run. 



**Motivation and context**
Tests failing inconsistently

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->


**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
