### PR TITLE
Add DOI badge to credits section

### DIFF
--- a/.ci-helpers/update_credits.py
+++ b/.ci-helpers/update_credits.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 import textwrap
 import warnings
+from datetime import date
 
 import requests
 from rst_include import rst_include
@@ -16,6 +17,7 @@ def generate_zenodo():
 
     CONCEPT_DOI = "592480"  # See: https://help.zenodo.org/#versioning
     zenodo_path = pathlib.Path("docs/resources/zenodo.rst")
+    year = date.today().year
 
     try:
         headers = {"accept": "application/x-bibtex"}
@@ -24,8 +26,13 @@ def generate_zenodo():
         )
         response.encoding = "utf-8"
         citation = re.findall("@software{(.*)\,", response.text)
+        specific_doi = citation[0].lstrip(f"kerzendorf_wolfgang_{year}_")
+        doi_org_url = f"https://doi.org/10.5281/zenodo.{specific_doi}"
+        doi_badge = f"https://img.shields.io/badge/DOI-10.5281/zenodo.{specific_doi}-blue"
         zenodo_record = (
-            f".. |ZENODO| replace:: {citation[0]}\n\n"
+            f".. |CITATION| replace:: {citation[0]}\n\n"
+            f".. |DOI_BADGE| image:: {doi_badge}\n"
+            f"                 :target: {doi_org_url}\n\n"
             ".. code-block:: bibtex\n\n"
             + textwrap.indent(response.text, " " * 4)
         )
@@ -41,7 +48,7 @@ def generate_zenodo():
                         """
 
         zenodo_record = (
-            ".. |ZENODO| replace:: <TARDIS SOFTWARE CITATION HERE> \n\n"
+            ".. |ZENODO| replace:: <TARDIS SOFTWARE SPECIFIC HERE> \n\n"
             ".. warning:: \n\n" + textwrap.indent(not_found_msg, " " * 4)
         )
 

--- a/docs/resources/credits_template.rst
+++ b/docs/resources/credits_template.rst
@@ -4,6 +4,8 @@
 Credits & Publication Policies
 ******************************
 
+|DOI_BADGE|
+
 We provide TARDIS as a free, open-source tool. If you are using it, please
 adhere to a few policies and acknowledge the TARDIS Team.
 
@@ -18,7 +20,7 @@ following paragraph to the Acknowledgement section:
 .. parsed-literal::
 
     This research made use of \\textsc{tardis}, a community-developed software package for spectral
-    synthesis in supernovae \\citep{2014MNRAS.440..387K, |ZENODO|}. The
+    synthesis in supernovae \\citep{2014MNRAS.440..387K, |CITATION|}. The
     development of \\textsc{tardis} received support from GitHub, the Google Summer of Code
     initiative, and from ESA's Summer of Code in Space program. \\textsc{tardis} is a fiscally
     sponsored project of NumFOCUS. \\textsc{tardis} makes extensive use of Astropy and Pyne.


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` | :roller_coaster: `infrastructure`

Added the specific DOI badge to the _Credits_ section of the documentation, and consequently in README.rst.


### :pushpin: Resources

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)

Can't be tested on CI because this changewill be triggered on post-release. But you can test it locally by running `python ./ci-helpers/update_credits.py` and then `cd docs && DISABLE_NBSPHINX=1 make html`. Should look like this:

![image](https://user-images.githubusercontent.com/22769314/172215910-2b56f351-a17b-4e8a-b9b4-9437079897a7.png)



### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
