### PR TITLE
Revert "Removing Levels Index Variable Within Atomic Data Preperation"

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -330,6 +330,10 @@ class AtomData(object):
 
         self.nlte_species = nlte_species
 
+        self.levels_index = pd.Series(
+            np.arange(len(self.levels), dtype=int), index=self.levels.index
+        )
+
         # cutting levels_lines
         self.lines = self.lines[
             self.lines.index.isin(
@@ -348,8 +352,20 @@ class AtomData(object):
             "level_number_upper"
         )
 
+        self.lines_lower2level_idx = (
+            self.levels_index.loc[tmp_lines_lower2level_idx]
+            .astype(np.int64)
+            .values
+        )
+
         tmp_lines_upper2level_idx = self.lines.index.droplevel(
             "level_number_lower"
+        )
+
+        self.lines_upper2level_idx = (
+            self.levels_index.loc[tmp_lines_upper2level_idx]
+            .astype(np.int64)
+            .values
         )
 
         if (


### PR DESCRIPTION
Reverts tardis-sn/tardis#1957

These quantities are necessary for the continuum interaction.  In the future, be careful removing "unused" properties as they may be required for ongoing physics implementations.  If these are slowing down the computation, you can use the CONTINUUM_PROCESS_ENABLED config variable to check if you want them computed