### PR TITLE
creating new docs building instructions

### DIFF
--- a/docs/contributing/development/documentation_guidelines.rst
+++ b/docs/contributing/development/documentation_guidelines.rst
@@ -60,6 +60,7 @@ To build TARDIS documentation locally, use the following commands:
     - If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
     - Use ``DISABLE_NBSPHINX=1 make html`` to disable notebook rendering (fast mode).
     - Use ``make html CORES=<number of cores>`` to have the documentation build in parallel. Using ``make html CORES=auto`` instructs Sphinx to use all of your device's cores.
+    - Use ``make html SPHINXOPTS="<insert sphinx options>"`` to include additional sphinx options, which can be found `here <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options>`_.
 
 After running this command, you can find the built docs (i.e. HTML webpages) in ``docs/_build/html``. Open the ``index.html`` in your browser to see how the documentation looks like with your edits. Navigate to page where you made changes or file that you added to check whether it looks as intended or not.
 
@@ -68,27 +69,24 @@ Additionally, check your terminal for warning messages during the documentation 
 
 .. _doc-preview:
 
-Sharing the built documentation in your PR (Documentation Preview)
-==================================================================
+Sharing the built documentation in your pull request
+====================================================
 
-When you make edits in TARDIS documentation and submit a PR, we can only see the changes in source files in GitHub files diff, but not the built documentation (webpages). This is usually fine unless you have made changes in the documentation itself or changes that could break the Jupyter notebooks used in the documentation. In such cases, you should share the preview of documentation with your changes by building it online via GitHub. This will help us (the reviewers of your PR) to check how the documentation will look once your PR is merged.
+When proposing changes to the documentation, or the code in general, it is useful to reviewers to see how the documentation will look once your pull request is merged. This is done by adding the ``build-docs`` label to your pull request on GitHub. If you do not have permission to add the label, leave a comment in your pull request or contact a senior member of the collaboration and it will be added.
 
-To preview your changes to the documentation on GitHub, please:
+The documentation will be built as soon as the label is added, and any subsequent commits while the label is present will trigger a documentation build. Your built documentation will be available at ``https://tardis-sn.github.io/tardis/pull/<pull request number>/index.html``. It will also be automatically linked to in the comments of the pull request.
 
-#. Enable GitHub Actions in the *Actions* tab of your fork.
-#. Under *Settings -> Pages* in your fork, make sure GitHub Pages is being built from the ``gh-pages`` branch and the ``/ (root)`` folder.
+Finally, to view the build logs (which will contain warning and error messages), go to the ``Actions`` tab in the TARDIS repository, and click on ``docs`` in the list of workflows. You can search documentation builds by branch to find your build log.
 
-Then, there are two ways to trigger the build:
 
-#. If the branch you are working on contains the word ``doc`` in it, then every commit pushed to that branch will trigger the build.
-#. If your commit message contains the ``[build docs]`` tag, then that commit will trigger the build.
+Troubleshooting Your Documentation
+==================================
 
-You can check for warning messages via the *Actions* tab of your fork. Your preview will be available at ``<username>.github.io/tardis/branch/<branch name>/index.html``.
+It is important to keep your documentation free of warnings and errors, which can be found in the build logs (locally these will appear in your terminal, and for builds on GitHub see the last paragraph in the above section). On GitHub, these will give you a notification that your documentation build failed. Below are some pointers for resolving these issues:
 
-.. note::
+* Errors often are a result of notebooks being incompatable with your new code. Make sure notebooks are always updated to reflect your additions.
+* Warnings are often due to incorrect syntax in RST documentation regarding links, section headers, tables of contents, etc. Please see the `RST documentation <https://sublime-and-sphinx-guide.readthedocs.io/en/latest/index.html>`_ for instructions on proper syntax.
+* Warnings can also be because docstrings are not consistent with the `numpy docstring format <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
+* On GitHub, built documentation files (including ``.ipynb`` files built by Sphinx) can be a maximum of 100 MB. You can check the file sizes after a local documentation build in ``docs/_build/html``. Note that image output in notebooks built by Sphinx are by default in SVG format. For detailed images, these images can be very large. If file size becomes a problem, you will need to change the image format for that notebook by placing ``%config InlineBackend.figure_formats='png2x'`` in a `hidden cell <https://nbsphinx.readthedocs.io/en/0.8.7/hidden-cells.html>`_ at the beginning of the notebook.
 
-    You always can trigger a new build by pushing an empty commit: ``git commit --allow-empty -m "[build docs]"``
-
-.. warning::
-    
-    On GitHub, built documentation files (including ``.ipynb`` files built by Sphinx) can be a maximum of 100 MB. You can check the file sizes after a local documentation build in ``docs/_build/html``, or after a documentation preview on GitHub in the ``gh-pages`` branch. Note that image output in notebooks built by Sphinx are by default in SVG format. For detailed images, these images can be very large. If file size becomes a problem, you will need to change the image format for that notebook by placing ``%config InlineBackend.figure_formats='png2x'`` in a `hidden cell <https://nbsphinx.readthedocs.io/en/0.8.7/hidden-cells.html>`_ at the beginning of the notebook.
+Please reach out for help if you have difficulties resolving issues in your documentation.

--- a/docs/contributing/development/git_workflow.rst
+++ b/docs/contributing/development/git_workflow.rst
@@ -352,6 +352,8 @@ When you are ready to ask for someone to review your code and consider a merge:
    pull request message.  This is still a good way to start a preliminary
    code review.
 
+The TARDIS documentation features interactive notebooks that run varius aspects of the code, as well as API documentation. To make sure that these notebooks remain up-to-date with the code, and that your docstrings are correctly incorporated into the API documentation, we ask that you build the documentation for your pull request following the instructions :ref:`here <doc-preview>`.
+
 .. _using-virtualenv:
 
 Making sure your Pull Request stays up-to-date


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Adds updated instructions for building documentation on GitHub.

Closes #2089.


### :pushpin: Resources

See the docs:


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Docs built on GitHub.

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
