### PR TITLE
Small bug fix for He NLTE.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -20,6 +20,7 @@ Andrew Fullard <andrewgfullard@gmail.com> Andrew Fullard <andrew.fullard@du.edu>
 
 Aoife Boyle <aboyle19@qub.ac.uk>
 Aoife Boyle <aboyle19@qub.ac.uk> aoifeboyle <aboyle19@qub.ac.uk>
+Aoife Boyle <boyle@iap.fr>
 
 Arib Alam <arib.alam.iitkgp@gmail.com>
 Arib Alam <arib.alam.iitkgp@gmail.com> aribalam <arib.alam.iitkgp@gmail.com>

--- a/tardis/plasma/properties/nlte.py
+++ b/tardis/plasma/properties/nlte.py
@@ -86,7 +86,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         helium_population.loc[0, 0] = 0.0
         # He II excited states
         he_two_population = level_boltzmann_factor.loc[2, 1].mul(
-            (g.loc[2, 1, 0] ** (-1.0))
+            (2 ** (-1.0))
         )
         helium_population.loc[1].update(he_two_population)
         # He II ground state
@@ -117,7 +117,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         """
         return (
             level_boltzmann_factor.loc[2, 0]
-            * (1.0 / (2 * g.loc[2, 1, 0]))
+            * (1.0 / (2 * 2))
             * (1 / g_electron)
             * (1 / (w**2.0))
             * np.exp(ionization_data.loc[2, 1] * beta_rad)
@@ -141,7 +141,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         zeta = PhiSahaNebular.get_zeta_values(zeta_data, 2, t_rad)[1]
         he_three_population = (
             2
-            * (float(g.loc[2, 2, 0]) / g.loc[2, 1, 0])
+            * (float(g.loc[2, 2, 0]) / 2)
             * g_electron
             * np.exp(-ionization_data.loc[2, 2] * beta_rad)
             * w

--- a/tardis/plasma/properties/nlte.py
+++ b/tardis/plasma/properties/nlte.py
@@ -86,7 +86,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         helium_population.loc[0, 0] = 0.0
         # He II excited states
         he_two_population = level_boltzmann_factor.loc[2, 1].mul(
-            (2 ** (-1.0))
+            (float(g.loc[2,1,0]) ** (-1.0))
         )
         helium_population.loc[1].update(he_two_population)
         # He II ground state
@@ -117,7 +117,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         """
         return (
             level_boltzmann_factor.loc[2, 0]
-            * (1.0 / (2 * 2))
+            * (1.0 / (float(g.loc[2,1,0]) * 2))
             * (1 / g_electron)
             * (1 / (w**2.0))
             * np.exp(ionization_data.loc[2, 1] * beta_rad)
@@ -141,7 +141,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         zeta = PhiSahaNebular.get_zeta_values(zeta_data, 2, t_rad)[1]
         he_three_population = (
             2
-            * (float(g.loc[2, 2, 0]) / 2)
+            * (float(g.loc[2, 2, 0]) / float(g.loc[2,1,0]))
             * g_electron
             * np.exp(-ionization_data.loc[2, 2] * beta_rad)
             * w

--- a/tardis/plasma/properties/nlte.py
+++ b/tardis/plasma/properties/nlte.py
@@ -86,7 +86,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         helium_population.loc[0, 0] = 0.0
         # He II excited states
         he_two_population = level_boltzmann_factor.loc[2, 1].mul(
-            (g.loc[2,1,0].values ** (-1.0))
+            (float(g.loc[2,1,0]) ** (-1.0))
         )
         helium_population.loc[1].update(he_two_population)
         # He II ground state
@@ -117,7 +117,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         """
         return (
             level_boltzmann_factor.loc[2, 0]
-            * (1.0 / (g.loc[2,1,0].values * 2))
+            * (1.0 / (float(g.loc[2,1,0]) * 2))
             * (1 / g_electron)
             * (1 / (w**2.0))
             * np.exp(ionization_data.loc[2, 1] * beta_rad)

--- a/tardis/plasma/properties/nlte.py
+++ b/tardis/plasma/properties/nlte.py
@@ -86,7 +86,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         helium_population.loc[0, 0] = 0.0
         # He II excited states
         he_two_population = level_boltzmann_factor.loc[2, 1].mul(
-            (float(g.loc[2,1,0]) ** (-1.0))
+            (g.loc[2,1,0].values ** (-1.0))
         )
         helium_population.loc[1].update(he_two_population)
         # He II ground state
@@ -117,7 +117,7 @@ class HeliumNLTE(ProcessingPlasmaProperty):
         """
         return (
             level_boltzmann_factor.loc[2, 0]
-            * (1.0 / (float(g.loc[2,1,0]) * 2))
+            * (1.0 / (g.loc[2,1,0].values * 2))
             * (1 / g_electron)
             * (1 / (w**2.0))
             * np.exp(ionization_data.loc[2, 1] * beta_rad)


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

With the new format for the atomic data associated with Boyle et al. (2016), an issue arises when calling the degeneracy factor g using the indexing g.loc[2,1,0], for example. I have replaced this with just the number that would be read in each case. These numbers would never need to change. 

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method (describe): Tested manually.
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
