### PR TITLE
Parallel fixes

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -2,6 +2,7 @@
 
 
 import logging
+from typing_extensions import dataclass_transform
 import numpy as np
 import pandas as pd
 
@@ -171,7 +172,20 @@ class AtomData(object):
                 except KeyError:
                     logger.debug(f"Dataframe does not contain {name} column")
                     nonavailable.append(name)
-
+            # Checks for various collisional data from Carsus files
+            if 'collisions' in store:
+                try:
+                    dataframes['collision_data_temperatures'] = store['collisions_metadata'].temperatures
+                    if store['collisions_metadata'].dataset == 'cmfgen':
+                        dataframes['yg_data'] = store['collisions']
+                        dataframes['collision_data'] = "dummy value"
+                    elif store['collisions_metadata'].dataset == 'chianti':
+                        dataframes['collision_data'] = store['collisions']
+                    else:
+                        raise KeyError("Atomic Data Collisions Not a Valid Chanti or CMFGEN Carsus Data File")
+                except KeyError as e:
+                    logger.warn("Atomic Data is not a Valid Carsus Atomic Data File")
+                    raise
             atom_data = cls(**dataframes)
 
             try:

--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -173,18 +173,24 @@ class AtomData(object):
                     logger.debug(f"Dataframe does not contain {name} column")
                     nonavailable.append(name)
             # Checks for various collisional data from Carsus files
-            if 'collisions' in store:
+            if "collisions" in store:
                 try:
-                    dataframes['collision_data_temperatures'] = store['collisions_metadata'].temperatures
-                    if store['collisions_metadata'].dataset == 'cmfgen':
-                        dataframes['yg_data'] = store['collisions']
-                        dataframes['collision_data'] = "dummy value"
-                    elif store['collisions_metadata'].dataset == 'chianti':
-                        dataframes['collision_data'] = store['collisions']
+                    dataframes["collision_data_temperatures"] = store[
+                        "collisions_metadata"
+                    ].temperatures
+                    if store["collisions_metadata"].dataset == "cmfgen":
+                        dataframes["yg_data"] = store["collisions"]
+                        dataframes["collision_data"] = "dummy value"
+                    elif store["collisions_metadata"].dataset == "chianti":
+                        dataframes["collision_data"] = store["collisions"]
                     else:
-                        raise KeyError("Atomic Data Collisions Not a Valid Chanti or CMFGEN Carsus Data File")
+                        raise KeyError(
+                            "Atomic Data Collisions Not a Valid Chanti or CMFGEN Carsus Data File"
+                        )
                 except KeyError as e:
-                    logger.warn("Atomic Data is not a Valid Carsus Atomic Data File")
+                    logger.warn(
+                        "Atomic Data is not a Valid Carsus Atomic Data File"
+                    )
                     raise
             atom_data = cls(**dataframes)
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -1,5 +1,8 @@
 from numba import prange, njit, objmode
