### PR TITLE
Kilonova missing zeta

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -70,6 +70,9 @@ Frederik Beaujean <beaujean@mpp.mpg.de> Frederik Beaujean <schoenerhans16@gmx.de
 Gaurav Gautam <gautam1168@gmail.com>
 Gaurav Gautam <gautam1168@gmail.com> gautam1168 <gautam1168@gmail.com>
 
+Gerrit Leck <gerritleck@web.de>
+Gerrit Leck <gerritleck@web.de> Gerrit Leck <g.leck@gsi.de>
+
 Isaac Smith <smithis7@msu.edu> 
 Isaac Smith <smithis7@msu.edu> Isaac Smith <71480393+smithis7@users.noreply.github.com>
 Isaac Smith <smithis7@msu.edu> smithis7 <71480393+smithis7@users.noreply.github.com>

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -626,13 +626,18 @@ class ZetaData(BaseAtomicDataProperty):
     outputs = ("zeta_data",)
 
     def _filter_atomic_property(self, zeta_data, selected_atoms):
+        #import pdb; pdb.set_trace()
         zeta_data["atomic_number"] = zeta_data.index.codes[0] + 1
         zeta_data["ion_number"] = zeta_data.index.codes[1] + 1
         zeta_data = zeta_data[zeta_data.atomic_number.isin(selected_atoms)]
         zeta_data_check = counter(zeta_data.atomic_number.values)
         keys = np.array(list(zeta_data_check.keys()))
         values = np.array(zeta_data_check.values())
-        if np.alltrue(keys + 1 == values):
+        #if not keys:
+            #keys = np.array(selected_atoms.values())
+            #values = np.array(selected_atoms.values())
+        #import pdb; pdb.set_trace()
+        if np.alltrue(keys + 1 == values) and keys:
             return zeta_data
         else:
             #            raise IncompleteAtomicData('zeta data')
@@ -669,6 +674,7 @@ class ZetaData(BaseAtomicDataProperty):
             updated_dataframe["atomic_number"] = np.array(updated_index[0])
             updated_dataframe["ion_number"] = np.array(updated_index[1])
             updated_dataframe.fillna(1.0, inplace=True)
+            import pdb; pdb.set_trace()
             return updated_dataframe
 
     def _set_index(self, zeta_data):

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -626,17 +626,12 @@ class ZetaData(BaseAtomicDataProperty):
     outputs = ("zeta_data",)
 
     def _filter_atomic_property(self, zeta_data, selected_atoms):
-        #import pdb; pdb.set_trace()
         zeta_data["atomic_number"] = zeta_data.index.codes[0] + 1
         zeta_data["ion_number"] = zeta_data.index.codes[1] + 1
         zeta_data = zeta_data[zeta_data.atomic_number.isin(selected_atoms)]
         zeta_data_check = counter(zeta_data.atomic_number.values)
         keys = np.array(list(zeta_data_check.keys()))
         values = np.array(zeta_data_check.values())
-        #if not keys:
-            #keys = np.array(selected_atoms.values())
-            #values = np.array(selected_atoms.values())
-        #import pdb; pdb.set_trace()
         if np.alltrue(keys + 1 == values) and keys:
             return zeta_data
         else:
@@ -674,7 +669,6 @@ class ZetaData(BaseAtomicDataProperty):
             updated_dataframe["atomic_number"] = np.array(updated_index[0])
             updated_dataframe["ion_number"] = np.array(updated_index[1])
             updated_dataframe.fillna(1.0, inplace=True)
-            import pdb; pdb.set_trace()
             return updated_dataframe
 
     def _set_index(self, zeta_data):


### PR DESCRIPTION
### :pencil: Description

This PR improves upon the suggestions from PR 1875 which I have closed.


**Type:** :beetle: `bugfix` 

The original problem from PR 1875 was: In case one runs a simulation with elements of atomic number > 28 only (as for kilonovae e.g.), in NLTE mode TARDIS would crash as it does not find any recombination (zeta) data. If one included at least one element with Z <= 28, the simulation would not crash.

Proposed changes here to fix the issue: In tardis/plasma/properties/atomic.py, just add "and keys" in the if condition in line 635. Creating an additional filter for zeta data turned out not to be necessary.
This if statement fills up missing zeta data with dummy values in the "else" condition if elements > 28 are included. However, this "else" condition was not reached if ONLY Z > 28 elements are provided as the list called "keys" is empty in that case. To force TARDIS to enter the "else" condition anyway, "and keys" checks if "keys" is not empty. If it is empty, the "else" condition is entered and executed, filling up the zeta dataframe with dummy values for all required ions.

What could be done in addition is to move all zeta data massaging which is done in ion_population.py, namely in get_zeta_values from the PhiSahaNebular class, to atomic.py. This would make the code even more consistent at this particular point. Andreas suggested I could do this as well as I have just checked out the code at this point.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

Running a simulation is enough, printing / checking with debugger the resulting dataframe for zeta data showed that the changes work fine.

- [ ] Testing pipeline
- [x ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
