### PR TITLE
correct the description of 'no_of_packets' in TARDIS Documentation

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -215,3 +215,5 @@ Youssef Eweis <joey070@gmail.com> Youssef Eweis <Youssef15015@users.noreply.gith
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com>
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> rohithvarma3000 <rohith.varma.buddaraju@gmail.com>
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> Rohith <rohith.varma.buddaraju@gmail.com>
+
+Karan Garg <grgkaran03@gmail.com>

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -17,7 +17,7 @@ properties:
   no_of_packets:
     type: number
     multipleOf: 1.0
-    description: This gives the number of packets normally used in each iteration.
+    description: Used for all iterations except the last one, this feature gives the number of packets used in each iteration.
   iterations:
     type: number
     multipleOf: 1.0

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -17,7 +17,7 @@ properties:
   no_of_packets:
     type: number
     multipleOf: 1.0
-    description: Seed for the random number generator
+    description: This gives the number of packets normally used in each iteration.
   iterations:
     type: number
     multipleOf: 1.0


### PR DESCRIPTION
### :pencil: Description

**Type:** : 📝

Description of no_of_particles parameter was incorrect in TARDIS documentation[ https://tinyurl.com/ef64s538 ]. So I looked up and corrected the description. 

closes https://github.com/tardis-sn/tardis/issues/2066#issue-1280388091


### :pushpin: Resources

https://tinyurl.com/ef64s538


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [X] My changes can't be tested ( Just corrected the text in .yml file. Don't think it needs tests.)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [X] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
