### PR TITLE
Stop redirecting docs page

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -125,6 +125,7 @@ jobs:
           publish_branch: ${{ env.DEPLOY_BRANCH }}
           publish_dir: ./docs/_build/html
           destination_dir: ${{ env.DEST_DIR }}
+          keep_files: true
           force_orphan: ${{ env.CLEAN_BRANCH }}
           user_name: 'TARDIS Bot'
           user_email: 'tardis.sn.bot@gmail.com'

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,7 +25,6 @@ on:
 env:
   CACHE_NUMBER: 0                       # increase to reset cache manually
   DEPLOY_BRANCH: gh-pages               # deployed docs branch
-  ROOT_REDIRECT: latest                 # redirects to: https://tardis-sn.github.io/tardis/latest
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -85,7 +84,7 @@ jobs:
           if [[ $EVENT == push ]] || [[ $EVENT == workflow_dispatch ]]; then
 
             if [[ $BRANCH == $DEFAULT ]]; then
-              echo "DEST_DIR=latest" >> $GITHUB_ENV
+              echo "DEST_DIR='.'" >> $GITHUB_ENV
             else
               echo "DEST_DIR=branch/$BRANCH" >> $GITHUB_ENV
             fi
@@ -114,25 +113,6 @@ jobs:
           destination_dir: ${{ env.DEST_DIR }}
           user_name: 'TARDIS Bot'
           user_email: 'tardis.sn.bot@gmail.com'
-
-      - name: Create redirect
-        run: |
-          mkdir redirects && cd redirects
-          echo '<head>' >> index.html
-          echo '  <meta http-equiv="Refresh" content="0; url='/${{ github.event.repository.name }}/${{ env.ROOT_REDIRECT }}'"/>' >> index.html
-          echo '</head>' >> index.html
-        if: github.event_name != 'pull_request_target'
-
-      - name: Deploy redirect
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.BOT_TOKEN }}
-          publish_branch: ${{ env.DEPLOY_BRANCH }}
-          publish_dir: ./redirects
-          keep_files: true
-          user_name: 'TARDIS Bot'
-          user_email: 'tardis.sn.bot@gmail.com'
-        if: github.event_name != 'pull_request_target'
 
       - name: Find comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -104,6 +104,20 @@ jobs:
           EVENT: ${{ github.event_name }}
           PR: ${{ github.event.number }}
 
+      - name: Set clean branch option
+        run: |
+          if [[ $EVENT == workflow_dispatch ]]; then
+            echo "CLEAN_BRANCH=true" >> $GITHUB_ENV
+
+          else
+            echo "CLEAN_BRANCH=false" >> $GITHUB_ENV
+
+          fi
+
+          cat $GITHUB_ENV
+        env:
+          EVENT: ${{ github.event_name }}
+
       - name: Deploy ${{ env.DEST_DIR }}
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -111,6 +125,7 @@ jobs:
           publish_branch: ${{ env.DEPLOY_BRANCH }}
           publish_dir: ./docs/_build/html
           destination_dir: ${{ env.DEST_DIR }}
+          force_orphan: ${{ env.CLEAN_BRANCH }}
           user_name: 'TARDIS Bot'
           user_email: 'tardis.sn.bot@gmail.com'
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -84,7 +84,7 @@ jobs:
           if [[ $EVENT == push ]] || [[ $EVENT == workflow_dispatch ]]; then
 
             if [[ $BRANCH == $DEFAULT ]]; then
-              echo "DEST_DIR='.'" >> $GITHUB_ENV
+              echo "DEST_DIR=" >> $GITHUB_ENV
             else
               echo "DEST_DIR=branch/$BRANCH" >> $GITHUB_ENV
             fi


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

Recently @nolanbrown01 found there are some broken links in the documentation due to redirecting the root of the page to `/latest`. Also, I found most of the links found in Google to the documentations are broken for the same reason.

This redirecting feature was implemented thinking in a wider project, I don't think we need that.

Also, I set up the pipeline to clean the `gh-pages` branch when triggered manually.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Tested extensively on [my fork's `gh-pages` branch](https://github.com/epassaro/tardis/tree/gh-pages).


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
