### PR TITLE
Fix post-release workflow automation

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -76,6 +76,7 @@ jobs:
           committer: TARDIS Bot <tardis.sn.bot@gmail.com>
           author: TARDIS Bot <tardis.sn.bot@gmail.com>
           branch: post-release-${{ env.DATE }}
+          base: master
           push-to-fork: tardis-bot/tardis
           commit-message: Automated changes for post-release ${{ env.DATE }}
           title: Post-release ${{ env.DATE }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -105,6 +105,7 @@ jobs:
           committer: TARDIS Bot <tardis.sn.bot@gmail.com>
           author: TARDIS Bot <tardis.sn.bot@gmail.com>
           branch: pre-release-${{ env.DATE }}
+          base: master
           push-to-fork: tardis-bot/tardis
           commit-message: Automated changes for pre-release ${{ env.DATE }}
           title: Pre-release ${{ env.DATE }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->

The `post-release` workflow failed after the latest release, but worked after running manually. The actual cause seems to be well documented in the [build log](https://github.com/tardis-sn/tardis/actions/runs/2271156583): 

```
When the repository is checked out on a commit instead of a branch, the 'base' input must be supplied.
```

I have the feeling this is going to fail too when the `pre-release` is triggered via `cron`, so added the parameter there too.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [ ] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [ ] I have requested two reviewers for this pull request
