### PR TITLE
Fix estimators parallel

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -229,6 +229,7 @@ def montecarlo_main_loop(
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
     for i in prange(len(output_nus)):
+        tid = get_thread_id()
         if show_progress_bars:
 
             if tid == main_thread_id:

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -188,7 +188,6 @@ def montecarlo_main_loop(
     vpacket_collections = List()
     # Configuring the Tracking for R_Packets
     rpacket_trackers = List()
-
     for i in range(len(output_nus)):
         vpacket_collections.append(
             VPacketCollection(
@@ -206,7 +205,7 @@ def montecarlo_main_loop(
     n_threads = get_num_threads()
 
     estimator_list = List()
-    for i in range(n_threads):  # betting get tid goes from 0 ot num threads
+    for i in range(n_threads):  # betting get tid goes from 0 to num threads
         estimator_list.append(
             Estimators(
                 np.copy(estimators.j_estimator),
@@ -229,12 +228,10 @@ def montecarlo_main_loop(
     virt_packet_last_interaction_type = []
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
-
     for i in prange(len(output_nus)):
         if show_progress_bars:
 
             if tid == main_thread_id:
-
                 with objmode:
                     update_amount = 1 * n_threads
                     update_packet_pbar(

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -203,8 +203,9 @@ def montecarlo_main_loop(
         rpacket_trackers.append(RPacketTracker())
 
     main_thread_id = get_thread_id()
-    estimator_list = List()
     n_threads = get_num_threads()
+
+    estimator_list = List()
     for i in range(n_threads):  # betting get tid goes from 0 ot num threads
         estimator_list.append(
             Estimators(
@@ -229,9 +230,6 @@ def montecarlo_main_loop(
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
 
-    last_update = int(0)
-    highest_iteration = int(0)
-
     for i in prange(len(output_nus)):
         if show_progress_bars:
 
@@ -245,7 +243,6 @@ def montecarlo_main_loop(
                         no_of_packets=no_of_packets,
                         total_iterations=total_iterations,
                     )
-                last_update = highest_iteration
 
 
         if montecarlo_configuration.single_packet_seed != -1:
@@ -263,8 +260,6 @@ def montecarlo_main_loop(
             i,
         )
         local_estimators = estimator_list[tid]
-        # print("Made it to after estimators")
-
         vpacket_collection = vpacket_collections[i]
         rpacket_tracker = rpacket_trackers[i]
 

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -242,7 +242,6 @@ def montecarlo_main_loop(
                         total_iterations=total_iterations,
                     )
 
-
         if montecarlo_configuration.single_packet_seed != -1:
             seed = packet_seeds[montecarlo_configuration.single_packet_seed]
             np.random.seed(seed)

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -1,4 +1,9 @@
 from numba import prange, njit, objmode
+from numba.np.ufunc.parallel import (
+    _get_thread_id as get_thread_id,
+    get_num_threads,
+)
+
 import numpy as np
 
 from tardis.montecarlo.montecarlo_numba.r_packet import (
@@ -128,6 +133,20 @@ def montecarlo_radial1d(
     if montecarlo_configuration.RPACKET_TRACKING:
         runner.rpacket_tracker = rpacket_trackers
 
+@njit(**njit_dict_no_parallel)
+def Estimators_from_estimator(estimator):
+
+    return Estimators(
+        np.copy(estimator.j_estimator),
+        np.copy(estimator.nu_bar_estimator),
+        np.copy(estimator.j_blue_estimator),
+        np.copy(estimator.Edotlu_estimator),
+        np.copy(estimator.photo_ion_estimator),
+        np.copy(estimator.stim_recomb_estimator),
+        np.copy(estimator.bf_heating_estimator),
+        np.copy(estimator.stim_recomb_cooling_estimator),
+        np.copy(estimator.photo_ion_estimator_statistics),
+    )
 
 @njit(**njit_dict)
 def montecarlo_main_loop(
@@ -183,6 +202,7 @@ def montecarlo_main_loop(
     vpacket_collections = List()
     # Configuring the Tracking for R_Packets
     rpacket_trackers = List()
+
     for i in range(len(output_nus)):
         vpacket_collections.append(
             VPacketCollection(
@@ -196,6 +216,12 @@ def montecarlo_main_loop(
         )
         rpacket_trackers.append(RPacketTracker())
 
+    main_thread_id = get_thread_id()
+    estimator_trackers = List()
+    n_threads = get_num_threads()
+    for i in range(n_threads):  # betting get tid goes from 0 ot num threads
+        estimator_trackers.append(Estimators_from_estimator(estimators))
+
     # Arrays for vpacket logging
     virt_packet_nus = []
     virt_packet_energies = []
@@ -205,16 +231,25 @@ def montecarlo_main_loop(
     virt_packet_last_interaction_type = []
     virt_packet_last_line_interaction_in_id = []
     virt_packet_last_line_interaction_out_id = []
+
+    last_update = int(0)
+    highest_iteration = int(0)
+
     for i in prange(len(output_nus)):
         if show_progress_bars:
-            with objmode:
-                update_amount = 1
-                update_packet_pbar(
-                    update_amount,
-                    current_iteration=iteration,
-                    no_of_packets=no_of_packets,
-                    total_iterations=total_iterations,
-                )
+
+            if tid == main_thread_id:
+
+                with objmode:
+                    update_amount = 1 * n_threads
+                    update_packet_pbar(
+                        update_amount,
+                        current_iteration=iteration,
+                        no_of_packets=no_of_packets,
+                        total_iterations=total_iterations,
+                    )
+                last_update = highest_iteration
+
 
         if montecarlo_configuration.single_packet_seed != -1:
             seed = packet_seeds[montecarlo_configuration.single_packet_seed]
@@ -230,6 +265,9 @@ def montecarlo_main_loop(
             seed,
             i,
         )
+
+        local_estimators = estimator_trackers[tid]
+        # print("Made it to after estimators")
 
         vpacket_collection = vpacket_collections[i]
         rpacket_tracker = rpacket_trackers[i]

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -555,6 +555,37 @@ class Estimators(object):
         self.photo_ion_estimator_statistics = photo_ion_estimator_statistics
 
 
+    @staticmethod
+    def from_estimator(estimator):
+
+        return Estimators(
+            np.copy(estimator.j_estimator),
+            np.copy(estimator.nu_bar_estimator),
+            np.copy(estimator.j_blue_estimator),
+            np.copy(estimator.Edotlu_estimator),
+            np.copy(estimator.photo_ion_estimator),
+            np.copy(estimator.stim_recomb_estimator),
+            np.copy(estimator.bf_heating_estimator),
+            np.copy(estimator.stim_recomb_cooling_estimator),
+            np.copy(estimator.photo_ion_estimator_statistics),
+        )
+
+    def increment(self, other):
+
+        self.j_estimator += other.j_estimator
+        self.nu_bar_estimator += other.nu_bar_estimator
+        self.j_blue_estimator += other.j_blue_estimator
+        self.Edotlu_estimator += other.Edotlu_estimator
+        self.photo_ion_estimator += other.photo_ion_estimator
+        self.stim_recomb_estimator += other.stim_recomb_estimator
+        self.bf_heating_estimator += other.bf_heating_estimator
+        self.stim_recomb_cooling_estimator += (
+            other.stim_recomb_cooling_estimator
+        )
+        self.photo_ion_estimator_statistics += (
+            other.photo_ion_estimator_statistics
+        )
+
 def configuration_initialize(runner, number_of_vpackets):
     if runner.line_interaction_type == "macroatom":
         montecarlo_configuration.line_interaction_type = (

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -570,6 +570,7 @@ class Estimators(object):
             other.photo_ion_estimator_statistics
         )
 
+
 def configuration_initialize(runner, number_of_vpackets):
     if runner.line_interaction_type == "macroatom":
         montecarlo_configuration.line_interaction_type = (

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -554,22 +554,6 @@ class Estimators(object):
         self.stim_recomb_cooling_estimator = stim_recomb_cooling_estimator
         self.photo_ion_estimator_statistics = photo_ion_estimator_statistics
 
-
-    @staticmethod
-    def from_estimator(estimator):
-
-        return Estimators(
-            np.copy(estimator.j_estimator),
-            np.copy(estimator.nu_bar_estimator),
-            np.copy(estimator.j_blue_estimator),
-            np.copy(estimator.Edotlu_estimator),
-            np.copy(estimator.photo_ion_estimator),
-            np.copy(estimator.stim_recomb_estimator),
-            np.copy(estimator.bf_heating_estimator),
-            np.copy(estimator.stim_recomb_cooling_estimator),
-            np.copy(estimator.photo_ion_estimator_statistics),
-        )
-
     def increment(self, other):
 
         self.j_estimator += other.j_estimator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Fixed the estimators when run in parallel
<!--- Describe your changes in detail -->

Estimators are now broken up into an estimator object unique to each thread
<!--- Why is this change required? What problem does it solve? Link issues here -->
Estimators being modified in parallel caused arrays to not always be incremented.

<!--- please describe how you tested your changes, `pytest` flags used, etc. -->

- [x] Testing pipeline
- [ ] Other

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->

- [x] Bug fix <!-- Non-breaking change which fixes an issue -->
- [ ] New feature <!-- Non-breaking change which adds functionality -->
- [ ] Breaking change <!-- Fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above <!-- Please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation according to my changes
- [ ] I have built the documentation by applying the `build_docs` label to this pull request (if you don't have enough privileges a reviewer will do it for you)
- [x] I have requested two reviewers for this pull request
