### PR TITLE
Polish up Quickstart guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,6 +134,12 @@ nbsphinx_prolog = r"""
 .. raw:: html
     
     <style>
+        /* strip stderr */
+        div.nboutput.container div.output_area.stderr {
+            background: #fdd;
+            display: none;
+        }
+
         .launch-btn {
             background-color: #2980B9;
             border: none;
@@ -163,7 +169,7 @@ nbsphinx_prolog = r"""
     </style>
     
     <div class="admonition note">
-    <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch interactive version</a></p>
+    <p class="note-p">You can interact with this notebook online: <a href="https://mybinder.org/v2/gh/tardis-sn/tardis/HEAD?filepath={{ docname|e }}" class="launch-btn" target="_blank" rel="noopener noreferrer">Launch notebook</a></p>
     </div>
 """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ mathjax2_config = {
 
 nbsphinx_execute_arguments = [
     "--InlineBackend.figure_formats={'svg', 'pdf'}",
-    "--InlineBackend.rc={'figure.dpi': 96}",
+    "--rc figure.dpi=96",
 ]
 
 nbsphinx_prolog = r"""

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -76,8 +76,10 @@ this method by following the steps described below.
 
     $ conda deactivate
 
-You are ready! From now on, just activate the ``tardis`` environment before working with the 
-TARDIS package.
+From now on, just activate the ``tardis`` environment before working with the TARDIS package.
+
+You have successfully installed TARDIS! 🎉 Please refer to `Quickstart for TARDIS <quickstart.ipynb>`_ 
+to start running simulations.
 
 
 Install from package

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -73,7 +73,7 @@
     "\n",
     "**Note:**\n",
     "\n",
-    "Get more info about the [logging configuration](io/optional/logging_configuration.ipynb), [convergence plots](io/visualization/convergence_plot.ipynb), and [progress bars](io/output/progress_bars.rst). \n",
+    "Get more information about the [progress bars](io/output/progress_bars.rst), [logging configuration](io/optional/logging_configuration.ipynb), and [convergence plots](io/visualization/convergence_plot.ipynb). \n",
     "    \n",
     "</div>"
    ]

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -4,20 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Quickstart for TARDIS ###"
+    "# Quickstart for TARDIS"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Every simulation run requires the atomic database (for more info refer to [atomic data](io/configuration/components/atomic/atomic_data.rst)) and a configuration file (more info at [configuration](io/configuration/index.rst)).\n",
-    "You can obtain a copy of the atomic database from the\n",
-    "(https://github.com/tardis-sn/tardis-refdata) repository\n",
-    "(`atom_data` subfolder). We recommended to use the\n",
-    "`kurucz_cd23_chianti_H_He.h5` dataset (which is auto-downloaded in the second cell already). The configuration file for this quickstart is `tardis_example.yml`, which can be downloaded [here](https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/tardis_example.yml)), though this file is auto-downloaded in the third cell.\n",
+    "Every simulation run requires  [atomic data](io/configuration/components/atomic/atomic_data.rst) and a [configuration file](io/configuration/index.rst). \n",
     "\n",
-    "After the [installation](installation.rst), start a Jupyter server executing `jupyter notebook` on the command line in a directory that contains this quickstart."
+    "## Atomic Data\n",
+    "\n",
+    "We recommend using the [`kurucz_cd23_chianti_H_He.h5`](https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=atom_data/kurucz_cd23_chianti_H_He.h5&resolveLfs=true) dataset."
    ]
   },
   {
@@ -26,24 +24,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tardis import run_tardis\n",
     "from tardis.io.atom_data.util import download_atom_data"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### Downloading the atomic data ####"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The data are automatically downloaded\n",
     "download_atom_data('kurucz_cd23_chianti_H_He')"
    ]
   },
@@ -51,36 +40,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Downloading the example file ####"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl -O https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/tardis_example.yml"
+    "You also can obtain a copy of the atomic data from the [tardis-refdata](https://github.com/tardis-sn/tardis-refdata/tree/master/atom_data) repository."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Running the simulation (long output) ####"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\">\n",
+    "## Example Configuration File\n",
     "\n",
