### PR TITLE
Added positronium notes

### DIFF
--- a/docs/physics/energy_input/index.rst
+++ b/docs/physics/energy_input/index.rst
@@ -1,6 +1,7 @@
 ***************************
-Gamma Ray Energy Deposition
+Energy Deposition
 ***************************
 
 .. toctree::
     gammaray_deposition
+    positronium

--- a/docs/physics/energy_input/positronium.rst
+++ b/docs/physics/energy_input/positronium.rst
@@ -1,0 +1,23 @@
+**************************
+Positronium
+**************************
+
+Positronium (Ps) is the pairing of an electron and positron into a bound state analogous to a hydrogen atom (see `Wikipedia <https://en.wikipedia.org/wiki/Positronium>`_). This occurs when the relative motion between the positron and electron is small :cite:`Jauch1976` (:math:`\beta \rightarrow 0`, :math:`\beta=v/c`).
+
+The mean lifetime of Ps is very short, on the order of nanoseconds. It is most likely to produce 2 or 3 gamma-ray photons depending on if it is para-Ps (2 photons of 511 keV each) or ortho-Ps (3 photons). The Ps types are dependent on the spin state of the electron and so occur in a 1/4 (para-Ps, S = 0, Ms = 0) to 3/4 (ortho-Ps, S = 1, Ms = −1, 0, 1) ratio. The triplet emission produces a continuum of photon energies described in :cite:`Ore1949`.
+
+In supernovae, Ps can form when :math:`\beta`-decay occurs in the radioactive material produced as part of the explosion. The amount of Ps formed compared to immediate 2 photon annihilation in supernovae is unknown. In the galaxy, the value is determined to be :math:`0.94\pm0.04` :cite:`Milne2004`. Gamma-ray transport codes typically assume either no Ps formation (and thus all :math:`\beta`-decay releases 2 511 keV photons) or 100% Ps formation (and thus photons are released in pairs or triplets in a 1/4 to 3/4 ratio).
+
+According to :cite:`Jauch1976` the density-dependent reciprocal lifetime :math:`\frac{1}{\tau_2}` (called a "cross-section") of para-Ps is
+
+.. math:: 
+    P \equiv \frac{1}{\tau_2} = r_0^2 \pi \rho
+
+where :math:`r_0` is the classical electron radius and :math:`\rho` is the electron number density. Note that the units here appear to be inverse length rather than the expected inverse time.
+
+For ortho-Ps, the cross-section is 
+
+.. math:: 
+    P \equiv \frac{1}{\tau_3} = \frac{4}{3} (\pi^2-9) \alpha r_0^2  \rho
+
+where :math:`\alpha` is the fine structure constant. This makes the ortho-Ps cross-section (and associated lifetime) roughly 300 times smaller than that of para-Ps.

--- a/docs/physics/energy_input/positronium.rst
+++ b/docs/physics/energy_input/positronium.rst
@@ -1,6 +1,6 @@
-**************************
+***********
 Positronium
-**************************
+***********
 
 Positronium (Ps) is the pairing of an electron and positron into a bound state analogous to a hydrogen atom (see `Wikipedia <https://en.wikipedia.org/wiki/Positronium>`_). This occurs when the relative motion between the positron and electron is small :cite:`Jauch1976` (:math:`\beta \rightarrow 0`, :math:`\beta=v/c`).
 

--- a/docs/tardis.bib
+++ b/docs/tardis.bib
@@ -285,3 +285,35 @@
    month        = {Jun},
    pages        = {32}
 }
+
+@ARTICLE{Milne2004,
+       author = {{Milne}, P.~A. and {Hungerford}, A.~L. and {Fryer}, C.~L. and {Evans}, T.~M. and {Urbatsch}, T.~J. and {Boggs}, S.~E. and {Isern}, J. and {Bravo}, E. and {Hirschmann}, A. and {Kumagai}, S. and {Pinto}, P.~A. and {The}, L. -S.},
+        title = "{Unified One-Dimensional Simulations of Gamma-Ray Line Emission from Type Ia Supernovae}",
+      journal = {\apj},
+     keywords = {Gamma Rays: Observations, Gamma Rays: Theory, Stars: Supernovae: General, Astrophysics},
+         year = 2004,
+        month = oct,
+       volume = {613},
+       number = {2},
+        pages = {1101-1119},
+          doi = {10.1086/423235},
+archivePrefix = {arXiv},
+       eprint = {astro-ph/0406173},
+ primaryClass = {astro-ph},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2004ApJ...613.1101M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@book{Jauch1976,
+	address = {Berlin, Heidelberg},
+	title = {The {Theory} of {Photons} and {Electrons}: the {Relativistic} {Quantum} {Field} {Theory} of {Charged} {Particles} with {Spin} {One}-half},
+	isbn = {978-3-642-80951-4 978-3-642-80953-8},
+	shorttitle = {The {Theory} of {Photons} and {Electrons}},
+	url = {https://doi.org/10.1007/978-3-642-80951-4},
+	language = {English},
+	urldate = {2022-07-27},
+	publisher = {Springer Berlin Heidelberg},
+	author = {Jauch, J. M and Rohrlich, F},
+	year = {1976},
+	note = {OCLC: 840300942},
+}


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Added some documentation for positronium discussion. Probably won't stay under the "energy input" header, but it's the best place to keep a record.


### :pushpin: Resources

See https://en.wikipedia.org/wiki/Positronium 
Positronium spectrum https://ui.adsabs.harvard.edu/abs/1949PhRv...75.1696O 
SN Ia commentary (section 2.2.2) https://ui.adsabs.harvard.edu/abs/2004ApJ...613.1101M/abstract

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
