### PR TITLE
Fix documentation build failure due to PR #1823

### DIFF
--- a/docs/io/visualization/convergence_plot.ipynb
+++ b/docs/io/visualization/convergence_plot.ipynb
@@ -234,36 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
-  },
-  "varInspector": {
-   "cols": {
-    "lenName": 16,
-    "lenType": 16,
-    "lenVar": 40
-   },
-   "kernels_config": {
-    "python": {
-     "delete_cmd_postfix": "",
-     "delete_cmd_prefix": "del ",
-     "library": "var_list.py",
-     "varRefreshCmd": "print(var_dic_list())"
-    },
-    "r": {
-     "delete_cmd_postfix": ") ",
-     "delete_cmd_prefix": "rm(",
-     "library": "var_list.r",
-     "varRefreshCmd": "cat(var_dic_list()) "
-    }
-   },
-   "types_to_exclude": [
-    "module",
-    "function",
-    "builtin_function_or_method",
-    "instance",
-    "_Feature"
-   ],
-   "window_display": false
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/docs/io/visualization/convergence_plot.ipynb
+++ b/docs/io/visualization/convergence_plot.ipynb
@@ -13,9 +13,7 @@
    "id": "dc1a0c1f",
    "metadata": {},
    "source": [
-    "The Convergence Plots consist of two Plotly FigureWidget Subplots, the `plasma_plot` and the `t_inner_luminosities_plot`. The plots are stored in the `convergence_plots` attribute of the simulation object `sim` and can be accessed using `sim.convergence_plots.plasma_plot` and `sim.convergence_plots.t_inner_luminosities_plot`.\n",
-    "\n",
-    "The Convergence Plots are shown by default when you running TARDIS because `show_convergence_plots` parameter of the `run_tardis()` function is set to `True`. If you don't want to do this, set it to `False`. "
+    "The Convergence Plots consist of two Plotly FigureWidget Subplots, the `plasma_plot` and the `t_inner_luminosities_plot`. The plots can be displayed by setting the `show_convergence_plots` option in the `run_tardis` function to `True`. The plots are stored in the `convergence_plots` attribute of the simulation object `sim` and can be accessed using `sim.convergence_plots.plasma_plot` and `sim.convergence_plots.t_inner_luminosities_plot`."
    ]
   },
   {
@@ -48,7 +46,7 @@
     "download_atom_data('kurucz_cd23_chianti_H_He')\n",
     "\n",
     "# We run a simulation\n",
-    "sim = run_tardis('tardis_example.yml', export_convergence_plots=True)"
+    "sim = run_tardis('tardis_example.yml', show_convergence_plots=True, export_convergence_plots=True)"
    ]
   },
   {
@@ -89,7 +87,7 @@
     "The default line-colors of the plasma plots can be changed by passing the name of the cmap in the `plasma_cmap` option. \n",
     "\n",
     "```py\n",
-    "sim = run_tardis(\"tardis_example.yml\",plasma_cmap= \"viridis\")\n",
+    "sim = run_tardis(\"tardis_example.yml\", show_convergence_plots=True, plasma_cmap=\"viridis\")\n",
     "```\n",
     "\n",
     "Alongwith the cmap name, one can also provide a list of colors in rgb, hex or css-names format in the `t_inner_luminosities_colors` option to change the default colors of the luminosity and inner boundary temperature plots. \n",
@@ -127,6 +125,7 @@
    "source": [
     "sim = run_tardis(\n",
     "    \"tardis_example.yml\",\n",
+    "    show_convergence_plots=True,\n",
     "    plasma_cmap= \"viridis\", \n",
     "    t_inner_luminosities_colors = ['rgb(102, 197, 204)',\n",
     "                         'rgb(246, 207, 113)',\n",
@@ -173,6 +172,7 @@
    "source": [
     "sim = run_tardis(\n",
     "    \"tardis_example.yml\",\n",
+    "    show_convergence_plots=True,\n",
     "    plasma_plot_config={\n",
     "        \"layout\": {\n",
     "            \"template\": \"ggplot2\",\n",
@@ -234,7 +234,36 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR changes the convergence plots notebook corresponding to the changes done in PR #1823.

**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
The documentation build pipeline is failing.

**How has this been tested?**
- [X] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Link to the documentation: https://atharva-2001.github.io/tardis/branch/fix_docs_cplots/io/visualization/convergence_plot.html 

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [X] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [X] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [X] I have assigned and requested two reviewers for this pull request.
