### PR TITLE
Ignore gamma-ray deposition notebook for now

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ exclude_patterns.append("_build")
 exclude_patterns.append("**_template.rst")
 exclude_patterns.append("**.ipynb_checkpoints")
 exclude_patterns.append("resources/research_done_using_TARDIS/ads.ipynb")
+exclude_patterns.append("physics/energy_input/gammaray_deposition.ipynb")
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
@@ -336,6 +337,7 @@ redirects = [
 # -- Sphinx hook-ins ---------------------------------------------------------
 
 from shutil import copyfile
+
 
 def generate_tutorials_page(app):
     """Create tutorials.rst"""


### PR DESCRIPTION
### :pencil: Description

Fixes the doc build failure due to incorrect file references- the gamma-ray notebook will be rewritten in future.

**Type:** :beetle: `bugfix`

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
