### PR TITLE
Restructuring model state

### DIFF
--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -2,8 +2,9 @@
 
 from tardis.io.config_reader import ConfigurationNameSpace
 from tardis.montecarlo.base import MontecarloRunner
-from tardis.util.base import parse_quantity, is_valid_nuclide_or_elem
+from tardis.util.base import parse_quantity, is_valid_nuclide_or_elem, quantity_linspace
 
+import os
 import warnings
 import numpy as np
 from numpy import recfromtxt, genfromtxt
@@ -927,3 +928,77 @@ def model_from_hdf(fname):
     new_model.w = d["w"]
 
     return new_model
+
+def model_state_from_config(config):
+    """
+    Creates a Model State object from a config object.
+
+    Parameters
+    ----------
+    config : tardis.io.config_reader.Configuration
+
+    Returns
+    -------
+    model_state : tardis.model.ModelState
+    """
+    from tardis.model.density import HomologousDensity
+    from tardis.model.base import ModelState
+    time_explosion = config.supernova.time_explosion.cgs
+    temperature = None
+    structure = config.model.structure
+    if structure.type == "specific":
+        velocity = quantity_linspace(
+            structure.velocity.start,
+            structure.velocity.stop,
+            structure.velocity.num + 1,
+        ).cgs
+        homologous_density = HomologousDensity.from_config(config)
+    elif structure.type == "file":
+        if os.path.isabs(structure.filename):
+            structure_fname = structure.filename
+        else:
+            structure_fname = os.path.join(
+                config.config_dirname, structure.filename
+            )
+
+        (
+            time_0,
+            velocity,
+            density_0,
+            electron_densities,
+            temperature,
+        ) = read_density_file(structure_fname, structure.filetype)
+        density_0 = density_0.insert(0, 0)
+        homologous_density = HomologousDensity(density_0, time_0)
+    else:
+        raise NotImplementedError
+
+    no_of_shells = len(velocity) - 1
+
+    if config.plasma.initial_t_inner < 0.0 * u.K:
+        luminosity_requested = config.supernova.luminosity_requested
+        t_inner = None
+    else:
+        luminosity_requested = None
+        t_inner = config.plasma.initial_t_inner
+
+    if temperature:
+        t_radiative = temperature
+    elif config.plasma.initial_t_rad > 0 * u.K:
+        t_radiative = (
+            np.ones(no_of_shells + 1) * config.plasma.initial_t_rad
+        )
+    else:
+        t_radiative = None
+
+    return ModelState(
+        time_explosion=time_explosion,
+        homologous_density=homologous_density,
+        velocity=velocity,
+        t_inner=t_inner,
+        luminosity_requested=luminosity_requested,
+        t_radiative=t_radiative,
+        dilution_factor=None,
+        v_boundary_inner=structure.get("v_inner_boundary", None),
+        v_boundary_outer=structure.get("v_outer_boundary", None),
+    )

--- a/tardis/io/model_reader.py
+++ b/tardis/io/model_reader.py
@@ -2,7 +2,11 @@
 
 from tardis.io.config_reader import ConfigurationNameSpace
 from tardis.montecarlo.base import MontecarloRunner
-from tardis.util.base import parse_quantity, is_valid_nuclide_or_elem, quantity_linspace
+from tardis.util.base import (
+    parse_quantity,
+    is_valid_nuclide_or_elem,
+    quantity_linspace,
+)
 
 import os
 import warnings
@@ -929,6 +933,7 @@ def model_from_hdf(fname):
 
     return new_model
 
+
 def model_state_from_config(config):
     """
     Creates a Model State object from a config object.
@@ -943,6 +948,7 @@ def model_state_from_config(config):
     """
     from tardis.model.density import HomologousDensity
     from tardis.model.base import ModelState
+
     time_explosion = config.supernova.time_explosion.cgs
     temperature = None
     structure = config.model.structure
@@ -985,9 +991,7 @@ def model_state_from_config(config):
     if temperature:
         t_radiative = temperature
     elif config.plasma.initial_t_rad > 0 * u.K:
