### PR TITLE
Fixes for CITATION.cff

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -87,9 +87,14 @@ jobs:
           title: Post-release ${{ env.DATE }}
           body: |
             *\*beep\* \*bop\**
-            
+
             Hi, human.
-            
+
             These are the changes required after the latest TARDIS release.
+
+            > :warning: **Warning:** 
+            >
+            > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. \
+            If the file is not changed by this pull request, check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and run the [run the workflow manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) again.
           labels: documentation,
           reviewers: wkerzendorf, andrewfullard, epassaro

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Wait for Zenodo webhook
+        run: sleep 120
+
       - name: Setup Python
         uses: actions/setup-python@v3
         with:
@@ -45,7 +48,9 @@ jobs:
         run: pip install git+https://github.com/citation-file-format/doi2cff
 
       - name: Update CITATION.cff
-        run: doi2cff update 10.5281/zenodo.592480
+        run: |
+          rm CITATION.cff
+          doi2cff init 10.5281/zenodo.592480
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -94,7 +94,6 @@ jobs:
 
             > :warning: **Warning:** 
             >
-            > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. \
-            If the file is not changed by this pull request, check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and run the [run the workflow manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow) again.
+            > The `post_release` workflow waits for a webhook and then updates `CITATION.cff`. If the file is not modified by this pull request, please check the latest release on [Zenodo's website](https://zenodo.org/record/592480), close this pull request, and [manually run the workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
           labels: documentation,
           reviewers: wkerzendorf, andrewfullard, epassaro


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
- Wait for the Zenodo webhook, otherwise `CITATION.cff` is not modified.
- `doi2cff update` does not update the `title` field and author order, use `doi2cff init` instead

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [ ] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [x] I have requested two reviewers for this pull request
