### PR TITLE
Change developer installation command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -63,7 +63,7 @@ this method by following the steps described below.
         $ git remote add upstream git@github.com:tardis-sn/tardis.git
         $ git fetch upstream
         $ git checkout upstream/master
-        $ pip install -e .
+        $ python setup.py develop
 
       .. note::
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Change developer mode installation command in docs. The `pip install -e .` is equivalent to `python setup.py develop` but solves and installs packages defined in package configuration files. This could lead to installing packages via `pip` to the local user directory (for example `astropy` in `~.local`) if the `tardis` environment is not activated.

There's nothing wrong with `pip install -e .` but could cause issues to new users.


### :pushpin: Resources

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
