### PR TITLE
Fixing latex_label Parameter within write_to_tex function

### DIFF
--- a/tardis/plasma/base.py
+++ b/tardis/plasma/base.py
@@ -317,7 +317,7 @@ class BasePlasma(PlasmaWriterMixin):
         for edge in print_graph.edges:
             label = print_graph.edges[edge]["label"]
             print_graph.edges[edge]["label"] = " "
-            if latex_label:
+            if latex_label is not None:
                 print_graph.edges[edge]["texlbl"] = label
 
         nx.drawing.nx_agraph.write_dot(print_graph, fname)

--- a/tardis/plasma/base.py
+++ b/tardis/plasma/base.py
@@ -316,8 +316,9 @@ class BasePlasma(PlasmaWriterMixin):
 
         for edge in print_graph.edges:
             label = print_graph.edges[edge]["label"]
-            print_graph.edges[edge]["label"] = "-"
-            print_graph.edges[edge]["texlbl"] = label
+            print_graph.edges[edge]["label"] = " "
+            if latex_label:
+                print_graph.edges[edge]["texlbl"] = label
 
         nx.drawing.nx_agraph.write_dot(print_graph, fname)
 

--- a/tardis/plasma/base.py
+++ b/tardis/plasma/base.py
@@ -296,7 +296,7 @@ class BasePlasma(PlasmaWriterMixin):
         print_graph = self.remove_hidden_properties(print_graph)
 
         for node in print_graph:
-            if latex_label:
+            if latex_label == True:
                 if hasattr(self.plasma_properties_dict[node], "latex_formula"):
                     print_graph.nodes[str(node)][
                         "label"
@@ -317,13 +317,13 @@ class BasePlasma(PlasmaWriterMixin):
         for edge in print_graph.edges:
             label = print_graph.edges[edge]["label"]
             print_graph.edges[edge]["label"] = " "
-            if latex_label is not None:
+            if latex_label == True:
                 print_graph.edges[edge]["texlbl"] = label
 
         nx.drawing.nx_agraph.write_dot(print_graph, fname)
 
         for line in fileinput.FileInput(fname, inplace=1):
-            if latex_label:
+            if latex_label == True:
                 print(
                     line.replace(
                         r'node [label="\N"]',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
The `latex_label` parameter on the `write_to_tex` plasma function does not work as intended and this PR addresses this issue

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
With this, the `latex_label` parameter now works as intended.

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->
Before this change, the `write_to_tex` function would not write the edge labels written in latex on any outputted file regardless of the state of `latex_label` as shown below using all default inputs:
![Base_Graph_Before_Change](https://user-images.githubusercontent.com/72052791/163041622-24b4ec14-71b7-49b6-a2c6-aec0375e4e4a.png)

With this change, the function will now write the edge labels unless `latex_label` is set to `False` as shown here:
![Base_Graph_After_Change](https://user-images.githubusercontent.com/72052791/163041729-1364a832-e694-4a0e-9194-a604ce14797a.png)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
