### PR TITLE
Fix relativistic packet initialization

### DIFF
--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -139,3 +139,76 @@ class BlackBodySimpleSource(BasePacketSource):
         energies = self.create_uniform_packet_energies(no_of_packets, rng)
 
         return radii, nus, mus, energies
+
+
+class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
+    def create_packets(self, T, no_of_packets, rng, radius, time_explosion):
+        """Generate relativistic black-body packet properties as arrays
+
+        Parameters
+        ----------
+        T : float64
+            Temperature
+        no_of_packets : int
+            Number of packets
+        rng : numpy random number generator
+        radius : float64
+            Initial packet radius
+        time_explosion: float64
+            Time elapsed since explosion
+
+        Returns
+        -------
+        array
+            Packet radii
+        array
+            Packet frequencies
+        array
+            Packet directions
+        array
+            Packet energies
+        """
+        self.beta = ((radius / time_explosion) / const.c).to("")
+        return super().create_packets(T, no_of_packets, rng, radius)
+
+    def create_zero_limb_darkening_packet_mus(self, no_of_packets, rng):
+        """
+        Create zero-limb-darkening packet :math:`\mu^\prime` distributed
+        according to :math:`\\mu^\\prime=2 \\frac{\\mu^\\prime + \\beta}{2 \\beta + 1}`.
+        The complicated distribution is due to the fact that the inner boundary
+        on which the packets are initialized is not comoving with the material.
+
+        Parameters
+        ----------
+        no_of_packets : int
+            number of packets to be created
+        """
+        z = rng.random(no_of_packets)
+        beta = self.beta
+        return -beta + np.sqrt(beta**2 + 2 * beta * z + z)
+
+    def create_uniform_packet_energies(self, no_of_packets, rng):
+        """
+        Uniformly distribute energy in arbitrary units where the ensemble of
+        packets has energy of 1 multiplied by relativistic correction factors.
+
+        Parameters
+        ----------
+        no_of_packets : int
+            number of packets
+
+        Returns
+        -------
+            energies for packets : numpy.ndarray
+        """
+        beta = self.beta
+        gamma = 1.0 / np.sqrt(1 - beta**2)
+        static_inner_boundary2cmf_factor = (2 * beta + 1) / (1 - beta**2)
+        energies = np.ones(no_of_packets) / no_of_packets
+        # In principle, the factor gamma should be applied to the time of
+        # simulation to account for time dilation between the lab and comoving
+        # frame. However, all relevant quantities (luminosities, estimators, ...)
+        # are calculated as ratios of packet energies and the time of simulation.
+        # Thus, we can absorb the factor gamma in the packet energies, which is
+        # more convenient.
+        return energies * static_inner_boundary2cmf_factor / gamma

--- a/tardis/transport/r_packet_transport.py
+++ b/tardis/transport/r_packet_transport.py
@@ -15,9 +15,7 @@ from tardis.montecarlo.montecarlo_numba.estimators import (
 from tardis.transport.frame_transformations import (
     get_doppler_factor,
 )
-from tardis.montecarlo.montecarlo_numba.numba_config import (
-    ENABLE_FULL_RELATIVITY,
-)
+import tardis.montecarlo.montecarlo_numba.numba_config as nc
 from tardis.montecarlo.montecarlo_numba.opacities import calculate_tau_electron
 from tardis.montecarlo.montecarlo_numba.r_packet import (
     InteractionType,
@@ -211,8 +209,8 @@ def move_r_packet(r_packet, distance, time_explosion, numba_estimator):
         comov_nu = r_packet.nu * doppler_factor
         comov_energy = r_packet.energy * doppler_factor
 
-        # Account for length contraction and angle aberration
-        if ENABLE_FULL_RELATIVITY:
+        # Account for length contraction
+        if nc.ENABLE_FULL_RELATIVITY:
             distance *= doppler_factor
 
         set_estimators(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

TARDIS currently does not initialize packets correctly for highly relativistic flows. The reason (found by @ssim) is that the inner boundary, on which we initialize the packets, is not comoving with the material. As a result, we need to adjust the distribution of comoving angles and energies.
(I will add a more detailed description later.)

With the changes in this PR, the flux from the TARDIS inner boundary matches the theoretical expectation for the emission of a highly relativistic sharp photosphere (beta = 0.2) as derived by @ssim:
![relativistic_flux_theory_tardis_comparison](https://user-images.githubusercontent.com/12252237/202769747-3d0060dc-92f7-456a-ac78-154508899951.png)
Also, TARDIS now produces W=0.5 directly at the inner boundary even for highly relativistic velocities as expected for zero limb darkening in the comoving frame.

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [X] Other method (check against Stuart's prediction, w=0.5)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
