### PR TITLE
Set astroPy version

### DIFF
--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -7,7 +7,7 @@ proposed by M. Kromer (see, for example, Kromer et al. 2013, figure 4).
 import numpy as np
 import pandas as pd
 import astropy.units as u
-import astropy.modeling.blackbody as abb
+import astropy.constants as const
 
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
@@ -21,6 +21,7 @@ from tardis.util.base import (
     species_tuple_to_string,
     roman_to_int,
     int_to_roman,
+    intensity_black_body,
 )
 from tardis.visualization import plot_util as pu
 
@@ -1065,12 +1066,14 @@ class SDECPlotter:
             of TARDIS simulation)
         """
         L_lambda_ph = (
-            abb.blackbody_lambda(
-                self.plot_wavelength,
+            intensity_black_body(
+                const.c.to("cm / s").value / self.plot_wavelength,
                 self.data[packets_mode].t_inner,
             )
+            * u.erg
+            / u.s
             * 4
-            * np.pi ** 2
+            * np.pi**2
             * self.data[packets_mode].r_inner[0] ** 2
             * u.sr
         ).to("erg / (AA s)")

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -11,10 +11,10 @@ dependencies:
   - numpy=1.19
   - scipy=1.5
   - pandas=1.0
-  - astropy=3
+  - astropy>=4.1
   - numba=0.53
   - numexpr
-  - pyne=0.7=nomoab_openmc*  # Issue #1537
+  - pyne=0.7=nomoab_openmc* # Issue #1537
 
   # Plasma
   - networkx
@@ -25,7 +25,7 @@ dependencies:
   - jsonschema=3 # Issue #1807
   - pytables
   - h5py
-  - pickle5  # Issue #1566
+  - pickle5 # Issue #1566
   - requests
   - tqdm
 
@@ -35,9 +35,9 @@ dependencies:
   - ipywidgets
   - plotly
   - qgrid
-# - pyside2  # (Qt GUI) Issue #1652
+  # - pyside2  # (Qt GUI) Issue #1652
 
-# --- Not required for conda-forge package and Numba integration pipeline ---
+  # --- Not required for conda-forge package and Numba integration pipeline ---
 
   # tardis-sn/nuclear dependencies
   - beautifulsoup4
@@ -56,7 +56,7 @@ dependencies:
   - nbconvert
   - nbformat
   - nbsphinx
-  - docutils=0.16  # Issue #1522
+  - docutils=0.16 # Issue #1522
   - snakeviz
 
   # Test/Coverage
@@ -73,4 +73,4 @@ dependencies:
   - git-lfs
 
   - pip:
-      - dot2tex  # conda-forge package requires python>=3.8
+      - dot2tex # conda-forge package requires python>=3.8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
This PR aims to set the minimum `astropy` version to 4.1 in TARDIS. To do this, functions deprecated in `astropy` 4.0 are replaced to fix deprecation warnings.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
This change is required to remove distutils warnings created by older versions of `astropy`, see PR #1813.

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
After updating the SDEC plotter to use the built-in blackbody function, the [SDEC interactive notebook](https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath=docs/io/visualization/sdec_plot.ipynb) 
generates a blackbody spectrum that is physically realistic:

![image](https://user-images.githubusercontent.com/84729132/160935458-954c644e-63b8-4a9e-bfcb-f20ac2ff222d.png)

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