-    "Note\n",
-    "    \n",
-    "The progress of the simulation can be tracked using progress bars which are displayed when the notebook is run, but are not displayed in the documentation. \n",
-    "    \n",
-    "</div>"
+    "The configuration file used for this Quickstart is [`tardis_example.yml`](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml)."
    ]
   },
   {
@@ -89,14 +58,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = run_tardis('tardis_example.yml')"
+    "!wget -q -nc https://raw.githubusercontent.com/tardis-sn/tardis/master/docs/tardis_example.yml"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Plotting the Spectrum ####"
+    "## Running the Simulation\n",
+    "\n",
+    "To run the simulation import the `run_tardis` function. Also, we are going to silence the `numpy` warnings on this notebook."
    ]
   },
   {
@@ -105,20 +76,70 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pylab inline\n",
+    "import numpy as np\n",
+    "from tardis import run_tardis\n",
     "\n",
+    "_ = np.seterr(divide=\"ignore\", invalid=\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "sim = run_tardis(\"tardis_example.yml\", virtual_packet_logging=True, log_level=\"ERROR\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plotting the Spectrum\n",
+    "\n",
+    "Finally, plot the spectrum using `matplotlib`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "spectrum = sim.runner.spectrum\n",
     "spectrum_virtual = sim.runner.spectrum_virtual\n",
-    "spectrum_integrated = sim.runner.spectrum_integrated\n",
+    "spectrum_integrated = sim.runner.spectrum_integrated"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "plt.figure(figsize=(10, 6.5))\n",
     "\n",
-    "figure(figsize=(10,6))\n",
-    "spectrum.plot(label='normal packets')\n",
-    "spectrum_virtual.plot(label='virtual packets')\n",
-    "spectrum_integrated.plot(label='formal integral')\n",
-    "xlabel('Wavelength [$\\AA$]')\n",
-    "ylabel('Luminosity Density [erg/s/$\\AA$]')\n",
-    "legend()\n",
-    "xlim(500, 9000)"
+    "spectrum.plot(label=\"Normal packets\")\n",
+    "spectrum_virtual.plot(label=\"Virtual packets\")\n",
+    "spectrum_integrated.plot(label='Formal integral')\n",
+    "\n",
+    "plt.xlim(500, 9000)\n",
+    "plt.title(\"TARDIS example model spectrum\")\n",
+    "plt.xlabel(\"Wavelength [$\\AA$]\")\n",
+    "plt.ylabel(\"Luminosity density [erg/s/$\\AA$]\")\n",
+    "plt.legend()"
    ]
   }
  ],
@@ -141,7 +162,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "## Atomic Data\n",
     "\n",
-    "We recommend using the [`kurucz_cd23_chianti_H_He.h5`](https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=atom_data/kurucz_cd23_chianti_H_He.h5&resolveLfs=true) dataset."
+    "We recommend using the [kurucz_cd23_chianti_H_He.h5](https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=atom_data/kurucz_cd23_chianti_H_He.h5&resolveLfs=true) dataset."
    ]
   },
   {
@@ -49,7 +49,7 @@
    "source": [
     "## Example Configuration File\n",
     "\n",
-    "The configuration file used for this Quickstart is [`tardis_example.yml`](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml)."
+    "The configuration file used for this Quickstart is [tardis_example.yml](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml)."
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -107,6 +107,7 @@
     "sim = run_tardis(\"tardis_example.yml\", \n",
     "                 virtual_packet_logging=True,\n",
     "                 show_convergence_plots=True,\n",
+    "                 export_convergence_plots=True,\n",
     "                 log_level=\"INFO\") "
    ]
   },

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -76,15 +76,7 @@
    "source": [
     "## Running the Simulation\n",
     "\n",
-    "To run the simulation, import the `run_tardis` function and create the `sim` object. \n",
-    "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "**Note:**\n",
-    "\n",
-    "Get more information about the [progress bars](io/output/progress_bars.rst), [logging configuration](io/optional/logging_configuration.ipynb), and [convergence plots](io/visualization/convergence_plot.ipynb). \n",
-    "    \n",
-    "</div>"
+    "To run the simulation, import the `run_tardis` function and create the `sim` object. "
    ]
   },
   {
@@ -94,6 +86,19 @@
    "outputs": [],
    "source": [
     "from tardis import run_tardis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note:**\n",
+    "\n",
+    "Get more information about the [progress bars](io/output/progress_bars.rst), [logging configuration](io/optional/logging_configuration.ipynb), and [convergence plots](io/visualization/convergence_plot.ipynb). \n",
+    "    \n",
+    "</div>"
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -139,7 +139,8 @@
     "plt.title(\"TARDIS example model spectrum\")\n",
     "plt.xlabel(\"Wavelength [$\\AA$]\")\n",
     "plt.ylabel(\"Luminosity density [erg/s/$\\AA$]\")\n",
-    "plt.legend()"
+    "plt.legend()\n",
+    "plt.show()"
    ]
   }
  ],

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -95,7 +95,10 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_example.yml\", virtual_packet_logging=True, export_convergence_plots=True, log_level=\"INFO\")"
+    "sim = run_tardis(\"tardis_example.yml\", \n",
+    "                 virtual_packet_logging=True,\n",
+    "                 show_convergence_plots=True,\n",
+    "                 log_level=\"INFO\") "
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Every simulation run requires  [atomic data](io/configuration/components/atomic/atomic_data.rst) and a [configuration file](io/configuration/index.rst). \n",
+    "Every simulation run requires [atomic data](io/configuration/components/atomic/atomic_data.rst) and a [configuration file](io/configuration/index.rst). \n",
     "\n",
     "## Atomic Data\n",
     "\n",
