### PR TITLE
Intensity p rays

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -588,11 +588,11 @@ class FormalIntegrator(object):
                 for i in range(nu.shape[0])
             ]
         )
+        error = np.max(np.abs((L_test - L) / L))
         assert (
-            np.max(np.abs((L_test - L) / L)) < 1e-7
-        ), "Incorrect I_nu_p values, max relative difference:{}".format(
-            np.max(np.abs((L_test - L) / L))
-        )
+            error < 1e-7
+        ), f"Incorrect I_nu_p values, max relative difference:{error}"
+
         return np.array(L, np.float64)
 
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -48,6 +48,13 @@ def numba_formal_integral(
 ):
     """
     model, plasma, and estimator are the numba variants
+    Returns 
+    -------
+    L : float64 array
+        integrated luminosities
+    I_nu_p : float64 2D array
+        intensities at each p-ray multiplied by p
+        frequency x p-ray grid
     """
     # todo: add all the original todos
     # Initialize the output which is shared among threads
@@ -66,7 +73,6 @@ def numba_formal_integral(
     # now loop over wavelength in spectrum
     I_nu_p = np.zeros((inu_size, N), dtype=np.float64)
     for nu_idx in prange(inu_size):
-        #I_nu = np.zeros(N, dtype=np.float64)
         I_nu = I_nu_p[nu_idx]
         z = np.zeros(2 * size_shell, dtype=np.float64)
         shell_id = np.zeros(2 * size_shell, dtype=np.int64)

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -571,6 +571,7 @@ class FormalIntegrator(object):
         ps = calculate_p_values(R_max, N)[None, :]
         I_nu_p[:, 1:] /= ps[:, 1:]
         self.runner.I_nu_p = I_nu_p
+        self.runner.p_rays = ps
 
         I_nu = self.runner.I_nu_p*ps
         L_test = np.array([8 * M_PI * M_PI * trapezoid_integration((I_nu)[i, :], R_max / N) for i in range(nu.shape[0])])

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -18,7 +18,9 @@ from tardis.montecarlo.montecarlo_numba.numba_interface import (
     NumbaModel,
     NumbaPlasma,
 )
-from tardis.montecarlo.montecarlo_numba.formal_integral_cuda import CudaFormalIntegrator
+from tardis.montecarlo.montecarlo_numba.formal_integral_cuda import (
+    CudaFormalIntegrator,
+)
 
 from tardis.montecarlo.spectrum import TARDISSpectrum
 
@@ -48,7 +50,7 @@ def numba_formal_integral(
 ):
     """
     model, plasma, and estimator are the numba variants
-    Returns 
+    Returns
     -------
     L : float64 array
         integrated luminosities
@@ -202,14 +204,14 @@ def numba_formal_integral(
     return L, I_nu_p
 
 
-#integrator_spec = [
+# integrator_spec = [
 #    ("model", NumbaModel.class_type.instance_type),
 #    ("plasma", NumbaPlasma.class_type.instance_type),
 #    ("points", int64),
-#]
+# ]
 
 
-#@jitclass(integrator_spec)
+# @jitclass(integrator_spec)
 class NumbaFormalIntegrator(object):
     """
     Helper class for performing the formal integral
@@ -254,15 +256,15 @@ class NumbaFormalIntegrator(object):
 
 class FormalIntegrator(object):
     """
-    Class containing the formal integrator. 
-    
-    If there is a NVIDIA CUDA GPU available, 
-    the formal integral will automatically run 
-    on it. If multiple GPUs are available, it will 
-    choose the first one that it sees. You can 
-    read more about selecting different GPUs on 
+    Class containing the formal integrator.
+
+    If there is a NVIDIA CUDA GPU available,
+    the formal integral will automatically run
+    on it. If multiple GPUs are available, it will
+    choose the first one that it sees. You can
+    read more about selecting different GPUs on
     Numba's CUDA documentation.
-    
+
     Parameters
     ----------
     model : tardis.model.Radial1DModel
@@ -390,9 +392,9 @@ class FormalIntegrator(object):
         model = self.model
         runner = self.runner
 
-        #macro_ref = self.atomic_data.macro_atom_references
+        # macro_ref = self.atomic_data.macro_atom_references
         macro_ref = self.atomic_data.macro_atom_references
-        #macro_data = self.atomic_data.macro_atom_data
+        # macro_data = self.atomic_data.macro_atom_data
         macro_data = self.original_plasma.macro_atom_data
 
         no_lvls = len(self.atomic_data.levels)
@@ -579,9 +581,18 @@ class FormalIntegrator(object):
         self.runner.I_nu_p = I_nu_p
         self.runner.p_rays = ps
 
-        I_nu = self.runner.I_nu_p*ps
-        L_test = np.array([8 * M_PI * M_PI * trapezoid_integration((I_nu)[i, :], R_max / N) for i in range(nu.shape[0])])
-        assert np.max(np.abs((L_test-L)/L)) < 1e-7, "Incorrect I_nu_p values, max relative difference:{}".format(np.max(np.abs((L_test-L)/L)))
+        I_nu = self.runner.I_nu_p * ps
+        L_test = np.array(
+            [
+                8 * M_PI * M_PI * trapezoid_integration((I_nu)[i, :], R_max / N)
+                for i in range(nu.shape[0])
+            ]
+        )
+        assert (
+            np.max(np.abs((L_test - L) / L)) < 1e-7
+        ), "Incorrect I_nu_p values, max relative difference:{}".format(
+            np.max(np.abs((L_test - L) / L))
+        )
         return np.array(L, np.float64)
 
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -64,8 +64,10 @@ def numba_formal_integral(
     line_list_nu = plasma.line_list_nu
     # done with instantiation
     # now loop over wavelength in spectrum
+    I_nu_p = np.zeros((inu_size, N), dtype=np.float64)
     for nu_idx in prange(inu_size):
-        I_nu = np.zeros(N, dtype=np.float64)
+        #I_nu = np.zeros(N, dtype=np.float64)
+        I_nu = I_nu_p[nu_idx]
         z = np.zeros(2 * size_shell, dtype=np.float64)
         shell_id = np.zeros(2 * size_shell, dtype=np.int64)
         offset = 0
@@ -191,7 +193,7 @@ def numba_formal_integral(
             I_nu[p_idx] *= p
         L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu, R_max / N)
 
-    return L
+    return L, I_nu_p
 
 
 #integrator_spec = [
@@ -554,7 +556,7 @@ class FormalIntegrator(object):
         Jblue_lu = res[2].flatten(order="F")
 
         self.generate_numba_objects()
-        L = self.integrator.formal_integral(
+        L, I_nu_p = self.integrator.formal_integral(
             self.model.t_inner,
             nu,
             nu.shape[0],
@@ -565,6 +567,7 @@ class FormalIntegrator(object):
             self.runner.electron_densities_integ,
             N,
         )
+        self.runner.I_nu_p = I_nu_p
         return np.array(L, np.float64)
 
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -567,7 +567,14 @@ class FormalIntegrator(object):
             self.runner.electron_densities_integ,
             N,
         )
+        R_max = self.runner.r_outer_i[-1]
+        ps = calculate_p_values(R_max, N)[None, :]
+        I_nu_p[:, 1:] /= ps[:, 1:]
         self.runner.I_nu_p = I_nu_p
+
+        I_nu = self.runner.I_nu_p*ps
+        L_test = np.array([8 * M_PI * M_PI * trapezoid_integration((I_nu)[i, :], R_max / N) for i in range(nu.shape[0])])
+        assert np.max(np.abs((L_test-L)/L)) < 1e-7, "Incorrect I_nu_p values, max relative difference:{}".format(np.max(np.abs((L_test-L)/L)))
         return np.array(L, np.float64)
 
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
@@ -282,7 +282,6 @@ class CudaFormalIntegrator(object):
             z,
             shell_id,
         )
-        
 
         return L, I_nu
 
@@ -376,6 +375,7 @@ class BoundsError(IndexError):
     Used to check bounds in reverse
     binary search
     """
+
     pass
 
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
@@ -282,8 +282,9 @@ class CudaFormalIntegrator(object):
             z,
             shell_id,
         )
