### PR TITLE
Failing docs build if warnings present

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -90,7 +90,7 @@ jobs:
           EVENT: ${{ github.event_name }}
 
       - name: Build documentation
-        run: cd docs/ && make html CORES=auto
+        run: cd docs/ && make html CORES=auto SPHINXOPTS="-W --keep-going"
 
       - name: Set destination directory
         run: |


### PR DESCRIPTION
### :pencil: Description

**Please hold off on merging as another warning needs to be fixed.**

**Type:** :memo: `documentation` 

The documentation build will fail if any warnings are present (this only occurs on the GitHub build, not locally). This is to keep our documentation clean, making sure no issues are introduced, and thus making it easier to maintain our documentation.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

I tested the command ``make html CORES=auto SPHINXOPTS="-W --keep-going"`` locally and it worked as expected.

I am not sure if there is a way to check these changes on GitHub.

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
