### PR TITLE
fixed index typo in Saha solver documentation

### DIFF
--- a/docs/physics/setup/plasma/lte_plasma.rst
+++ b/docs/physics/setup/plasma/lte_plasma.rst
@@ -25,7 +25,7 @@ In the second step (`LTEPlasma.calculate_ionization_balance`), we calculate in a
     N(X) &= N_1 + N_2 + N_3 + \dots\\
     N(X) &= N_1 + \frac{N_2}{N_1} N_1 + \frac{N_3}{N_2}\frac{N_2}{N_1} N_1 + \frac{N_4}{N_3}\frac{N_3}{N_2}\frac{N_2}{N_1} N_1 + \dots\\
     N(X) &= N_1 (1 + \frac{N_2}{N_1} + \frac{N_3}{N_2}\frac{N_2}{N_1} + \frac{N_4}{N_3}\frac{N_3}{N_2}\frac{N_2}{N_1} + \dots)\\
-    N(X) &= N_1 \underbrace{(1 + \frac{\Phi_{i, 2/1}}{N_e} + \frac{\Phi_{i, 2/2}}{N_e}\frac{\Phi_{i, 2/1}}{N_e} +
+    N(X) &= N_1 \underbrace{(1 + \frac{\Phi_{i, 2/1}}{N_e} + \frac{\Phi_{i, 3/2}}{N_e}\frac{\Phi_{i, 2/1}}{N_e} +
             \frac{\Phi_{i, 4/3}}{N_e}\frac{\Phi_{i, 3/2}}{N_e}\frac{\Phi_{i, 2/1}}{N_e} + \dots)}_{\alpha}\\
     N_1 &= \frac{N(X)}{\alpha}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
The documentation of the Saha LTE ionisation solver has a typo in the index: 
https://tardis-sn.github.io/tardis/physics/setup/plasma/lte_plasma.html

**Description**
The Phi index in the red box shown in the screenshot below should be 3/2 (see following term):
<img width="907" alt="Screenshot 2022-04-20 at 14 10 24" src="https://user-images.githubusercontent.com/33418619/164229555-dc7895a5-a738-4885-b803-26b6502f25ca.png">

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [x] My change requires a change to the documentation.
    - [x] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
