### PR TITLE
Force constant version date length

### DIFF
--- a/.ci-helpers/get_current_version.py
+++ b/.ci-helpers/get_current_version.py
@@ -2,7 +2,6 @@
 
 import sys
 from setuptools_scm import version_from_scm
-from setuptools_scm.version import guess_next_date_ver
 
 version = version_from_scm(".").tag.public
 

--- a/.ci-helpers/get_next_version.py
+++ b/.ci-helpers/get_next_version.py
@@ -6,7 +6,13 @@ from setuptools_scm.version import guess_next_date_ver
 
 version = version_from_scm(".").tag.public
 version = guess_next_date_ver(version)
+
 version = version.rstrip(".0") if version.endswith(".0") else version
+version = version.split(".")
+
+version[1:3] = ["0" + i if len(i) == 1 else i for i in version[1:3]]
+version = ".".join(version)
 
 print(version)
+
 sys.exit(0)

--- a/.ci-helpers/get_next_version.py
+++ b/.ci-helpers/get_next_version.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python
 
 import sys
+from datetime import date
 from setuptools_scm import version_from_scm
 from setuptools_scm.version import guess_next_date_ver
 
-version = version_from_scm(".").tag.public
-version = guess_next_date_ver(version)
+scm_version = version_from_scm(".").tag.public
+scm_version = guess_next_date_ver(scm_version)
+scm_version = [ int(i) for i in scm_version.split(".") ]
 
+build = scm_version[3]
+release = scm_version[0:3]
+iso_date = date(*release).isoformat()
+iso_date = iso_date.replace("-",".")
+
+version = f"{iso_date}.{str(build)}"
 version = version.rstrip(".0") if version.endswith(".0") else version
-version = version.split(".")
-
-version[1:3] = ["0" + i if len(i) == 1 else i for i in version[1:3]]
-version = ".".join(version)
 
 print(version)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

Currently, version names have the form `tardis-YYYY.MM.DD.B` with:

Y: year
M: month
D: day
B: build number (if build number is >0, otherwise version is just `YYYY.MM.DD`)

But for months from 1-9 and days from 1-9 the version is resolved as YYYY.M.D. 

With this patch the number of digits is always 8.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

Locally run with the `tardis` env activated: `python .ci-helpers/get_next_version.py`

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
