### PR TITLE
Disable profiling page build on pull requests

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -75,6 +75,20 @@ jobs:
       - name: Install package
         run: pip install -e .
 
+      - name: Set profiling option
+        run: |
+          if [[ $EVENT == pull_request_target ]]; then
+            echo "DISABLE_PROFILING=1" >> $GITHUB_ENV
+
+          else
+            echo "DISABLE_PROFILING=0" >> $GITHUB_ENV
+
+          fi
+
+          cat $GITHUB_ENV
+        env:
+          EVENT: ${{ github.event_name }}
+
       - name: Build documentation
         run: cd docs/ && make html CORES=auto
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,9 @@ exclude_patterns.append("**.ipynb_checkpoints")
 exclude_patterns.append("resources/research_done_using_TARDIS/ads.ipynb")
 exclude_patterns.append("physics/energy_input/gammaray_deposition.ipynb")
 
+if os.getenv("DISABLE_PROFILING"):
+    exclude_patterns.append("contributing/development/profiling/**.ipynb")
+
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
 rst_epilog = """


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` | :roller_coaster: `infrastructure`

- Avoids running profiling notebooks under on `pull_request_target` events. Saves 3-4' on each run
- `push` and `workflow_dispatch` remains unchanged


### :pushpin: Resources

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Tested the `pull_request_target` on my fork: https://github.com/epassaro/tardis/actions/runs/2457627178


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
