### PR TITLE
Resturcture ABCs import from collections module

### DIFF
--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -7,7 +7,7 @@ import logging
 
 import pandas as pd
 import numpy as np
-import collections
+import collections.abc as collections_abc
 from collections import OrderedDict
 
 import yaml
@@ -155,11 +155,11 @@ def traverse_configs(base, other, func, *args):
     args :
         Arguments passed into `func`
     """
-    if isinstance(base, collections.Mapping):
+    if isinstance(base, collections_abc.Mapping):
         for k in base:
             traverse_configs(base[k], other[k], func, *args)
     elif (
-        isinstance(base, collections.Iterable)
+        isinstance(base, collections_abc.Iterable)
         and not isinstance(base, basestring)
         and not hasattr(base, "shape")
     ):


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Change import of ABCs from 'collections' to 'collections.abc' because the old import will fail in future versions of python.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 

Resolves #1903 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
