### PR TITLE
added documentation for using particular refdata files for unit testing

### DIFF
--- a/docs/contributing/development/running_tests.rst
+++ b/docs/contributing/development/running_tests.rst
@@ -28,11 +28,37 @@ tests, you can run this with:
 
 Running the more advanced unit tests requires TARDIS Reference data that can be
 downloaded
-(`tardis_refdata <https://github.com/tardis-sn/tardis-refdata>`_).
+(`tardis-refdata <https://github.com/tardis-sn/tardis-refdata>`_).
+`Git LFS <https://www.atlassian.com/git/tutorials/git-lfs>`_ is used
+to download the large refdata files in the tardis-refdata repository.
+
+However, it is not required to download the entire repository. Firstly it is
+important to identify the refdata files that are needed. Sometimes, it is possible
+that a preused fixture that is also being used in the current tests is using some
+refdata. So, it is advised to check for such cases beforehand.
+
+After identifying the refdata files to be used in the unit tests, those particular
+files can be downloaded using ``git lfs`` 
+
+.. code-block:: shell
+
+    > git lfs pull --include=filename
+
+It is important to maintain the same directory structure as the tardis-refdata repo
+i.e. the lfs files should be in the same directory tree exactly as in tardis-refdata
+repository.
+
+Finally, the tests can be run using the following command
 
 .. code-block:: shell
 
     > pytest tardis --tardis-refdata=/path/to/tardis-refdata/
+
+Or, to run tests for a particular file or directory
+
+.. code-block:: shell
+
+    > pytest tardis/path/to/test_file_or_directory --tardis-refdata=/path/to/tardis-refdata/
 
 Generating Plasma Reference
 ===========================


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

This PR adds documentation to the developer workflow when working with unit tests. It says how to download only a required slice of refdata for running some unit tests of interest .

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