@@ -40,7 +40,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You also can obtain a copy of the atomic data from the [tardis-refdata](https://github.com/tardis-sn/tardis-refdata/tree/master/atom_data) repository."
+    "You can also obtain a copy of the atomic data from the [tardis-refdata](https://github.com/tardis-sn/tardis-refdata/tree/master/atom_data) repository."
    ]
   },
   {
@@ -49,7 +49,7 @@
    "source": [
     "## Example Configuration File\n",
     "\n",
-    "The configuration file [tardis_example.yml](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml) is used through this Quickstart."
+    "The configuration file [tardis_example.yml](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml) is used throughout this Quickstart."
    ]
   },
   {
@@ -67,7 +67,15 @@
    "source": [
     "## Running the Simulation\n",
     "\n",
-    "To run the simulation import the `run_tardis` function. Also, we are going to silence the `numpy` warnings on this notebook."
+    "To run the simulation, import the `run_tardis` function and create the `sim` object. \n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "**Note:**\n",
+    "\n",
+    "Get more info about the [logging configuration](io/optional/logging_configuration.ipynb), [convergence plots](io/visualization/convergence_plot.ipynb), and [progress bars](io/output/progress_bars.rst). \n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -76,10 +84,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "from tardis import run_tardis\n",
-    "\n",
-    "_ = np.seterr(divide=\"ignore\", invalid=\"ignore\")"
+    "from tardis import run_tardis"
    ]
   },
   {
@@ -90,7 +95,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_example.yml\", virtual_packet_logging=True, log_level=\"WARNING\")"
+    "sim = run_tardis(\"tardis_example.yml\", virtual_packet_logging=True, export_convergence_plots=True, log_level=\"INFO\")"
    ]
   },
   {
@@ -99,7 +104,7 @@
    "source": [
     "## Plotting the Spectrum\n",
     "\n",
-    "Finally, plot the spectrum using `matplotlib`."
+    "Finally, plot the generated spectrum with `matplotlib`."
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -62,6 +62,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat tardis_example.yml"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "## Example Configuration File\n",
     "\n",
-    "The configuration file used for this Quickstart is [tardis_example.yml](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml)."
+    "The configuration file [tardis_example.yml](https://github.com/tardis-sn/tardis/tree/master/docs/tardis_example.yml) is used through this Quickstart."
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -90,7 +90,7 @@
    },
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_example.yml\", virtual_packet_logging=True, log_level=\"ERROR\")"
+    "sim = run_tardis(\"tardis_example.yml\", virtual_packet_logging=True, log_level=\"WARNING\")"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Currently, the Quickstart guide has unnecessary long descriptions and long outputs. This is basically the same Quickstart guide but clearer and more concise.

### :pushpin: Resources

Old version: https://tardis-sn.github.io/tardis/quickstart.html
New version: https://tardis-sn.github.io/tardis/pull/2042/quickstart.html

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
