### PR TITLE
Fix for isotope abundance parsing

### DIFF
--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -186,7 +186,8 @@ class Radial1DModel(HDFWriterMixin):
             density=density,
         )
         self.raw_abundance = self._abundance
-        self.raw_isotope_abundance = isotope_abundance
+        self.raw_isotope_abundance = isotope_abundance[self.v_boundary_inner_index + 1 : self.v_boundary_outer_index + 1]
+
 
         if t_inner is None:
             if luminosity_requested is not None:

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -186,8 +186,7 @@ class Radial1DModel(HDFWriterMixin):
             density=density,
         )
         self.raw_abundance = self._abundance
-        self.raw_isotope_abundance = isotope_abundance[self.v_boundary_inner_index + 1 : self.v_boundary_outer_index + 1]
-
+        self.raw_isotope_abundance = isotope_abundance
 
         if t_inner is None:
             if luminosity_requested is not None:

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -251,7 +251,10 @@ def assemble_plasma(config, model, atom_data=None):
 
     if not model.raw_isotope_abundance.empty:
         plasma_modules += isotope_properties
-        kwargs.update(isotope_abundance=model.raw_isotope_abundance)
+        isotope_abundance = model.raw_isotope_abundance.loc[
+            :, model.v_boundary_inner_index : model.v_boundary_outer_index - 1
+        ]
+        kwargs.update(isotope_abundance=isotope_abundance)
 
     kwargs["helium_treatment"] = config.plasma.helium_treatment
 


### PR DESCRIPTION
The CSVY parsing of isotope abundances does not provide them to the plasma pre-cut for the inner and outer velocity bounaries

<!--- Provide a general summary of your changes in the title above -->

**Description**
Now the proper isotope abundance array with velocity cuts is passed to the correct plasma properties.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [ ] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [ ] I have requested two reviewers for this pull request
