### PR TITLE
Move link_t_rad_t_electron to config file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -155,6 +155,8 @@ Shilpi Prasad <shilpiprd@gmail.com> Shilpi <72646134+shilpiprd@users.noreply.git
 
 Sourav Singh <souravsingh@users.noreply.github.com>
 
+Sona Chitchyan <chitchyan.sona@gmail.com>
+
 Srinath Rajagopalan <srinath132@gmail.com>
 Srinath Rajagopalan <srinath132@gmail.com>
 Srinath Rajagopalan <srinath132@gmail.com> Srinath R <srinath132@gmail.com>

--- a/tardis/io/schemas/plasma.yml
+++ b/tardis/io/schemas/plasma.yml
@@ -110,7 +110,7 @@ properties:
   link_t_rad_t_electron:
     type: number
     default: 0.9
-    description: Value used for estimate of electron temperature from t_rad.
+    description: Value used for estimating the electron temperature from radiation temperature.
 required:
 - ionization
 - excitation

--- a/tardis/io/schemas/plasma.yml
+++ b/tardis/io/schemas/plasma.yml
@@ -107,6 +107,10 @@ properties:
     type: string
     default: none
     description: Path to file containing heating rate/light curve data.
+  link_t_rad_t_electron:
+    type: number
+    default: 0.9
+    description: Value used for estimate of electron temperature from t_rad.
 required:
 - ionization
 - excitation

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -130,7 +130,7 @@ def assemble_plasma(config, model, atom_data=None):
         atomic_data=atom_data,
         time_explosion=model.time_explosion,
         w=model.dilution_factor,
-        link_t_rad_t_electron=0.9,
+        link_t_rad_t_electron=config.plasma.link_t_rad_t_electron,
         continuum_interaction_species=continuum_interaction_species,
     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Moved link_t_rad_t_electron from being defined in standard_plasmas.py to plasma.yml in io/schemas
**Description**
<!--- Describe your changes in detail -->

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [ ] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [ ] I have requested two reviewers for this pull request
