### PR TITLE
Plasma number densities using isotopes

### DIFF
--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -573,7 +573,7 @@ class IsotopeMass(ProcessingPlasmaProperty):
                 element_name = rd.utils.Z_to_elem(Z)
                 isotope_name = element_name + str(A)
 
-                isotope_mass_dict[i] = rd.Nuclide(isotope_name).atomic_mass
+                isotope_mass_dict[(Z, A)] = rd.Nuclide(isotope_name).atomic_mass
 
             isotope_mass_df = pd.DataFrame.from_dict(
                 isotope_mass_dict, orient="index", columns=["mass"]

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -569,9 +569,9 @@ class IsotopeMass(ProcessingPlasmaProperty):
             if isotope_abundance.empty:
                 return None
             isotope_mass_dict = {}
-            for i in isotope_abundance.index:
-                element_name = rd.utils.Z_to_elem(i[0])
-                isotope_name = element_name + str(i[1])
+            for Z, A in isotope_abundance.index:
+                element_name = rd.utils.Z_to_elem(Z)
+                isotope_name = element_name + str(A)
 
                 isotope_mass_dict[i] = rd.Nuclide(isotope_name).atomic_mass
 

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -538,6 +538,7 @@ class AtomicMass(ProcessingPlasmaProperty):
         else:
             return atomic_data.atom_data.loc[selected_atoms].mass
 
+
 class IsotopeMass(ProcessingPlasmaProperty):
     """
     Attributes
@@ -558,9 +559,17 @@ class IsotopeMass(ProcessingPlasmaProperty):
             for i in isotope_abundance.index:
                 element_name = rd.utils.Z_to_elem(i[0])
                 isotope_name = element_name + str(i[1])
-                
-                isotope_mass_dict[isotope_name] = rd.Nuclide(isotope_name).atomic_mass
-            return pd.DataFrame.from_dict(isotope_mass_dict, orient="index", columns=["mass"])
+
+                isotope_mass_dict[i] = rd.Nuclide(isotope_name).atomic_mass
+
+            isotope_mass_df = pd.DataFrame.from_dict(
+                isotope_mass_dict, orient="index", columns=["mass"]
+            )
+            isotope_mass_df.index = pd.MultiIndex.from_tuples(
+                isotope_mass_df.index
+            )
+            isotope_mass_df.index.names = ["atomic_number", "mass_number"]
+            return isotope_mass_df / const.N_A
 
 
 class IonizationData(BaseAtomicDataProperty):

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -6,6 +6,7 @@ from numba import njit
 from scipy.special import expn
 from scipy.interpolate import PchipInterpolator
 from collections import Counter as counter
+import radioactivedecay as rd
 from tardis import constants as const
 
 from tardis.plasma.properties.base import (
@@ -32,6 +33,7 @@ __all__ = [
     "LinesLowerLevelIndex",
     "LinesUpperLevelIndex",
     "AtomicMass",
+    "IsotopeMass",
     "IonizationData",
     "ZetaData",
     "NLTEData",
@@ -535,6 +537,30 @@ class AtomicMass(ProcessingPlasmaProperty):
             return (getattr(self, self.outputs[0]),)
         else:
             return atomic_data.atom_data.loc[selected_atoms].mass
+
+class IsotopeMass(ProcessingPlasmaProperty):
+    """
+    Attributes
+    ----------
+    isotope_mass : pandas.Series
+        Masses of the isotopes used. Indexed by isotope name e.g. 'Ni56'.
+    """
+
+    outputs = ("isotope_mass",)
+
+    def calculate(self, isotope_abundance):
+        if getattr(self, self.outputs[0]) is not None:
+            return (getattr(self, self.outputs[0]),)
+        else:
+            if isotope_abundance.empty:
+                return None
+            isotope_mass_dict = {}
+            for i in isotope_abundance.index:
+                element_name = rd.utils.Z_to_elem(i[0])
+                isotope_name = element_name + str(i[1])
+                
+                isotope_mass_dict[isotope_name] = rd.Nuclide(isotope_name).atomic_mass
+            return pd.DataFrame.from_dict(isotope_mass_dict, orient="index", columns=["mass"])
 
 
 class IonizationData(BaseAtomicDataProperty):

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -550,6 +550,19 @@ class IsotopeMass(ProcessingPlasmaProperty):
     outputs = ("isotope_mass",)
 
     def calculate(self, isotope_abundance):
+        """
+        Determine mass of each isotope.
+
+        Parameters
+        ----------
+        isotope_abundance : pandas.DataFrame
+            Fractional abundance of isotopes.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Masses of the isotopes used. Indexed by isotope name e.g. 'Ni56'.
+        """
         if getattr(self, self.outputs[0]) is not None:
             return (getattr(self, self.outputs[0]),)
         else:

--- a/tardis/plasma/properties/general.py
+++ b/tardis/plasma/properties/general.py
@@ -99,7 +99,7 @@ class NumberDensity(ProcessingPlasmaProperty):
 class IsotopeNumberDensity(ProcessingPlasmaProperty):
     """
     Calculate the atom number density based on isotope mass.
-    
+
     Attributes
     ----------
     isotope_number_density : Pandas DataFrame, dtype float

--- a/tardis/plasma/properties/general.py
+++ b/tardis/plasma/properties/general.py
@@ -98,6 +98,8 @@ class NumberDensity(ProcessingPlasmaProperty):
 
 class IsotopeNumberDensity(ProcessingPlasmaProperty):
     """
+    Calculate the atom number density based on isotope mass.
+    
     Attributes
     ----------
     isotope_number_density : Pandas DataFrame, dtype float
@@ -109,6 +111,23 @@ class IsotopeNumberDensity(ProcessingPlasmaProperty):
 
     @staticmethod
     def calculate(isotope_mass, isotope_abundance, density):
+        """
+        Calculate the atom number density based on isotope mass.
+
+        Parameters
+        ----------
+        isotope_mass : pandas.DataFrame
+            Masses of isotopes.
+        isotope_abundance : pandas.DataFrame
+            Fractional abundance of isotopes.
+        density : pandas.DataFrame
+            Density of each shell.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Indexed by atomic number, columns corresponding to zones.
+        """
         number_densities = isotope_abundance * density
         isotope_number_density_array = (
             number_densities.to_numpy() / isotope_mass.to_numpy()

--- a/tardis/plasma/properties/general.py
+++ b/tardis/plasma/properties/general.py
@@ -13,6 +13,7 @@ __all__ = [
     "BetaRadiation",
     "GElectron",
     "NumberDensity",
+    "IsotopeNumberDensity",
     "SelectedAtoms",
     "ElectronTemperature",
     "BetaElectron",
@@ -93,6 +94,28 @@ class NumberDensity(ProcessingPlasmaProperty):
     def calculate(atomic_mass, abundance, density):
         number_densities = abundance * density
         return number_densities.div(atomic_mass.loc[abundance.index], axis=0)
+
+
+class IsotopeNumberDensity(ProcessingPlasmaProperty):
+    """
+    Attributes
+    ----------
+    isotope_number_density : Pandas DataFrame, dtype float
+                     Indexed by atomic number, columns corresponding to zones
+    """
+
+    outputs = ("isotope_number_density",)
+    latex_name = ("N_{i}",)
+
+    @staticmethod
+    def calculate(isotope_mass, isotope_abundance, density):
+        number_densities = isotope_abundance * density
+        isotope_number_density_array = (
+            number_densities.to_numpy() / isotope_mass.to_numpy()
+        )
+        return pd.DataFrame(
+            isotope_number_density_array, index=isotope_abundance.index
+        )
 
 
 class SelectedAtoms(ProcessingPlasmaProperty):

--- a/tardis/plasma/properties/plasma_input.py
+++ b/tardis/plasma/properties/plasma_input.py
@@ -5,6 +5,7 @@ __all__ = [
     "DilutionFactor",
     "AtomicData",
     "Abundance",
+    "IsotopeAbundance",
     "Density",
     "TimeExplosion",
     "JBlueEstimator",
@@ -60,6 +61,17 @@ class Abundance(Input):
     """
 
     outputs = ("abundance",)
+
+
+class IsotopeAbundance(Input):
+    """
+    Attributes
+    ----------
+    isotope_abundance : Numpy array, dtype float
+        Fractional abundance of isotopes
+    """
+
+    outputs = ("isotope_abundance",)
 
 
 class Density(ArrayInput):

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -150,3 +150,6 @@ two_photon_properties = PlasmaPropertyCollection(
         TwoPhotonFrequencySampler,
     ]
 )
