### PR TITLE
Set specific qgrid feedstock version

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -38,7 +38,7 @@ dependencies:
   - matplotlib-base
   - ipywidgets
   - plotly
-  - qgrid
+  - qgrid=1.3.1=pyhd8ed1ab_4 # qgrid-feedstock/issues/18
 
   # --- Packages not required for conda-forge recipe ---
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Adds explicit qgrid feedstock version to solve environment creation issues.

Fixes #2137 

### :pushpin: Resources

#2137
https://github.com/qgrid-feedstock/issues/18

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