-from numba.np.ufunc.parallel import _get_thread_id as get_thread_id, get_num_threads
+from numba.np.ufunc.parallel import (
+    _get_thread_id as get_thread_id,
+    get_num_threads,
+)
 import numpy as np
 
 from tardis.montecarlo.montecarlo_numba.r_packet import (
@@ -129,15 +132,23 @@ def montecarlo_radial1d(
     if montecarlo_configuration.RPACKET_TRACKING:
         runner.rpacket_tracker = rpacket_trackers
 
+
 @njit(**njit_dict_no_parallel)
 def Estimators_from_estimator(estimator):
 
-    return Estimators(np.copy(estimator.j_estimator), np.copy(estimator.nu_bar_estimator),
-                np.copy(estimator.j_blue_estimator), np.copy(estimator.Edotlu_estimator),
-                np.copy(estimator.photo_ion_estimator), np.copy(estimator.stim_recomb_estimator),
-                np.copy(estimator.bf_heating_estimator), np.copy(estimator.stim_recomb_cooling_estimator),
-                np.copy(estimator.photo_ion_estimator_statistics)
-            )
+    return Estimators(
+        np.copy(estimator.j_estimator),
+        np.copy(estimator.nu_bar_estimator),
+        np.copy(estimator.j_blue_estimator),
+        np.copy(estimator.Edotlu_estimator),
+        np.copy(estimator.photo_ion_estimator),
+        np.copy(estimator.stim_recomb_estimator),
+        np.copy(estimator.bf_heating_estimator),
+        np.copy(estimator.stim_recomb_cooling_estimator),
+        np.copy(estimator.photo_ion_estimator_statistics),
+    )
+
+
 @njit(**njit_dict)
 def montecarlo_main_loop(
     packet_collection,
@@ -192,7 +203,7 @@ def montecarlo_main_loop(
     vpacket_collections = List()
     # Configuring the Tracking for R_Packets
     rpacket_trackers = List()
-    
+
     for i in range(len(output_nus)):
         vpacket_collections.append(
             VPacketCollection(
@@ -208,7 +219,7 @@ def montecarlo_main_loop(
     main_thread_id = get_thread_id()
     estimator_trackers = List()
     n_threads = get_num_threads()
-    for i in range(n_threads): # betting get tid goes from 0 ot num threads
+    for i in range(n_threads):  # betting get tid goes from 0 ot num threads
         estimator_trackers.append(Estimators_from_estimator(estimators))
     # Arrays for vpacket logging
     virt_packet_nus = []
@@ -219,8 +230,7 @@ def montecarlo_main_loop(
     virt_packet_last_interaction_type = []
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
-    
-    
+
     last_update = int(0)
     highest_iteration = int(0)
     for i in prange(len(output_nus)):
@@ -228,9 +238,9 @@ def montecarlo_main_loop(
         tid = get_thread_id()
         if show_progress_bars:
             if tid == main_thread_id:
-                             
+
                 with objmode:
-                    update_amount = 1*n_threads
+                    update_amount = 1 * n_threads
                     update_packet_pbar(
                         update_amount,
                         current_iteration=iteration,
@@ -254,7 +264,7 @@ def montecarlo_main_loop(
             i,
         )
         local_estimators = estimator_trackers[tid]
-        #print("Made it to after estimators")
+        # print("Made it to after estimators")
         vpacket_collection = vpacket_collections[i]
         rpacket_tracker = rpacket_trackers[i]
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -200,9 +200,11 @@ def montecarlo_main_loop(
             )
         )
         rpacket_trackers.append(RPacketTracker())
+
     main_thread_id = get_thread_id()
-    estimator_list = List()
     n_threads = get_num_threads()
+
+    estimator_list = List()
     for i in range(n_threads):  # betting get tid goes from 0 ot num threads
         estimator_list.append(
             Estimators(
@@ -227,8 +229,6 @@ def montecarlo_main_loop(
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
 
-    last_update = int(0)
-    highest_iteration = int(0)
     for i in prange(len(output_nus)):
         highest_iteration += 1
         tid = get_thread_id()
@@ -243,7 +243,6 @@ def montecarlo_main_loop(
                         no_of_packets=no_of_packets,
                         total_iterations=total_iterations,
                     )
-                last_update = highest_iteration
 
         if montecarlo_configuration.single_packet_seed != -1:
             seed = packet_seeds[montecarlo_configuration.single_packet_seed]
@@ -260,7 +259,6 @@ def montecarlo_main_loop(
             i,
         )
         local_estimators = estimator_list[tid]
-        # print("Made it to after estimators")
         vpacket_collection = vpacket_collections[i]
         rpacket_tracker = rpacket_trackers[i]
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -26,8 +26,8 @@ from tardis.montecarlo import (
 from tardis.montecarlo.montecarlo_numba.single_packet_loop import (
     single_packet_loop,
 )
-from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
-from numba.typed import List, Dict
+from tardis.montecarlo.montecarlo_numba import njit_dict
+from numba.typed import List
 from tardis.util.base import update_iterations_pbar, update_packet_pbar
 
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -187,7 +187,6 @@ def montecarlo_main_loop(
     vpacket_collections = List()
     # Configuring the Tracking for R_Packets
     rpacket_trackers = List()
-
     for i in range(len(output_nus)):
         vpacket_collections.append(
             VPacketCollection(
@@ -205,7 +204,7 @@ def montecarlo_main_loop(
     n_threads = get_num_threads()
 
     estimator_list = List()
-    for i in range(n_threads):  # betting get tid goes from 0 ot num threads
+    for i in range(n_threads):  # betting get tid goes from 0 to num threads
         estimator_list.append(
             Estimators(
                 np.copy(estimators.j_estimator),
@@ -228,13 +227,11 @@ def montecarlo_main_loop(
     virt_packet_last_interaction_type = []
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
-
     for i in prange(len(output_nus)):
         highest_iteration += 1
         tid = get_thread_id()
         if show_progress_bars:
             if tid == main_thread_id:
-
                 with objmode:
                     update_amount = 1 * n_threads
                     update_packet_pbar(

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -133,22 +133,6 @@ def montecarlo_radial1d(
         runner.rpacket_tracker = rpacket_trackers
 
 
-@njit(**njit_dict_no_parallel)
-def Estimators_from_estimator(estimator):
-
-    return Estimators(
-        np.copy(estimator.j_estimator),
-        np.copy(estimator.nu_bar_estimator),
-        np.copy(estimator.j_blue_estimator),
-        np.copy(estimator.Edotlu_estimator),
-        np.copy(estimator.photo_ion_estimator),
-        np.copy(estimator.stim_recomb_estimator),
-        np.copy(estimator.bf_heating_estimator),
-        np.copy(estimator.stim_recomb_cooling_estimator),
-        np.copy(estimator.photo_ion_estimator_statistics),
-    )
-
-
 @njit(**njit_dict)
 def montecarlo_main_loop(
     packet_collection,
@@ -217,10 +201,22 @@ def montecarlo_main_loop(
         )
         rpacket_trackers.append(RPacketTracker())
     main_thread_id = get_thread_id()
-    estimator_trackers = List()
+    estimator_list = List()
     n_threads = get_num_threads()
     for i in range(n_threads):  # betting get tid goes from 0 ot num threads
-        estimator_trackers.append(Estimators_from_estimator(estimators))
+        estimator_list.append(
+            Estimators(
+                np.copy(estimators.j_estimator),
+                np.copy(estimators.nu_bar_estimator),
+                np.copy(estimators.j_blue_estimator),
+                np.copy(estimators.Edotlu_estimator),
+                np.copy(estimators.photo_ion_estimator),
+                np.copy(estimators.stim_recomb_estimator),
+                np.copy(estimators.bf_heating_estimator),
+                np.copy(estimators.stim_recomb_cooling_estimator),
+                np.copy(estimators.photo_ion_estimator_statistics),
+            )
+        )
     # Arrays for vpacket logging
     virt_packet_nus = []
     virt_packet_energies = []
@@ -263,7 +259,7 @@ def montecarlo_main_loop(
             seed,
             i,
         )
-        local_estimators = estimator_trackers[tid]
+        local_estimators = estimator_list[tid]
         # print("Made it to after estimators")
         vpacket_collection = vpacket_collections[i]
         rpacket_tracker = rpacket_trackers[i]
@@ -310,9 +306,10 @@ def montecarlo_main_loop(
             ):
                 continue
             v_packets_energy_hist[idx] += vpackets_energy[j]
-    print("Made it to the end")
-    for sub_estimator in estimator_trackers:
+
+    for sub_estimator in estimator_list:
         estimators.increment(sub_estimator)
+
     if virtual_packet_logging:
         for vpacket_collection in vpacket_collections:
             vpackets_nu = vpacket_collection.nus[: vpacket_collection.idx]

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -554,6 +554,27 @@ class Estimators(object):
         self.stim_recomb_cooling_estimator = stim_recomb_cooling_estimator
         self.photo_ion_estimator_statistics = photo_ion_estimator_statistics
 
+    @staticmethod
+    def from_estimator(estimator):
+
+        return Estimators(np.copy(estimator.j_estimator), np.copy(estimator.nu_bar_estimator),
+                    np.copy(estimator.j_blue_estimator), np.copy(estimator.Edotlu_estimator),
+                    np.copy(estimator.photo_ion_estimator), np.copy(estimator.stim_recomb_estimator),
+                    np.copy(estimator.bf_heating_estimator), np.copy(estimator.stim_recomb_cooling_estimator),
+                    np.copy(estimator.photo_ion_estimator_statistics)
+                )
+
+    def increment(self, other):
+
+        self.j_estimator += other.j_estimator
+        self.nu_bar_estimator += other.nu_bar_estimator
+        self.j_blue_estimator += other.j_blue_estimator
+        self.Edotlu_estimator += other.Edotlu_estimator
+        self.photo_ion_estimator += other.photo_ion_estimator
+        self.stim_recomb_estimator += other.stim_recomb_estimator
+        self.bf_heating_estimator += other.bf_heating_estimator
+        self.stim_recomb_cooling_estimator += other.stim_recomb_cooling_estimator
+        self.photo_ion_estimator_statistics +=  other.photo_ion_estimator_statistics
 
 def configuration_initialize(runner, number_of_vpackets):
     if runner.line_interaction_type == "macroatom":

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -557,12 +557,17 @@ class Estimators(object):
     @staticmethod
     def from_estimator(estimator):
 
-        return Estimators(np.copy(estimator.j_estimator), np.copy(estimator.nu_bar_estimator),
-                    np.copy(estimator.j_blue_estimator), np.copy(estimator.Edotlu_estimator),
-                    np.copy(estimator.photo_ion_estimator), np.copy(estimator.stim_recomb_estimator),
-                    np.copy(estimator.bf_heating_estimator), np.copy(estimator.stim_recomb_cooling_estimator),
-                    np.copy(estimator.photo_ion_estimator_statistics)
-                )
+        return Estimators(
+            np.copy(estimator.j_estimator),
+            np.copy(estimator.nu_bar_estimator),
+            np.copy(estimator.j_blue_estimator),
+            np.copy(estimator.Edotlu_estimator),
+            np.copy(estimator.photo_ion_estimator),
+            np.copy(estimator.stim_recomb_estimator),
+            np.copy(estimator.bf_heating_estimator),
+            np.copy(estimator.stim_recomb_cooling_estimator),
+            np.copy(estimator.photo_ion_estimator_statistics),
+        )
 
     def increment(self, other):
 
@@ -573,8 +578,13 @@ class Estimators(object):
         self.photo_ion_estimator += other.photo_ion_estimator
         self.stim_recomb_estimator += other.stim_recomb_estimator
         self.bf_heating_estimator += other.bf_heating_estimator
-        self.stim_recomb_cooling_estimator += other.stim_recomb_cooling_estimator
-        self.photo_ion_estimator_statistics +=  other.photo_ion_estimator_statistics
+        self.stim_recomb_cooling_estimator += (
+            other.stim_recomb_cooling_estimator
+        )
+        self.photo_ion_estimator_statistics += (
+            other.photo_ion_estimator_statistics
+        )
+
 
 def configuration_initialize(runner, number_of_vpackets):
     if runner.line_interaction_type == "macroatom":

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -722,6 +722,8 @@ class YgData(ProcessingPlasmaProperty):
 
     def calculate(self, atomic_data, continuum_interaction_species):
         yg_data = atomic_data.yg_data
+        if yg_data is None:
+            raise ValueError("Tardis does not support continuum interactions for atomic data sources that do not contain yg_data")
 
         mask_selected_species = yg_data.index.droplevel(
             ["level_number_lower", "level_number_upper"]

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -728,7 +728,8 @@ class YgData(ProcessingPlasmaProperty):
         ).isin(continuum_interaction_species)
         yg_data = yg_data[mask_selected_species]
 
-        t_yg = yg_data.columns.values.astype(float)
+        #t_yg = yg_data.columns.values.astype(float)
+        t_yg = atomic_data.collision_data_temperatures
         yg_data.columns = t_yg
         approximate_yg_data = self.calculate_yg_van_regemorter(
             atomic_data, t_yg, continuum_interaction_species

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -723,14 +723,16 @@ class YgData(ProcessingPlasmaProperty):
     def calculate(self, atomic_data, continuum_interaction_species):
         yg_data = atomic_data.yg_data
         if yg_data is None:
-            raise ValueError("Tardis does not support continuum interactions for atomic data sources that do not contain yg_data")
+            raise ValueError(
+                "Tardis does not support continuum interactions for atomic data sources that do not contain yg_data"
+            )
 
         mask_selected_species = yg_data.index.droplevel(
             ["level_number_lower", "level_number_upper"]
         ).isin(continuum_interaction_species)
         yg_data = yg_data[mask_selected_species]
 
-        #t_yg = yg_data.columns.values.astype(float)
+        # t_yg = yg_data.columns.values.astype(float)
         t_yg = atomic_data.collision_data_temperatures
         yg_data.columns = t_yg
         approximate_yg_data = self.calculate_yg_van_regemorter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**

Currently the estimators run the risk of not updating properly when tardis is run with multiple threads due to different threads trying to increment the arrays at the same time. Fix for #2021 

<!--- Describe your changes in detail -->

To remedy this, each thread is given it's own estimator array that it updates with it's own packets.  The resulting estimators are summed together at the end

**Motivation and context**
Running the continuum branch in parallel revealed this bug

**How has this been tested?**
<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [ ] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [ ] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [ ] I have requested two reviewers for this pull request
