### PR TITLE
Restructure code to remove the single_packet_seed field

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -204,3 +204,7 @@ Wolfgang Kerzendorf <wkerzendorf@gmail.com> Wolfgang Kerzendorf <wkerzend@Wolfga
 
 Youssef Eweis <joey070@gmail.com>
 Youssef Eweis <joey070@gmail.com> Youssef Eweis <Youssef15015@users.noreply.github.com>
+
+Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com>
+Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> rohithvarma3000 <rohith.varma.buddaraju@gmail.com>
+Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> Rohith <rohith.varma.buddaraju@gmail.com>

--- a/docs/contributing/development/debug_numba.rst
+++ b/docs/contributing/development/debug_numba.rst
@@ -5,8 +5,8 @@ To facilitate more in-depth debugging when interfacing with the `montecarlo_numb
 module, we provide a set of debugging configurations. PyCharm debugging
 configurations, in addition to related scripts and .yml files, are contained in
 `tardis.scripts.debug`. Currently, these include the ability to run TARDIS
-in asingle-packet mode, with the packet seed identified at debug time.
-`tardis_example_single.yml` is the configuration filethat is used to set up the
+in a single-packet mode.
+`tardis_example_single.yml` is the configuration file that is used to set up the
 single-packet TARDIS run; `run_numba_single.py` is thePython script that runs
 this .yml file; `run_numba_single.xml` is the PyCharmdebug configuration file
 that can be used in conjunction with the above files.

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -90,11 +90,6 @@ properties:
     type: number
     default: 1
     description: Provides option to not log every line.
-  single_packet_seed:
-    type:
-      - number
-    default: -1
-    description: If debug_packets is true, this is the seed for the only packet.
 
 required:
 - no_of_packets

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -100,7 +100,6 @@ class MontecarloRunner(HDFWriterMixin):
         packet_source=None,
         debug_packets=False,
         logger_buffer=1,
-        single_packet_seed=None,
         tracking_rpacket=False,
         use_gpu=False,
     ):
@@ -119,7 +118,6 @@ class MontecarloRunner(HDFWriterMixin):
         self.enable_full_relativity = enable_full_relativity
         numba_config.ENABLE_FULL_RELATIVITY = enable_full_relativity
         self.line_interaction_type = line_interaction_type
-        self.single_packet_seed = single_packet_seed
         self.integrator_settings = integrator_settings
         self.v_packet_settings = v_packet_settings
         self.spectrum_method = spectrum_method
@@ -689,7 +687,6 @@ class MontecarloRunner(HDFWriterMixin):
             packet_source=packet_source,
             debug_packets=config.montecarlo.debug_packets,
             logger_buffer=config.montecarlo.logger_buffer,
-            single_packet_seed=config.montecarlo.single_packet_seed,
             virtual_packet_logging=(
                 config.spectrum.virtual.virtual_packet_logging
                 | virtual_packet_logging

--- a/tardis/montecarlo/montecarlo_configuration.py
+++ b/tardis/montecarlo/montecarlo_configuration.py
@@ -1,7 +1,6 @@
 from tardis import constants as const
 
 full_relativity = True
-single_packet_seed = -1
 temporary_v_packet_bins = 0
 number_of_vpackets = 0
 montecarlo_seed = 0

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -244,12 +244,8 @@ def montecarlo_main_loop(
                         total_iterations=total_iterations,
                     )
 
-        if montecarlo_configuration.single_packet_seed != -1:
-            seed = packet_seeds[montecarlo_configuration.single_packet_seed]
-            np.random.seed(seed)
-        else:
-            seed = packet_seeds[i]
-            np.random.seed(seed)
+        seed = packet_seeds[i]
+        np.random.seed(seed)
         r_packet = RPacket(
             numba_model.r_inner[0],
             packet_collection.packets_input_mu[i],
@@ -295,9 +291,7 @@ def montecarlo_main_loop(
         v_packets_idx = np.floor(
             (vpackets_nu - spectrum_frequency[0]) / delta_nu
         ).astype(np.int64)
-        # if we're only in a single-packet mode
-        # if montecarlo_configuration.single_packet_seed == -1:
-        #    break
+        
         for j, idx in enumerate(v_packets_idx):
             if (vpackets_nu[j] < spectrum_frequency[0]) or (
                 vpackets_nu[j] > spectrum_frequency[-1]

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -291,7 +291,7 @@ def montecarlo_main_loop(
         v_packets_idx = np.floor(
             (vpackets_nu - spectrum_frequency[0]) / delta_nu
         ).astype(np.int64)
-        
+
         for j, idx in enumerate(v_packets_idx):
             if (vpackets_nu[j] < spectrum_frequency[0]) or (
                 vpackets_nu[j] > spectrum_frequency[-1]

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -600,7 +600,6 @@ def configuration_initialize(runner, number_of_vpackets):
     montecarlo_configuration.temporary_v_packet_bins = number_of_vpackets
     montecarlo_configuration.full_relativity = runner.enable_full_relativity
     montecarlo_configuration.montecarlo_seed = runner.seed
-    montecarlo_configuration.single_packet_seed = runner.single_packet_seed
     montecarlo_configuration.v_packet_spawn_start_frequency = (
         runner.virtual_spectrum_spawn_range.end.to(
             u.Hz, equivalencies=u.spectral()

--- a/tardis/scripts/debug/run_numba_single.py
+++ b/tardis/scripts/debug/run_numba_single.py
@@ -1,22 +1,5 @@
 from tardis import run_tardis
-import numpy as np
-from tardis.montecarlo.montecarlo_numba.base import montecarlo_main_loop
-import os
-import numba
-import sys
-import yaml
 
-
-SEED = eval(sys.argv[1].split("=")[1])[0]
-
-yaml_file, params = "tardis_example_single.yml", None
-
-with open(yaml_file) as f:
-    params = yaml.safe_load(f)
-
-params["montecarlo"]["single_packet_seed"] = SEED
-
-with open(yaml_file, "w") as f:
-    yaml.safe_dump(params, f)
+yaml_file = "tardis_example_single.yml"
 
 mdl = run_tardis(yaml_file)

--- a/tardis/scripts/debug/tardis_example_single.yml
+++ b/tardis/scripts/debug/tardis_example_single.yml
@@ -28,7 +28,6 @@ montecarlo:
   no_of_virtual_packets: 0
   nthreads: 6
   seed: 23111963
-  single_packet_seed: 46
 plasma:
   disable_electron_scattering: false
   excitation: lte


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Restructure the code to remove the single_packet_seed field in code, yml and documentation. Fixes https://github.com/tardis-sn/tardis/issues/1902 . The single_packet_seed is creating some unexpected bugs. Continuation of #1926 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

pytest tardis

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