+isotope_properties = PlasmaPropertyCollection(
+    [IsotopeAbundance, IsotopeMass, IsotopeNumberDensity]
+)

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -27,6 +27,7 @@ from tardis.plasma.properties.property_collections import (
     continuum_interaction_inputs,
     adiabatic_cooling_properties,
     two_photon_properties,
+    isotope_properties,
 )
 from tardis.plasma.exceptions import PlasmaConfigError
 
@@ -247,6 +248,9 @@ def assemble_plasma(config, model, atom_data=None):
             property_kwargs[IonNumberDensity] = dict(
                 electron_densities=electron_densities
             )
+
+    if model.raw_isotope_abundance:
+        plasma_modules += isotope_properties
 
     kwargs["helium_treatment"] = config.plasma.helium_treatment
 

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -249,8 +249,9 @@ def assemble_plasma(config, model, atom_data=None):
                 electron_densities=electron_densities
             )
 
-    if model.raw_isotope_abundance:
+    if not model.raw_isotope_abundance.empty:
         plasma_modules += isotope_properties
+        kwargs.update(isotope_abundance=model.raw_isotope_abundance)
 
     kwargs["helium_treatment"] = config.plasma.helium_treatment
 

--- a/tardis/plasma/tests/test_tardis_model_density_config.py
+++ b/tardis/plasma/tests/test_tardis_model_density_config.py
@@ -31,6 +31,11 @@ def test_electron_densities(raw_plasma):
     assert_almost_equal(raw_plasma.electron_densities[3], 2.6e14)
 
 
