### PR TITLE
GPU Options

### DIFF
--- a/tardis/io/schemas/spectrum.yml
+++ b/tardis/io/schemas/spectrum.yml
@@ -36,6 +36,21 @@ properties:
             integral quantities are interpolated. For -1 no interpolation
             is used. The default is to use twice the number of computational
             shells but at least 80.
+      compute:
+          type: string
+          default: "CPU"
+          description: Which method the formal_integral will be computed with.
+            It defaults to the Numba version, but it can be run on NVIDIA Cuda
+            GPUs. GPU will make it only run on a NVIDIA Cuda GPU, so if one is 
+            not available it will raise an error. Automatic first tries to find
+            an acceptable GPU, and if none is found it will run on the CPU.
+          properties:
+            type:
+              enum:
+                - "CPU"
+                - "GPU"
+                - "Automatic"
+            
   virtual:
     type: object
     default: {}

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -671,10 +671,7 @@ class MontecarloRunner(HDFWriterMixin):
 
         mc_config_module.INITIAL_TRACKING_ARRAY_LENGTH = (
             config.montecarlo.tracking.initial_array_length
-        )
-        
-        
-            
+        )  
 
         return cls(
             seed=config.montecarlo.seed,

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -272,8 +272,8 @@ class MontecarloRunner(HDFWriterMixin):
             #This was changed from unpacking to specific attributes as compute
             #is not used in calculate_spectrum
             self._spectrum_integrated = self.integrator.calculate_spectrum(
-                self.spectrum_frequency[:-1], self.integrator_settings.points, 
-                self.integrator_settings.interpolate_shells,
+                self.spectrum_frequency[:-1], points=self.integrator_settings.points, 
+                interpolate_shells=self.integrator_settings.interpolate_shells,
             )
         return self._spectrum_integrated
 
@@ -663,7 +663,6 @@ class MontecarloRunner(HDFWriterMixin):
                 """An invalid option for compute was passed. The three
                 valid values are 'GPU', 'CPU', and 'Automatic'."""
             )
-            
         
         mc_config_module.disable_line_scattering = (
             config.plasma.disable_line_scattering
@@ -671,7 +670,7 @@ class MontecarloRunner(HDFWriterMixin):
 
         mc_config_module.INITIAL_TRACKING_ARRAY_LENGTH = (
             config.montecarlo.tracking.initial_array_length
-        )  
+        )
 
         return cls(
             seed=config.montecarlo.seed,

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -18,7 +18,6 @@ from tardis.montecarlo.montecarlo_numba.numba_interface import (
     NumbaModel,
     NumbaPlasma,
 )
-from numba import cuda
 from tardis.montecarlo.montecarlo_numba.formal_integral_cuda import CudaFormalIntegrator
 
 from tardis.montecarlo.spectrum import TARDISSpectrum

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -287,7 +287,7 @@ class FormalIntegrator(object):
         self.numba_plasma = numba_plasma_initialize(
             self.original_plasma, self.runner.line_interaction_type
         )
-        if cuda.is_available():
+        if self.runner.use_gpu:
             self.integrator = CudaFormalIntegrator(
                 self.numba_model, self.numba_plasma, self.points
             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Allows a user to select which method the formal_integral should run. 

**Description**
<!--- Describe your changes in detail -->
Added the compute option in schemas for the config.yml so now users can add compute under spectrum/integrated to select different options for running the formal_integral. The other two are GPU and Automatic. GPU will try to use a NVIDIA Cuda GPU, and if none are available it will throw an error. Automatic will first try to find a GPU, and if none can be found it will default to running on numba. If GPU, CPU, or Automatic are not passed as arguments, it will throw an error for an invalid parameter. (All of them are set to be upper so user case is not an issue). 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Feature

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