-        t_radiative = (
-            np.ones(no_of_shells + 1) * config.plasma.initial_t_rad
-        )
+        t_radiative = np.ones(no_of_shells + 1) * config.plasma.initial_t_rad
     else:
         t_radiative = None
 

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -330,6 +330,7 @@ class ModelState:
             time_explosion=self.time_explosion.cgs.value,
         )
 
+
 class Radial1DModel(HDFWriterMixin):
     """
     An object that hold information about the individual shells.

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -59,8 +59,12 @@ class ModelState:
         v_boundary_inner=None,
         v_boundary_outer=None,
     ):
-        v_outer = velocity[1:]
-        v_inner = velocity[:-1]
+        self._v_boundary_inner = None
+        self._v_boundary_outer = None
+        self._velocity = None
+        self.raw_velocity = velocity
+        v_outer = self.velocity[1:]
+        v_inner = self.velocity[:-1]
         r_inner = time_explosion * v_inner
         r_outer = time_explosion * v_outer
         self.time_explosion = time_explosion
@@ -79,10 +83,7 @@ class ModelState:
             "v_outer": v_outer.unit,
             "r_outer": r_outer.unit,
         }
-        self._velocity = None
-        self.raw_velocity = velocity
-        self._v_boundary_inner = None
-        self._v_boundary_outer = None
+
         self.v_boundary_inner = v_boundary_inner
         self.v_boundary_outer = v_boundary_outer
 

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -134,7 +134,7 @@ class ModelState:
 
         self.radiation_field = pd.DataFrame(
             {
-                "t_radiative": self.t_rad.value,
+                "temperature_radiative": self.t_radiative.value,
                 "dilution_factor": self.dilution_factor,
             }
         )
@@ -261,14 +261,6 @@ class ModelState:
         return self._velocity
 
     @property
-    def t_rad(self):
-        return self.t_radiative
-
-    @t_rad.setter
-    def t_rad(self, value):
-        self.t_radiative = value
-
-    @property
     def t_radiative(self):
         if len(self._t_radiative) == self.no_of_shells:
             return self._t_radiative
@@ -295,14 +287,6 @@ class ModelState:
     @property
     def no_of_shells(self):
         return len(self.velocity) - 1
-
-    @property
-    def w(self):
-        return self.dilution_factor
-
-    @w.setter
-    def w(self, value):
-        self.dilution_factor = value
 
     @property
     def dilution_factor(self):

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -70,19 +70,27 @@ class ModelState:
         return self.geometry.v_inner.values * self.geometry_units["v_inner"]
 
     @property
-    def r_inner(self):
-        """Inner radius of model shells."""
-        return self.geometry.r_inner.values * self.geometry_units["r_inner"]
-
-    @property
     def v_outer(self):
         """Outer boundary velocity."""
         return self.geometry.v_outer.values * self.geometry_units["v_outer"]
 
     @property
+    def v_middle(self):
+        return 0.5 * self.v_inner + 0.5 * self.v_outer
+
+    @property
+    def r_inner(self):
+        """Inner radius of model shells."""
+        return self.geometry.r_inner.values * self.geometry_units["r_inner"]
+
+    @property
     def r_outer(self):
         """Outer radius of model shells."""
         return self.geometry.r_outer.values * self.geometry_units["r_outer"]
+
+    @property
+    def r_middle(self):
+        return 0.5 * self.r_inner + 0.5 * self.r_outer
 
     def to_numba_model(self):
         return NumbaModel(

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -496,13 +496,6 @@ class Radial1DModel(HDFWriterMixin):
         self._abundance = abundance
         self.time_explosion = time_explosion
         self._electron_densities = electron_densities
-        # v_outer = self.velocity[1:]
-        # v_inner = self.velocity[:-1]
-        # density = (
-        #     self.homologous_density.calculate_density_at_time_of_simulation(
-        #         self.time_explosion
-        #     )[self.v_boundary_inner_index + 1 : self.v_boundary_outer_index + 1]
-        # )
         self.model_state = ModelState(
             time_explosion=time_explosion,
             homologous_density=homologous_density,

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -59,8 +59,8 @@ class ModelState:
         v_boundary_inner=None,
         v_boundary_outer=None,
     ):
-        v_outer = self.velocity[1:]
-        v_inner = self.velocity[:-1]
+        v_outer = velocity[1:]
+        v_inner = velocity[:-1]
         r_inner = time_explosion * v_inner
         r_outer = time_explosion * v_outer
         self.time_explosion = time_explosion
@@ -79,11 +79,12 @@ class ModelState:
             "v_outer": v_outer.unit,
             "r_outer": r_outer.unit,
         }
+        self._velocity = None
         self.raw_velocity = velocity
-        self.v_boundary_inner = v_boundary_inner
-        self.v_boundary_outer = v_boundary_outer
         self._v_boundary_inner = None
         self._v_boundary_outer = None
+        self.v_boundary_inner = v_boundary_inner
+        self.v_boundary_outer = v_boundary_outer
 
         self.density = (
             self.homologous_density.calculate_density_at_time_of_simulation(
@@ -134,7 +135,7 @@ class ModelState:
         self.radiation_field = pd.DataFrame(
             {
                 "t_radiative": self.t_rad.value,
-                "dilution_factor": self.dilution_factor.value,
+                "dilution_factor": self.dilution_factor,
             }
         )
 
@@ -495,20 +496,23 @@ class Radial1DModel(HDFWriterMixin):
         self._abundance = abundance
         self.time_explosion = time_explosion
         self._electron_densities = electron_densities
-        v_outer = self.velocity[1:]
-        v_inner = self.velocity[:-1]
-        density = (
-            self.homologous_density.calculate_density_at_time_of_simulation(
-                self.time_explosion
-            )[self.v_boundary_inner_index + 1 : self.v_boundary_outer_index + 1]
-        )
+        # v_outer = self.velocity[1:]
+        # v_inner = self.velocity[:-1]
+        # density = (
+        #     self.homologous_density.calculate_density_at_time_of_simulation(
+        #         self.time_explosion
+        #     )[self.v_boundary_inner_index + 1 : self.v_boundary_outer_index + 1]
+        # )
         self.model_state = ModelState(
-            v_inner=v_inner,
-            v_outer=v_outer,
-            r_inner=self.time_explosion * v_inner,
-            r_outer=self.time_explosion * v_outer,
-            time_explosion=self.time_explosion,
-            density=density,
+            time_explosion=time_explosion,
+            homologous_density=homologous_density,
+            velocity=velocity,
+            t_inner=t_inner,
+            luminosity_requested=luminosity_requested,
+            t_radiative=t_radiative,
+            dilution_factor=dilution_factor,
+            v_boundary_inner=v_boundary_inner,
+            v_boundary_outer=v_boundary_outer,
         )
         self.raw_abundance = self._abundance
         self.raw_isotope_abundance = isotope_abundance

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -506,7 +506,7 @@ class Radial1DModel(HDFWriterMixin):
         self.model_state = ModelState(
             time_explosion=time_explosion,
             homologous_density=homologous_density,
-            velocity=velocity,
+            velocity=self.velocity,
             t_inner=t_inner,
             luminosity_requested=luminosity_requested,
             t_radiative=t_radiative,

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -35,6 +35,13 @@ class ModelState:
     r_outer : astropy.units.quantity.Quantity
     density : astropy.units.quantity.Quantity
     time_explosion : astropy.units.quantity.Quantity
+    velocity : np.ndarray
+    t_inner : astropy.units.quantity.Quantity
+    luminosity_requested : astropy.units.quantity.Quantity
+    t_radiative : astropy.units.quantity.Quantity
+    dilution_factor : astropy.units.quantity.Quantity
+    v_boundary_inner : astropy.units.quantity.Quantity
+    v_boundary_outer : astropy.units.quantity.Quantity
 
     Attributes
     ----------

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from astropy import units as u
 from tardis import constants
+from tardis.montecarlo.montecarlo_numba.numba_interface import NumbaModel
 
 from tardis.util.base import quantity_linspace, is_valid_nuclide_or_elem
 from tardis.io.parsers.csvy import load_csvy
@@ -82,6 +83,15 @@ class ModelState:
     def r_outer(self):
         """Outer radius of model shells."""
         return self.geometry.r_outer.values * self.geometry_units["r_outer"]
+
+    def to_numba_model(self):
+        return NumbaModel(
+            v_inner= self.v_inner.cgs.value,
+            v_outer= self.v_outer.cgs.value,
+            r_inner= self.r_inner.cgs.value,
+            r_outer= self.r_outer.cgs.value,
+            time_explosion= self.time_explosion.cgs.value,
+        )
 
 
 class Radial1DModel(HDFWriterMixin):

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -122,6 +122,13 @@ class ModelState:
         else:
             self._dilution_factor = dilution_factor
 
+        self.radiation_field = pd.DataFrame(
+            {
+                "t_radiative": self.t_rad.value,
+                "dilution_factor": self.dilution_factor.value,
+            }
+        )
+
     @property
     def v_inner(self):
         """Inner boundary velocity."""

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -63,12 +63,14 @@ class ModelState:
         self._v_boundary_outer = None
         self._velocity = None
         self.raw_velocity = velocity
+        self.v_boundary_inner = v_boundary_inner
+        self.v_boundary_outer = v_boundary_outer
+        self.time_explosion = time_explosion
+        self.homologous_density = homologous_density
         v_outer = self.velocity[1:]
         v_inner = self.velocity[:-1]
         r_inner = time_explosion * v_inner
         r_outer = time_explosion * v_outer
-        self.time_explosion = time_explosion
-        self.homologous_density = homologous_density
         self.geometry = pd.DataFrame(
             {
                 "v_inner": v_inner.value,
@@ -83,9 +85,6 @@ class ModelState:
             "v_outer": v_outer.unit,
             "r_outer": r_outer.unit,
         }
-
-        self.v_boundary_inner = v_boundary_inner
-        self.v_boundary_outer = v_boundary_outer
 
         self.density = (
             self.homologous_density.calculate_density_at_time_of_simulation(
@@ -353,7 +352,6 @@ class ModelState:
         temperature = None
         structure = config.model.structure
         if structure.type == "specific":
-
             velocity = quantity_linspace(
                 structure.velocity.start,
                 structure.velocity.stop,
@@ -500,7 +498,7 @@ class Radial1DModel(HDFWriterMixin):
         self.model_state = ModelState(
             time_explosion=time_explosion,
             homologous_density=homologous_density,
-            velocity=self.velocity,
+            velocity=velocity,
             t_inner=t_inner,
             luminosity_requested=luminosity_requested,
             t_radiative=t_radiative,
@@ -552,6 +550,13 @@ class Radial1DModel(HDFWriterMixin):
         else:
             # self.dilution_factor = dilution_factor[self.v_boundary_inner_index + 1:self.v_boundary_outer_index]
             self._dilution_factor = dilution_factor
+
+        # self.radiation_field = pd.DataFrame(
+        #     {
+        #         "t_radiative": self.t_rad.value,
+        #         "dilution_factor": self.dilution_factor,
+        #     }
+        # )
 
     @property
     def w(self):

--- a/tardis/model/tests/test_base.py
+++ b/tardis/model/tests/test_base.py
@@ -378,6 +378,69 @@ class TestModelState:
             self.model.model_state.density.value, self.model.density.value
         )
 
+    def test_v_boundary_inner(self):
+        assert (
+            self.model.model_state.v_boundary_inner.unit
+            == self.model.v_boundary_inner.unit
+        )
+        assert_almost_equal(
+            self.model.model_state.v_boundary_inner.value,
+            self.model.v_boundary_inner.value,
+        )
+
+    def test_v_boundary_outer(self):
+        assert (
+            self.model.model_state.v_boundary_outer.unit
+            == self.model.v_boundary_outer.unit
+        )
+        assert_almost_equal(
+            self.model.model_state.v_boundary_outer.value,
+            self.model.v_boundary_outer.value,
+        )
+
+    def test_homologous_density(self):
+        assert (
+            self.model.model_state.homologous_density
+            == self.model.homologous_density
+        )
+
+    def test_t_inner(self):
+        assert self.model.model_state.t_inner.unit == self.model.t_inner.unit
+        assert_almost_equal(
+            self.model.model_state.t_inner.value, self.model.t_inner.value
+        )
+
+    def test_t_radiative(self):
+        assert (
+            self.model.model_state.t_radiative.unit
+            == self.model.t_radiative.unit
+        )
+        assert_almost_equal(
+            self.model.model_state.t_radiative.value,
+            self.model.t_radiative.value,
+        )
+
+    def test_dilution_factor(self):
+        assert_almost_equal(
+            self.model.model_state.dilution_factor,
+            self.model.dilution_factor,
+        )
+
+    def test_v_boundary_inner_index(self):
+        assert_almost_equal(
+            self.model.model_state.v_boundary_inner_index,
+            self.model.v_boundary_inner_index,
+        )
+
+    def test_v_boundary_outer_index(self):
+        assert_almost_equal(
+            self.model.model_state.v_boundary_outer_index,
+            self.model.v_boundary_outer_index,
+        )
+
+    def test_no_of_shells(self):
+        assert self.model.model_state.no_of_shells == self.model.no_of_shells
+
 
 ###
 # Save and Load

--- a/tardis/model/tests/test_model_state.py
+++ b/tardis/model/tests/test_model_state.py
@@ -1,4 +1,5 @@
 import os
+from numpy import array_equal
 import pytest
 import pandas as pd
 from astropy import units as u
@@ -205,3 +206,16 @@ def test_ascii_reader_exponential_law():
     for i, mdens in enumerate(expected_densites):
         assert_almost_equal(model_state.density[i].value, mdens)
         assert model_state.density[i].unit == u.Unit(expected_unit)
+
+
+def test_model_state_to_numba_model():
+    filename = "tardis_configv1_ascii_density_abund.yml"
+    config = Configuration.from_yaml(data_path(filename))
+    model_state = model_state_from_config(config)
+    numba_model = model_state.to_numba_model()
+
+    assert array_equal(numba_model.v_inner, model_state.v_inner.cgs.value)
+    assert array_equal(numba_model.v_outer, model_state.v_outer.cgs.value)
+    assert array_equal(numba_model.r_inner, model_state.r_inner.cgs.value)
+    assert array_equal(numba_model.r_outer, model_state.r_outer.cgs.value)
+    assert numba_model.time_explosion == model_state.time_explosion.cgs.value

--- a/tardis/model/tests/test_model_state.py
+++ b/tardis/model/tests/test_model_state.py
@@ -1,0 +1,207 @@
+import os
+import pytest
+import pandas as pd
+from astropy import units as u
+from numpy.testing import assert_almost_equal, assert_array_almost_equal
+
+from tardis.io.config_reader import Configuration
+from tardis.io.model_reader import model_state_from_config
+from tardis.model import ModelState
+
+
+def data_path(filename):
+    return os.path.abspath(os.path.join("tardis/io/tests/data/", filename))
+
+
+class TestModelStateFromPaper1Config:
+    def setup(self):
+        filename = "paper1_tardis_configv1.yml"
+        self.config = Configuration.from_yaml(data_path(filename))
+        self.model_state = model_state_from_config(self.config)
+
+    def test_velocities(self):
+        velocity = self.config.model.structure.velocity
+        assert_almost_equal(
+            velocity.start.cgs.value, self.model_state.v_inner[0].cgs.value
+        )
+        assert_almost_equal(
+            velocity.stop.cgs.value, self.model_state.v_outer[-1].cgs.value
+        )
+        assert len(self.model_state.v_outer) == velocity.num
+
+    def test_densities(self):
+        assert_almost_equal(
+            self.model_state.density[0].cgs.value,
+            (7.542803599143591e-14 * u.Unit("g/cm^3")).value,
+        )
+        assert_almost_equal(
+            self.model_state.density[-1].cgs.value,
+            (1.432259798833509e-15 * u.Unit("g/cm^3")).value,
+        )
+
+    def test_time_explosion(self):
+        assert_almost_equal(
+            self.model_state.time_explosion.to(u.day).value, 13.0
+        )
+
+
+class TestModelStateFromASCIIDensity:
+    def setup(self):
+        filename = "tardis_configv1_ascii_density.yml"
+        self.config = Configuration.from_yaml(data_path(filename))
+        self.model_state = model_state_from_config(self.config)
+
+    def test_velocities(self):
+        assert self.model_state.v_inner.unit == u.Unit("cm/s")
+        assert_almost_equal(self.model_state.v_inner[0].value, 1e4 * 1e5)
+
+
+class TestModelStateFromArtisDensity:
+    def setup(self):
+        filename = "tardis_configv1_artis_density.yml"
+        self.config = Configuration.from_yaml(data_path(filename))
+        self.model_state = model_state_from_config(self.config)
+
+    def test_velocities(self):
+        assert self.model_state.v_inner.unit == u.Unit("cm/s")
+        assert_almost_equal(
+            self.model_state.v_inner[0].value, 1.259375e03 * 1e5
+        )
+
+
+class TestModelFromUniformDensity:
+    def setup(self):
+        filename = "tardis_configv1_uniform_density.yml"
+        self.config = Configuration.from_yaml(data_path(filename))
+        self.model_state = model_state_from_config(self.config)
+
+    def test_density(self):
+        assert_array_almost_equal(
+            self.model_state.density.to(u.Unit("g / cm3")).value, 1.0e-14
+        )
+
+
+class TestModelFromInitialTinner:
+    def setup(self):
+        filename = "tardis_configv1_uniform_density.yml"
+        self.config = Configuration.from_yaml(data_path(filename))
+        self.config.plasma.initial_t_inner = 2508 * u.K
+        self.model = model_state_from_config(self.config)
+
+    def test_initial_temperature(self):
+        assert_almost_equal(self.model.t_inner.value, 2508)
+
+
+class TestModelFromArtisDensityAbundancesAllAscii:
+    def setup(self):
+        filename = "tardis_configv1_ascii_density_abund.yml"
+        self.config = Configuration.from_yaml(data_path(filename))
+        self.config.model.structure.filename = "density.dat"
+        self.config.model.abundances.filename = "abund.dat"
+        self.model_state = model_state_from_config(self.config)
+
+    def test_velocities(self):
+        assert self.model_state.v_inner.unit == u.Unit("cm/s")
+        assert_almost_equal(
+            self.model_state.v_inner[0].to(u.km / u.s).value, 11000
+        )
+
+    def test_densities(self):
+        assert_almost_equal(
+            self.model_state.density[0].to(u.Unit("g/cm3")).value,
+            9.7656229e-11 / 13.0**3,
+        )
+        assert_almost_equal(
+            self.model_state.density[1].to(u.Unit("g/cm3")).value,
+            4.8170911e-11 / 13.0**3,
+        )
+        assert_almost_equal(
+            self.model_state.density[2].to(u.Unit("g/cm3")).value,
+            2.5600000e-11 / 13.0**3,
+        )
+        assert_almost_equal(
+            self.model_state.density[3].to(u.Unit("g/cm3")).value,
+            1.4450533e-11 / 13.0**3,
+        )
+        assert_almost_equal(
+            self.model_state.density[4].to(u.Unit("g/cm3")).value,
+            8.5733893e-11 / 13.0**3,
+        )
+        assert_almost_equal(
+            self.model_state.density[5].to(u.Unit("g/cm3")).value,
+            5.3037103e-11 / 13.0**3,
+        )
+        assert_almost_equal(
+            self.model_state.density[6].to(u.Unit("g/cm3")).value,
+            3.3999447e-11 / 13.0**3,
+        )
+
+
+def test_ascii_reader_power_law():
+    filename = "tardis_configv1_density_power_law_test.yml"
+    config = Configuration.from_yaml(data_path(filename))
+    model_state = model_state_from_config(config)
+
+    expected_densites = [
+        3.29072513e-14,
+        2.70357804e-14,
+        2.23776573e-14,
+        1.86501954e-14,
+        1.56435277e-14,
+        1.32001689e-14,
+        1.12007560e-14,
+        9.55397475e-15,
+        8.18935779e-15,
+        7.05208050e-15,
+        6.09916083e-15,
+        5.29665772e-15,
+        4.61758699e-15,
+        4.04035750e-15,
+        3.54758837e-15,
+        3.12520752e-15,
+        2.76175961e-15,
+        2.44787115e-15,
+        2.17583442e-15,
+        1.93928168e-15,
+    ]
+
+    assert model_state.no_of_shells == 20
+    for i, mdens in enumerate(expected_densites):
+        assert_almost_equal(
+            model_state.density[i].to(u.Unit("g / (cm3)")).value, mdens
+        )
+
+
+def test_ascii_reader_exponential_law():
+    filename = "tardis_configv1_density_exponential_test.yml"
+    config = Configuration.from_yaml(data_path(filename))
+    model_state = model_state_from_config(config)
+
+    expected_densites = [
+        5.18114795e-14,
+        4.45945537e-14,
+        3.83828881e-14,
+        3.30364579e-14,
+        2.84347428e-14,
+        2.44740100e-14,
+        2.10649756e-14,
+        1.81307925e-14,
+        1.56053177e-14,
+        1.34316215e-14,
+        1.15607037e-14,
+        9.95038990e-15,
+        8.56437996e-15,
+        7.37143014e-15,
+        6.34464872e-15,
+        5.46088976e-15,
+        4.70023138e-15,
+        4.04552664e-15,
+        3.48201705e-15,
+        2.99699985e-15,
+    ]
+    expected_unit = "g / (cm3)"
+
+    assert model_state.no_of_shells == 20
+    for i, mdens in enumerate(expected_densites):
+        assert_almost_equal(model_state.density[i].value, mdens)
+        assert model_state.density[i].unit == u.Unit(expected_unit)

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -50,13 +50,7 @@ def montecarlo_radial1d(
         runner._output_energy,
     )
 
-    numba_model = NumbaModel(
-        runner.r_inner_cgs,
-        runner.r_outer_cgs,
-        runner.v_inner_cgs,
-        runner.v_outer_cgs,
-        model.time_explosion.to("s").value,
-    )
+    numba_model = model.model_state.to_numba_model()
     numba_plasma = numba_plasma_initialize(plasma, runner.line_interaction_type)
     estimators = Estimators(
         runner.j_estimator,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -9,6 +9,7 @@ from tardis import model
 
 from tardis.montecarlo import MontecarloRunner
 from tardis.model import Radial1DModel
+from tardis.model import ModelState
 from tardis.plasma.standard_plasmas import assemble_plasma
 from tardis.io.util import HDFWriterMixin
 from tardis.io.config_reader import ConfigurationError
@@ -123,6 +124,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self,
         iterations,
         model,
+        model_state,
         plasma,
         runner,
         no_of_packets,
@@ -154,6 +156,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self.luminosity_requested = luminosity_requested
         self.nthreads = nthreads
         self.show_progress_bars = show_progress_bars
+        self.model_state = model_state
 
         if convergence_strategy.type in ("damped"):
             self.convergence_strategy = convergence_strategy
@@ -636,6 +639,10 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 model = Radial1DModel.from_csvy(config)
             else:
                 model = Radial1DModel.from_config(config)
+        if "model-state" in kwargs:
+            model_state = kwargs["model-state"]
+        else:
+            model_state = ModelState.from_config(config)
         if "plasma" in kwargs:
             plasma = kwargs["plasma"]
         else:
@@ -689,6 +696,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         return cls(
             iterations=config.montecarlo.iterations,
             model=model,
+            model_state=model_state,
             plasma=plasma,
             runner=runner,
             show_convergence_plots=show_convergence_plots,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -13,6 +13,7 @@ from tardis.model import ModelState
 from tardis.plasma.standard_plasmas import assemble_plasma
 from tardis.io.util import HDFWriterMixin
 from tardis.io.config_reader import ConfigurationError
+from tardis.io.model_reader import model_state_from_config
 from tardis.util.base import is_notebook
 from tardis.montecarlo import montecarlo_configuration as mc_config_module
 from tardis.visualization import ConvergencePlots
@@ -642,7 +643,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         if "model-state" in kwargs:
             model_state = kwargs["model-state"]
         else:
-            model_state = ModelState.from_config(config)
+            model_state = model_state_from_config(config)
         if "plasma" in kwargs:
             plasma = kwargs["plasma"]
         else:


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `restructure`

Restructuring the model state to hold the geometry of the model along with electron densities, isotope abundances and radiation field. Also making the model state a direct part of the simulation.

closes #2074 

### :pushpin: Resources

[restructure_project.pdf](https://github.com/tardis-sn/tardis/files/9009334/restructure_project.pdf)

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label