### PR TITLE
Pin setuptools_scm to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install setuptools_scm
-        run: pip install setuptools_scm
+        run: pip install 'setuptools_scm<7'
 
       - name: Show current version
         run: python .ci-helpers/get_current_version.py

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -8,9 +8,9 @@ dependencies:
   # WARNING: any change to this section must be applied to the conda-forge
   # package recipe at https://github.com/conda-forge/tardis-sn-feedstock
 
-  - python=3.8
+  - python =3.8
   - setuptools
-  - setuptools_scm
+  - setuptools_scm<7
   - pip
   - numpy=1.19
   - scipy=1.5

--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -8,7 +8,7 @@ dependencies:
   # WARNING: any change to this section must be applied to the conda-forge
   # package recipe at https://github.com/conda-forge/tardis-sn-feedstock
 
-  - python =3.8
+  - python=3.8
   - setuptools
   - setuptools_scm<7
   - pip


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

Version helper scripts do not work with `setuptools_scm>=7` breaking the release cycle.


### :pushpin: Resources

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

You can check this on your computer by manually updating `setuptools_scm` to and running any of the scripts at `.ci-helpers`.


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
