### PR TITLE
Wait for pull request creation

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -128,6 +128,9 @@ jobs:
           reviewers: wkerzendorf, andrewfullard, epassaro
         id: create-pr
 
+      - name: Wait for pull request
+        run: sleep 30
+
       - name: Approve pull request
         uses: juliangruber/approve-pull-request-action@v1
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -138,6 +138,9 @@ jobs:
           reviewers: wkerzendorf, andrewfullard, epassaro
         id: create-pr
 
+      - name: Wait for pull request
+        run: sleep 30
+
       - name: Approve pull request
         uses: juliangruber/approve-pull-request-action@v1
         with:


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Automerge on both `pre-release` and `post-release` workflows [failed](https://github.com/tardis-sn/tardis/runs/6951548662?check_suite_focus=true) with the same error:

```
Run juliangruber/approve-pull-request-action@v1
  with:
    github-token: ***
    number: 2060
  env:
    DATE: 2022.06.19
    PULL_REQUEST_NUMBER: 2060
Error: Not Found
```

The pull request opened by the workflow is #2060, so I suspect the following step requires a few seconds to find the pull request through the GitHub API.

~If this does not work I should open an issue on those actions repositories.~

Seems this is the recommended solution by the developer: https://github.com/peter-evans/enable-pull-request-automerge/issues/286#issuecomment-1018065884

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