+        
 
-        return L
+        return L, I_nu
 
 
 @cuda.jit(device=True)

--- a/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
@@ -375,7 +375,7 @@ def test_full_formal_integral(
         formal_integrator_cuda.runner.tau_sobolevs_integ,
         formal_integrator_cuda.runner.electron_densities_integ,
         formal_integrator_cuda.points,
-    )
+    )[0]
 
     L_numba = formal_integrator_numba.integrator.formal_integral(
         formal_integrator_numba.model.t_inner,
@@ -387,6 +387,6 @@ def test_full_formal_integral(
         formal_integrator_numba.runner.tau_sobolevs_integ,
         formal_integrator_numba.runner.electron_densities_integ,
         formal_integrator_numba.points,
-    )
+    )[0]
 
     ntest.assert_allclose(L_cuda, L_numba, rtol=1e-14)

--- a/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
@@ -66,9 +66,7 @@ def black_body_caller(nu, T, actual):
 @pytest.mark.skipif(
     not GPUs_available, reason="No GPU is available to test CUDA function"
 )
-@pytest.mark.parametrize(
-    "N", (1e2, 1e3, 1e4, 1e5)
-)
+@pytest.mark.parametrize("N", (1e2, 1e3, 1e4, 1e5))
 def test_trapezoid_integration_cuda(N):
     """
     Initializes the test of the cuda version
@@ -85,10 +83,10 @@ def test_trapezoid_integration_cuda(N):
 
     expected = formal_integral_numba.trapezoid_integration(data, h)
     trapezoid_integration_caller[1, 1](data, h, actual)
-    
-    #This is 1e-13, as more points are added to the integration
-    #there will be more floating point error due to the difference
-    #in how the trapezoid integration is called. 
+
+    # This is 1e-13, as more points are added to the integration
+    # there will be more floating point error due to the difference
+    # in how the trapezoid integration is called.
     ntest.assert_allclose(actual[0], expected, rtol=1e-13)
 
 
@@ -100,7 +98,6 @@ def trapezoid_integration_caller(data, h, actual):
     """
     x = cuda.grid(1)
     actual[x] = formal_integral_cuda.trapezoid_integration_cuda(data, h)
-
 
 
 TESTDATA_model = [


### PR DESCRIPTION
Add the intensity p-ray values (as well as the p-ray impact parameters) to the runner.  

**Description**

The intensity p-rays are indexed by frequency then p.  Values are in cgs (the array itself is unitless).  Can be accessed by runner.I_nu_p and runner.p_rays after running the integrated spectrum.

**Motivation and context**
Requested

**How has this been tested?**
- [x] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->
Currently an assertion just happens inside the formal integral to make sure the integrated intensity adds up to the computed luminosity.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
