### PR TITLE
removed scatter function from interaction.py

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -144,24 +144,6 @@ def sample_nu_free_bound(numba_plasma, shell, continuum_id):
 
 
 @njit(**njit_dict_no_parallel)
-def scatter(r_packet, time_explosion):
-
-    old_doppler_factor = get_doppler_factor(
-        r_packet.r, r_packet.mu, time_explosion
-    )
-    comov_nu = r_packet.nu * old_doppler_factor
-    comov_energy = r_packet.energy * old_doppler_factor
-    r_packet.mu = get_random_mu()
-    inverse_new_doppler_factor = get_inverse_doppler_factor(
-        r_packet.r, r_packet.mu, time_explosion
-    )
-
-    r_packet.energy = comov_energy * inverse_new_doppler_factor
-
-    return comov_nu, inverse_new_doppler_factor
-
-
-@njit(**njit_dict_no_parallel)
 def continuum_event(
     r_packet,
     time_explosion,


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Scatter function is not used in the interaction.py, this PR removes that.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
