### PR TITLE
Removing Levels Index Variable Within Atomic Data Preperation

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -330,10 +330,6 @@ class AtomData(object):
 
         self.nlte_species = nlte_species
 
-        self.levels_index = pd.Series(
-            np.arange(len(self.levels), dtype=int), index=self.levels.index
-        )
-
         # cutting levels_lines
         self.lines = self.lines[
             self.lines.index.isin(
@@ -352,20 +348,8 @@ class AtomData(object):
             "level_number_upper"
         )
 
-        self.lines_lower2level_idx = (
-            self.levels_index.loc[tmp_lines_lower2level_idx]
-            .astype(np.int64)
-            .values
-        )
-
         tmp_lines_upper2level_idx = self.lines.index.droplevel(
             "level_number_lower"
-        )
-
-        self.lines_upper2level_idx = (
-            self.levels_index.loc[tmp_lines_upper2level_idx]
-            .astype(np.int64)
-            .values
         )
 
         if (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
This removed the `levels_index` variable as well as a few other variables associated with it 

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
This aims to allow faster computing of the plasma state

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
