### PR TITLE
Replacing NumbaModel with NumbaRadial1DGeometry

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -167,6 +167,7 @@ def montecarlo_main_loop(
     Parameters
     ----------
     packet_collection : PacketCollection
+    numba_model: NumbaModel
     numba_radial_1d_geometry : NumbaRadial1DGeometry
     numba_plasma : NumbaPlasma
     estimators : NumbaEstimators

--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -57,6 +57,13 @@ def montecarlo_radial1d(
         geometry.v_inner.cgs.value,
         geometry.v_outer.cgs.value,
     )
+    numba_model = NumbaModel(
+        geometry.r_inner.cgs.value,
+        geometry.r_outer.cgs.value,
+        geometry.v_inner.cgs.value,
+        geometry.v_outer.cgs.value,
+        model.model_state.time_explosion.cgs.value,
+    )
     numba_plasma = numba_plasma_initialize(plasma, runner.line_interaction_type)
     estimators = Estimators(
         runner.j_estimator,
@@ -89,6 +96,7 @@ def montecarlo_radial1d(
         rpacket_trackers,
     ) = montecarlo_main_loop(
         packet_collection,
+        numba_model,
         numba_radial_1d_geometry,
         numba_plasma,
         estimators,
@@ -139,6 +147,7 @@ def montecarlo_radial1d(
 @njit(**njit_dict)
 def montecarlo_main_loop(
     packet_collection,
+    numba_model,
     numba_radial_1d_geometry,
     numba_plasma,
     estimators,
@@ -260,6 +269,7 @@ def montecarlo_main_loop(
 
         loop = single_packet_loop(
             r_packet,
+            numba_model,
             numba_radial_1d_geometry,
             numba_plasma,
             estimators,

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -13,6 +13,32 @@ from tardis.montecarlo import (
 
 C_SPEED_OF_LIGHT = const.c.to("cm/s").value
 
+numba_geometry_spec = [
+    ("r_inner", float64[:]),
+    ("r_outer", float64[:]),
+    ("v_inner", float64[:]),
+    ("v_outer", float64[:]),
+]
+
+
+@jitclass(numba_geometry_spec)
+class NumbaRadial1DGeometry(object):
+    def __init__(self, r_inner, r_outer, v_inner, v_outer):
+        """Geometry for the Numba mode
+
+        Parameters
+        ----------
+        r_inner : numpy.ndarray
+        r_outer : numpy.ndarray
+        v_inner : numpy.ndarray
+        v_outer : numpy.ndarray
+        """
+        self.r_inner = r_inner
+        self.r_outer = r_outer
+        self.v_inner = v_inner
+        self.v_outer = v_outer
+
+
 numba_model_spec = [
     ("r_inner", float64[:]),
     ("r_outer", float64[:]),

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -51,6 +51,7 @@ def single_packet_loop(
     Parameters
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
+    numba_model: tardis.montecarlo.montecarlo_numba.numba_interface.NumbaModel
     numba_radial_1d_geometry : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaRadial1DGeometry
     numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
     estimators : tardis.montecarlo.montecarlo_numba.numba_interface.Estimators

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -41,6 +41,7 @@ C_SPEED_OF_LIGHT = const.c.to("cm/s").value
 def single_packet_loop(
     r_packet,
     numba_model,
+    numba_radial_1d_geometry,
     numba_plasma,
     estimators,
     vpacket_collection,
@@ -50,7 +51,7 @@ def single_packet_loop(
     Parameters
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
-    numba_model : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaModel
+    numba_radial_1d_geometry : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaRadial1DGeometry
     numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
     estimators : tardis.montecarlo.montecarlo_numba.numba_interface.Estimators
     vpacket_collection : tardis.montecarlo.montecarlo_numba.numba_interface.VPacketCollection
@@ -65,10 +66,10 @@ def single_packet_loop(
     line_interaction_type = montecarlo_configuration.line_interaction_type
 
     if montecarlo_configuration.full_relativity:
-        set_packet_props_full_relativity(r_packet, numba_model)
+        set_packet_props_full_relativity(r_packet, numba_radial_1d_geometry)
     else:
-        set_packet_props_partial_relativity(r_packet, numba_model)
-    r_packet.initialize_line_id(numba_plasma, numba_model)
+        set_packet_props_partial_relativity(r_packet, numba_radial_1d_geometry)
+    r_packet.initialize_line_id(numba_plasma, numba_radial_1d_geometry)
 
     trace_vpacket_volley(
         r_packet, vpacket_collection, numba_model, numba_plasma
@@ -138,7 +139,7 @@ def single_packet_loop(
                 r_packet, distance, numba_model.time_explosion, estimators
             )
             move_packet_across_shell_boundary(
-                r_packet, delta_shell, len(numba_model.r_inner)
+                r_packet, delta_shell, len(numba_radial_1d_geometry.r_inner)
             )
 
         elif interaction_type == InteractionType.LINE:

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -66,10 +66,10 @@ def single_packet_loop(
     line_interaction_type = montecarlo_configuration.line_interaction_type
 
     if montecarlo_configuration.full_relativity:
-        set_packet_props_full_relativity(r_packet, numba_radial_1d_geometry)
+        set_packet_props_full_relativity(r_packet, numba_model)
     else:
-        set_packet_props_partial_relativity(r_packet, numba_radial_1d_geometry)
-    r_packet.initialize_line_id(numba_plasma, numba_radial_1d_geometry)
+        set_packet_props_partial_relativity(r_packet, numba_model)
+    r_packet.initialize_line_id(numba_plasma, numba_model)
 
     trace_vpacket_volley(
         r_packet, vpacket_collection, numba_model, numba_plasma


### PR DESCRIPTION
### :pencil: Description

**Type:**  :rocket: `restructure`

Replacing NumbaModel with NumbaRadial1DGeometry.