+def test_isotope_number_densities(raw_plasma):
+    assert_almost_equal(raw_plasma.isotope_number_density[0], 2.72e14)
+    assert_almost_equal(raw_plasma.isotope_number_density[1], 2.6e14)
+
+
 def test_t_rad(raw_plasma):
     assert_almost_equal(raw_plasma.t_rad[5], 76459.592)
     assert_almost_equal(raw_plasma.t_rad[3], 76399.042)

--- a/tardis/plasma/tests/test_tardis_model_density_config.py
+++ b/tardis/plasma/tests/test_tardis_model_density_config.py
@@ -32,8 +32,12 @@ def test_electron_densities(raw_plasma):
 
 
 def test_isotope_number_densities(raw_plasma):
-    assert_almost_equal(raw_plasma.isotope_number_density[0], 2.72e14)
-    assert_almost_equal(raw_plasma.isotope_number_density[1], 2.6e14)
+    assert_almost_equal(
+        raw_plasma.isotope_number_density.loc[(28, 56), 0], 9688803936.317898
+    )
+    assert_almost_equal(
+        raw_plasma.isotope_number_density.loc[(28, 58), 1], 13097656958.746628
+    )
 
 
 def test_t_rad(raw_plasma):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
The current calculations for number density are performed using mean atomic mass instead of isotope mass, leading to disagreements of up to 5% (and possibly more) with other codes in number densities.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Gamma-ray deposition code relies heavily on isotopes

**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [x] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
