### PR TITLE
Fix low temperature problem of Van Regemorter approximation

### DIFF
--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -3,7 +3,7 @@ import logging
 import numpy as np
 import pandas as pd
 from numba import njit
-from scipy.special import expn
+from scipy.special import exp1
 from scipy.interpolate import PchipInterpolator
 from collections import Counter as counter
 import radioactivedecay as rd
@@ -758,9 +758,9 @@ class YgData(ProcessingPlasmaProperty):
         )
         return yg_data, t_yg, index, delta_E, yg_idx
 
-    @staticmethod
+    @classmethod
     def calculate_yg_van_regemorter(
-        atomic_data, t_electrons, continuum_interaction_species
+        cls, atomic_data, t_electrons, continuum_interaction_species
     ):
         """
         Calculate collision strengths in the van Regemorter approximation.
@@ -806,12 +806,36 @@ class YgData(ProcessingPlasmaProperty):
         yg = 14.5 * coll_const * t_electrons * yg[:, np.newaxis]
 
         u0 = nu_lines[np.newaxis].T / t_electrons * (H / K_B)
-        gamma = 0.276 * np.exp(u0) * expn(1, u0)
+        gamma = 0.276 * cls.exp1_times_exp(u0)
         gamma[gamma < 0.2] = 0.2
         yg *= u0 * gamma / BETA_COLL
         yg = pd.DataFrame(yg, index=lines_filtered.index, columns=t_electrons)
 
         return yg
+
+    @staticmethod
+    def exp1_times_exp(x):
+        """
+        Product of the Exponential integral E1 and an exponential.
+
+        This function calculates the product of the Exponential integral E1
+        and an exponential in a way that also works for large values.
+
+        Parameters
+        ----------
+        x : array_like
+            Input values.
+
+        Returns
+        -------
+        array_like
+            Output array.
+        """
+        f = exp1(x) * np.exp(x)
+        # Use Laurent series for large values to avoid infinite exponential
+        mask = x > 500
+        f[mask] = (x**-1 - x**-2 + 2 * x**-3 - 6 * x**-4)[mask]
+        return f
 
 
 class YgInterpolator(ProcessingPlasmaProperty):


### PR DESCRIPTION
The exponential in the calculation of the van Regemorter approximation can become infinite, e.g. for 100 K and transition energies bigger than roughly 6.5 eV:
`np.exp(((6.5 * units.eV) / (100 * units.K * const.k_B)).to(''))`
The product of the exponential integral E1 and the exponential, however, stays finite. I have added an implementation of 
the product that does not calculate the exponential for large values but instead uses the Laurent series expansion.


**How has this been tested?**
- [x] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
