### PR TITLE
Fixing documentation links and misc. API documentation issues

### DIFF
--- a/docs/contributing/development/git_workflow.rst
+++ b/docs/contributing/development/git_workflow.rst
@@ -364,6 +364,8 @@ To make sure that your changes are still working on the new master, you want to
 *rebase* your branch on top of the evolved master.
 
 
+.. _rebase-on-trunk:
+
 Rebasing on trunk
 ^^^^^^^^^^^^^^^^^
 

--- a/tardis/model/density.py
+++ b/tardis/model/density.py
@@ -204,7 +204,7 @@ def calculate_density_after_time(densities, time_0, time_explosion):
     time of the explosion by ^-3
 
     Parameters
-    -----------
+    ----------
     densities : astropy.units.Quantity
         densities
     time_0 : astropy.units.Quantity
@@ -213,7 +213,7 @@ def calculate_density_after_time(densities, time_0, time_explosion):
         time to be scaled to
 
     Returns
-    --------
+    -------
     scaled_density
     """
 

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -264,7 +264,12 @@ class MonteCarloTransProbs(ProcessingPlasmaProperty):
     """
     Attributes
     ----------
-    
+    non_continuum_trans_probs
+    level_absorption_probs
+    deactivation_channel_probs
+    transition_probabilities
+    macro_block_references
+    macro_atom_data
     """
 
     def calculate(
@@ -353,8 +358,9 @@ class MonteCarloTransProbs(ProcessingPlasmaProperty):
         deactivation_channel_probs = pd.concat(
             [
                 level_idxs2transition_idx.loc[deactivation_channel_probs.index],
-                deactivation_channel_probs
-            ], axis=1
+                deactivation_channel_probs,
+            ],
+            axis=1,
         ).reindex(deactivation_channel_probs.index)
 
         deactivation_channel_probs = deactivation_channel_probs.drop(

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -264,6 +264,7 @@ class MonteCarloTransProbs(ProcessingPlasmaProperty):
     """
     Attributes
     ----------
+    
     """
 
     def calculate(

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -264,7 +264,6 @@ class MonteCarloTransProbs(ProcessingPlasmaProperty):
     """
     Attributes
     ----------
-    
     """
 
     def calculate(

--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -128,7 +128,9 @@ class TableSummaryLabel:
         label_value : int
             Initial summary value of the table to be shown in label
 
-        .. note:: TableSummaryLabel can only be created for a table with two
+        Notes
+        -----
+        TableSummaryLabel can only be created for a table with two
         columns (including index as 1st column) as of now
         """
         if len(table_col_widths) != 2:
@@ -155,8 +157,8 @@ class TableSummaryLabel:
         value : int
             Value to be shown in label
 
-        Note
-        ----
+        Notes
+        -----
         The width resizing operation is highly dependent on qgrid tables'
         layout. So it may not remain precise if there happens any CSS change
         in upcoming versions of qgrid.

--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -128,10 +128,8 @@ class TableSummaryLabel:
         label_value : int
             Initial summary value of the table to be shown in label
 
-        Notes
-        -----
-        TableSummaryLabel can only be created for a table with two columns
-        (including index as 1st column) as of now
+        .. note:: TableSummaryLabel can only be created for a table with two
+        columns (including index as 1st column) as of now
         """
         if len(table_col_widths) != 2:
             raise NotImplementedError(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
I fix a link in the contributing section of the documentation and fix various issues with docstrings to make the API documentation appear correctly and eliminate sphinx warnings.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
This is just general maintenance of the documentation.

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Documentation built locally and on GitHub. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
GitHub docs build with no warnings: https://github.com/smithis7/tardis/runs/5459550673#step:5:416

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [x] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
