### PR TITLE
Add note on GPU selection to formal integral

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -247,7 +247,12 @@ class NumbaFormalIntegrator(object):
 
 class FormalIntegrator(object):
     """
-    Class containing the formal integrator
+    Class containing the formal integrator. If there is a 
+    NVIDIA CUDA GPU available, the formal integral will 
+    automatically run on it. If multiple GPUs are available, 
+    it will choose the first one that it sees. You can 
+    read more about selecting different GPUs on Numba's 
+    CUDA documentation.
     """
 
     def __init__(self, model, plasma, runner, points=1000):

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -247,12 +247,21 @@ class NumbaFormalIntegrator(object):
 
 class FormalIntegrator(object):
     """
-    Class containing the formal integrator. If there is a 
-    NVIDIA CUDA GPU available, the formal integral will 
-    automatically run on it. If multiple GPUs are available, 
-    it will choose the first one that it sees. You can 
-    read more about selecting different GPUs on Numba's 
-    CUDA documentation.
+    Class containing the formal integrator. 
+    
+    If there is a NVIDIA CUDA GPU available, 
+    the formal integral will automatically run 
+    on it. If multiple GPUs are available, it will 
+    choose the first one that it sees. You can 
+    read more about selecting different GPUs on 
+    Numba's CUDA documentation.
+    
+    Parameters
+    ----------
+    model : tardis.model.Radial1DModel
+    plasma : tardis.plasma.BasePlasma
+    runner : tardis.montecarlo.MontecarloRunner
+    points : int64
     """
 
     def __init__(self, model, plasma, runner, points=1000):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This adds a small note about which method TARDIS uses to run the formal integral.
**Description**
<!--- Describe your changes in detail -->
I added a brief explanation in the docstring of the FormalIntegrator class to inform users
that it automatically selects a NVIDIA CUDA GPU if available, and also inform them that there
are more options that can be figured, and this information can be found in the Numba CUDA documentation. 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Small note to inform users. 

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
