### PR TITLE
Enable automerge on pre and post-release workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -36,7 +36,7 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  build:
+  build-docs:
 
     if: github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -123,7 +123,8 @@ jobs:
             >
             > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. If the file is not modified by this pull request, please check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
           labels: automerge, build-docs
-          reviewers: epassaro, tardis-bot
+          reviewers: tardis-bot
+          team-reviewers: tardis-infrastructure
         id: create-pr
 
       - name: Approve pull request

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -84,7 +84,7 @@ jobs:
             docs/resources/credits.rst
 
   pull_request:
-    needs: [changelog, citation]
+    needs: [changelog, citation, credits]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -137,5 +137,5 @@ jobs:
         uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ secrets.BOT_TOKEN }}
-          pull-request-number: ${{ github.event.number }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: squash

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -71,7 +71,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install rst-include 
-        run: pip install rst-include requests
+        run: pip install rst-include==2.1.2.2 requests==2.27.1
 
       - name: Update README.rst
         run: python .ci-helpers/update_credits.py

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -122,5 +122,5 @@ jobs:
             > :warning: **Warning:** 
             >
             > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. If the file is not modified by this pull request, please check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
-          labels: documentation,
-          reviewers: wkerzendorf, andrewfullard, epassaro
+          labels: automerge, build-docs
+          reviewers: epassaro

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -123,4 +123,4 @@ jobs:
             >
             > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. If the file is not modified by this pull request, please check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
           labels: automerge, build-docs
-          reviewers: epassaro
+          reviewers: epassaro, tardis-bot

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -124,3 +124,18 @@ jobs:
             > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. If the file is not modified by this pull request, please check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
           labels: automerge, build-docs
           reviewers: epassaro, tardis-bot
+        id: create-pr
+
+      - name: Approve pull request
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          number: ${{ steps.create-pr.outputs.pull-request-number }}
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+
+      - name: Enable automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          pull-request-number: ${{ github.event.number }}
+          merge-method: squash

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -108,14 +108,30 @@ jobs:
           base: master
           push-to-fork: tardis-bot/tardis
           commit-message: Automated changes for pre-release ${{ env.DATE }}
-          title: Pre-release ${{ env.DATE }}
+          title: '[ci skip] Pre-release ${{ env.DATE }}'
           body: |
             *\*beep\* \*bop\**
-            
+
             Hi, human.
-            
+
             I prepared everything for a new TARDIS release.
-            
-            If all **checks pass**, merge this pull request and I'll do the rest.
-          labels: build-docs, CI-CD, priority - high :fire:,
-          reviewers: wkerzendorf, andrewfullard, epassaro
+
+            <br>
+
+            > :warning: **WARNING:** 
+            >
+            > This pull request has been labeled as `automerge` and will be merged automatically after the checks are completed. **Do not merge manually if any check fails**.
+            >
+            > Instead, remove the `automerge` label and push your fixes to the [`pre-release-${{ env.DATE }}`](https://github.com/tardis-bot/tardis/tree/pre-release-${{ env.DATE }}) branch on [**tardis-bot/tardis**](https://github.com/tardis-bot/tardis).
+            >
+            > ```
+            > $ git remote add tardis-bot git@github.com:tardis-bot/tardis.git
+            > $ git fetch tardis-bot
+            > $ git checkout tardis-bot/pre-release-${{ env.DATE }}
+            > $ git add <file_1> <file_2> ...
+            > $ git commit -m "<your_commit_message>"
+            > $ git push tardis-bot HEAD:pre-release-${{ env.DATE }}
+            > ```
+            >
+            > Once all the checks pass, you can safely merge this pull request manually.
+          labels: automerge, build-docs

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -136,3 +136,18 @@ jobs:
             > Once all the checks pass, you can safely merge this pull request manually.
           labels: automerge, build-docs
           reviewers: epassaro, tardis-bot
+        id: create-pr
+
+      - name: Approve pull request
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.BOT_TOKEN }}
+          number: ${{ steps.create-pr.outputs.pull-request-number }}
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+
+      - name: Enable automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          pull-request-number: ${{ github.event.number }}
+          merge-method: squash

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -149,5 +149,5 @@ jobs:
         uses: peter-evans/enable-pull-request-automerge@v2
         with:
           token: ${{ secrets.BOT_TOKEN }}
-          pull-request-number: ${{ github.event.number }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: squash

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -108,7 +108,7 @@ jobs:
           base: master
           push-to-fork: tardis-bot/tardis
           commit-message: Automated changes for pre-release ${{ env.DATE }}
-          title: '[ci skip] Pre-release ${{ env.DATE }}'
+          title: Pre-release ${{ env.DATE }}
           body: |
             *\*beep\* \*bop\**
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -135,4 +135,4 @@ jobs:
             >
             > Once all the checks pass, you can safely merge this pull request manually.
           labels: automerge, build-docs
-          reviewers: epassaro
+          reviewers: epassaro, tardis-bot

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -135,7 +135,8 @@ jobs:
             >
             > Once all the checks pass, you can safely merge this pull request manually.
           labels: automerge, build-docs
-          reviewers: epassaro, tardis-bot
+          reviewers: tardis-bot
+          team-reviewers: tardis-infrastructure
         id: create-pr
 
       - name: Approve pull request

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -135,3 +135,4 @@ jobs:
             >
             > Once all the checks pass, you can safely merge this pull request manually.
           labels: automerge, build-docs
+          reviewers: epassaro


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

Automerge requires important changes in the TARDIS infrastructure:

- ~Add branch protection rules to enforce passing `tests` and `docs` before merging a pull request~ DONE
- ~Make @tardis-bot a less privileged user to avoid merging pull requests with failing tests. In this moment the bot has **administator** rights and does not follow the principle of least privilege. All the operations made by the bot can be performed with less privileges (see [this table](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role))~ DONE
- :warning:  Remove @tardis-bot from organization OWNERS

This pull request makes minor changes to `pre` and `post` release:

- Changes to pull request body message.

Other changes:
- Change job name in `docs` workflow (required to mark this job as a required status check before automerge).

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [ ] Testing pipeline
- [x] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix <!-- Non-breaking change which fixes an issue -->
- [x] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [x] I have requested two reviewers for this pull request
