### PR TITLE
Fixes for compare-refdata pipeline

### DIFF
--- a/.azure-pipelines/compare-refdata.yml
+++ b/.azure-pipelines/compare-refdata.yml
@@ -34,7 +34,7 @@ jobs:
       - template: templates/default.yml
         parameters:
           fetchRefdata: true
-          refdataRepo: 'azure'  # use 'github' to compare between custom ref hashes
+          refdataRepo: 'azure'  # use 'github' when comparing between custom ref hashes
           useMamba: false
 
       - bash: |

--- a/.azure-pipelines/compare-refdata.yml
+++ b/.azure-pipelines/compare-refdata.yml
@@ -97,11 +97,10 @@ jobs:
 
       - bash: |
           ssh azuredevops@opensupernova.org "mkdir -p /home/azuredevops/public_html/files/refdata-results/$(subfolder)"
-          scp $(refdata.dir)/notebooks/ref_data_compare.html azuredevops@opensupernova.org:/home/azuredevops/public_html/files/refdata-results/$(pr.number)/$(commit.sha).html
+          scp $(refdata.dir)/notebooks/ref_data_compare.html azuredevops@opensupernova.org:/home/azuredevops/public_html/files/refdata-results/$(subfolder)/$(commit.sha).html
         displayName: 'Copy files to server'
         condition: succeededOrFailed()
 
-      # Run if the pipeline is triggered by a pull request.
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - task: GitHubComment@0
           inputs:

--- a/.azure-pipelines/compare-refdata.yml
+++ b/.azure-pipelines/compare-refdata.yml
@@ -19,10 +19,9 @@ pr:
     - '*'
 
 variables:
-  system.debug: false
-  results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   pr.number: '$(System.PullRequest.PullRequestNumber)'
   commit.sha: '$(Build.SourceVersion)'
+  results.url: 'http://opensupernova.org/~azuredevops/files/refdata-results'
   #ref1.hash: ''
   #ref2.hash: ''
 
@@ -35,7 +34,7 @@ jobs:
       - template: templates/default.yml
         parameters:
           fetchRefdata: true
-          refdataRepo: 'azure'
+          refdataRepo: 'azure'  # use 'github' to compare between custom ref hashes
           useMamba: false
 
       - bash: |
@@ -47,8 +46,13 @@ jobs:
           cd $(refdata.dir)
           git remote add upstream $(git remote get-url origin)
           git fetch upstream
-          git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
         displayName: 'Set upstream remote'
+
+      - ${{ if or(startsWith(variables['ref1.hash'], 'upstream/pr'), startsWith(variables['ref2.hash'], 'upstream/pr')) }}:
+        - bash: |
+            cd $(refdata.dir)
+            git fetch upstream "+refs/pull/*/head:refs/remotes/upstream/pr/*"
+          displayName: 'Fetch pull requests'
 
       - bash: |
           cd $(tardis.dir)

--- a/.azure-pipelines/templates/default.yml
+++ b/.azure-pipelines/templates/default.yml
@@ -38,7 +38,7 @@ steps:
   - ${{ if eq(parameters.useMamba, false) }}:
     - bash: |
         echo "##vso[task.setvariable variable=package.manager]conda"
-      displayName: 'Set environment variables'
+      displayName: 'Set package manager'
 
   - ${{ if eq(parameters.useMamba, true) }}:
     - bash: |
@@ -51,6 +51,7 @@ steps:
 
   - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'azure')) }}:
     - checkout: git://TARDIS/tardis-refdata
+      path: s/tardis-refdata
       lfs: true
       displayName: 'Fetch reference data (Azure)'
 

--- a/.azure-pipelines/templates/default.yml
+++ b/.azure-pipelines/templates/default.yml
@@ -50,10 +50,14 @@ steps:
     fetchDepth: ${{ parameters.fetchDepth }}
 
   - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'azure')) }}:
-    - checkout: git://TARDIS/tardis-refdata
-      path: s/tardis-refdata
-      lfs: true
-      displayName: 'Fetch reference data (Azure)'
+      # Azure Repos requires token auth for public repositories containing LFS objects (bug).
+      # Fetch reference data from Azure with a PAT until a fix arrives.
+      - bash: |
+          MY_PAT=$(refdata_token)
+          B64_PAT=$(printf ":$MY_PAT" | base64)
+          git -c http.extraHeader="Authorization: Basic ${B64_PAT}" clone https://tardis-sn@dev.azure.com/tardis-sn/TARDIS/_git/tardis-refdata $(refdata.dir)
+          cd $(refdata.dir); git -c http.extraHeader="Authorization: Basic ${B64_PAT}" lfs fetch --all
+        displayName: 'Fetch reference data repository'
 
   - ${{ if and(eq(parameters.fetchRefdata, true), eq(parameters.refdataRepo, 'github')) }}:
     - bash: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

:warning: **`This pipeline is going to be ported to GitHub actions very soon`**

These changes are only to make the pipeline work just in case someone needs it in the next few days.

- I noticed this pipeline is capable to work with the mirrored reference data if you don't require to fetch pull requests from the `tardis-refdata` repository.
- Needed to re-apply the "old" patch to fetch from Azure due to a still unresolved authentication bug.
- Fixed paths in OpenSupernova server.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [x] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

The reference data pipeline itself.

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [x] I have assigned and requested two reviewers for this pull request.
