### PR TITLE
Improvements for reference data in tests workflow

### DIFF
--- a/.ci-helpers/download_reference_data.sh
+++ b/.ci-helpers/download_reference_data.sh
@@ -1,27 +1,35 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-REF_PATH="$GITHUB_WORKSPACE/tardis-refdata"
-REPO_URL="https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata"
+MIRROR_URL="https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata"
+HDF5_FILES=("arepo_data/arepo_snapshot.hdf5"
+            "arepo_data/arepo_snapshot.json"
+            "atom_data/chianti_He.h5"
+            "atom_data/kurucz_cd23_chianti_H_He.h5"
+            "montecarlo_1e5_compare_data.h5"
+            "nlte_atom_data/TestNLTE_He_Ti.h5"
+            "packet_unittest.h5"
+            "sdec_ref.h5"
+            "unit_test_data.h5")
 
-FILES=('atom_data/kurucz_cd23_chianti_H_He.h5'
-       'atom_data/chianti_He.h5'
-       'montecarlo_1e5_compare_data.h5'
-       'packet_unittest.h5'
-       'sdec_ref.h5'
-       'unit_test_data.h5'
-       'arepo_data/arepo_snapshot.hdf5'
-       'arepo_data/arepo_snapshot.json'
-       'nlte_atom_data/TestNLTE_He_Ti.h5')
+REFDATA_PATH="$GITHUB_WORKSPACE/tardis-refdata"
+mkdir -p "$REFDATA_PATH/arepo_data"
+mkdir -p "$REFDATA_PATH/atom_data"
 
-mkdir -p $REF_PATH/atom_data
-mkdir -p $REF_PATH/arepo_data
-mkdir -p $REF_PATH/nlte_atom_data
+if [[ -z $REFDATA_SHA ]]; then
+    VERSION="master"
+    TYPE="branch"
 
-for FILE in "${FILES[@]}"
+else
+    VERSION="$REFDATA_SHA"
+    TYPE="commit"
+
+fi
+
+for FILE in "${HDF5_FILES[@]}"
 do
-    wget -q "$REPO_URL/items?path=$FILE&resolveLfs=true" -O $REF_PATH/$FILE
+    curl -o "$REFDATA_PATH/$FILE" "$MIRROR_URL/items?path=$FILE&versionType=$TYPE&version=$VERSION&resolveLfs=true"
 done
 
 exit 0

--- a/.ci-helpers/download_reference_data.sh
+++ b/.ci-helpers/download_reference_data.sh
@@ -17,7 +17,7 @@ REFDATA_PATH="$GITHUB_WORKSPACE/tardis-refdata"
 mkdir -p "$REFDATA_PATH/arepo_data"
 mkdir -p "$REFDATA_PATH/atom_data"
 
-if [[ -z $REFDATA_SHA ]]; then
+if [[ -z "$REFDATA_SHA" ]]; then
     VERSION="master"
     TYPE="branch"
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` | :roller_coaster: `infrastructure`

- Addresses issues of the `download_reference_data.sh` script:
  - Do not allow unbound variables (e.g. GITHUB_WORKSPACE)
  - Allow downloading different versions of reference data based on commit SHA. If `REFDATA_SHA` is blank, proceed to download the latest commit from `master`.

### :pushpin: Resources

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Locally, set GITHUB_WORKSPACE="/path/to/folder" and REFDATA_SHA="" (o use a commit SHA instead)

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
