### PR TITLE
 Rename T variables to temperature 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
+Abhishek Patidar <1e9abhi1e10@gmail.com>
 Adam Suban-Loewen <adam.subanloewen@gmail.com>
 
 Alexander Holas <alexander.holas@h-its.org>

--- a/tardis/analysis/opacities.py
+++ b/tardis/analysis/opacities.py
@@ -372,13 +372,13 @@ class opacity_calculator(object):
 
         for i in range(self.nshells):
             delta_nu = self.nu_bins[1:] - self.nu_bins[:-1]
-            T = self.mdl.plasma.t_rad[i]
-            bb_nu = Blackbody(T)
+            temperature = self.mdl.plasma.t_rad[i]
+            bb_nu = Blackbody(temperature)
 
             tmp = (
                 bb_nu(self.nu_bins[:-1]) * delta_nu * self.kappa_tot[:, 0]
             ).sum()
-            tmp /= (bb_nu(self.nu_bins[:-1], T) * delta_nu).sum()
+            tmp /= (bb_nu(self.nu_bins[:-1], temperature) * delta_nu).sum()
 
             kappa_planck_mean[i] = tmp
 

--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -208,7 +208,7 @@ class MontecarloRunner(HDFWriterMixin):
         self.v_outer_cgs = model.v_outer.to("cm/s").value
 
     def _initialize_packets(
-        self, T, no_of_packets, iteration, radius, time_explosion
+        self, temperature, no_of_packets, iteration, radius, time_explosion
     ):
         # the iteration is added each time to preserve randomness
         # across different simulations with the same temperature,
@@ -220,11 +220,11 @@ class MontecarloRunner(HDFWriterMixin):
         seeds = rng.choice(MAX_SEED_VAL, no_of_packets, replace=True)
         if not self.enable_full_relativity:
             radii, nus, mus, energies = self.packet_source.create_packets(
-                T, no_of_packets, rng, radius
+                temperature, no_of_packets, rng, radius
             )
         else:
             radii, nus, mus, energies = self.packet_source.create_packets(
-                T, no_of_packets, rng, radius, time_explosion
+                temperature, no_of_packets, rng, radius, time_explosion
             )
 
         mc_config_module.packet_seeds = seeds

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -743,12 +743,12 @@ def trapezoid_integration(array, h):
 
 
 @njit(**njit_dict_no_parallel)
-def intensity_black_body(nu, T):
+def intensity_black_body(nu, temperature):
     """Get the black body intensity at frequency nu
-    and temperature T"""
+    and temperature """
     if nu == 0:
         return np.nan  # to avoid ZeroDivisionError
-    beta_rad = 1 / (KB_CGS * T)
+    beta_rad = 1 / (KB_CGS * temperature)
     coefficient = 2 * H_CGS * C_INV * C_INV
     return coefficient * nu * nu * nu / (np.exp(H_CGS * nu * beta_rad) - 1)
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -744,8 +744,20 @@ def trapezoid_integration(array, h):
 
 @njit(**njit_dict_no_parallel)
 def intensity_black_body(nu, temperature):
-    """Get the black body intensity at frequency nu
-    and temperature """
+    """
+    Read black body intensity.
+
+    Parameters
+    ----------
+    nu : float64
+        frequency
+    temperature : float64
+        Temperature
+
+    Returns
+    -------
+    float64
+    """
     if nu == 0:
         return np.nan  # to avoid ZeroDivisionError
     beta_rad = 1 / (KB_CGS * temperature)

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -745,7 +745,7 @@ def trapezoid_integration(array, h):
 @njit(**njit_dict_no_parallel)
 def intensity_black_body(nu, temperature):
     """
-    Read black body intensity.
+    Calculate the blackbody intensity.
 
     Parameters
     ----------

--- a/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
@@ -477,13 +477,14 @@ def trapezoid_integration_cuda(arr, dx):
 @cuda.jit(device=True)
 def intensity_black_body_cuda(nu, temperature):
     """
-    Get the black body intensity at frequency nu
-    and temperature
+    Read black body intensity.
 
     Parameters
     ----------
     nu : float64
+        frequency
     temperature : float64
+        Temperature
 
     Returns
     -------

--- a/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
@@ -475,15 +475,15 @@ def trapezoid_integration_cuda(arr, dx):
 
 
 @cuda.jit(device=True)
-def intensity_black_body_cuda(nu, T):
+def intensity_black_body_cuda(nu, temperature):
     """
     Get the black body intensity at frequency nu
-    and temperature T
+    and temperature
 
     Parameters
     ----------
     nu : float64
-    T : float64
+    temperature : float64
 
     Returns
     -------
@@ -491,7 +491,7 @@ def intensity_black_body_cuda(nu, T):
     """
     if nu == 0:
         return np.nan  # to avoid ZeroDivisionError
-    beta_rad = 1 / (KB_CGS * T)
+    beta_rad = 1 / (KB_CGS * temperature)
     coefficient = 2 * H_CGS * C_INV * C_INV
     return coefficient * nu * nu * nu / (math.exp(H_CGS * nu * beta_rad) - 1)
 

--- a/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral_cuda.py
@@ -477,7 +477,7 @@ def trapezoid_integration_cuda(arr, dx):
 @cuda.jit(device=True)
 def intensity_black_body_cuda(nu, temperature):
     """
-    Read black body intensity.
+    Calculate the blackbody intensity.
 
     Parameters
     ----------

--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -116,9 +116,9 @@ def sample_nu_free_free(numba_plasma, shell):
         Frequency of the free-free emission process
 
     """
-    T = numba_plasma.t_electrons[shell]
+    temperature = numba_plasma.t_electrons[shell]
     zrand = np.random.random()
-    return -K_B * T / H * np.log(zrand)
+    return -K_B * temperature / H * np.log(zrand)
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
@@ -32,14 +32,14 @@ GPUs_available = cuda.is_available()
     not GPUs_available, reason="No GPU is available to test CUDA function"
 )
 @pytest.mark.parametrize(
-    ["nu", "T"],
+    ["nu", "temperature"],
     [
         (1e14, 1e4),
         (0, 1),
         (1, 1),
     ],
 )
-def test_intensity_black_body_cuda(nu, T):
+def test_intensity_black_body_cuda(nu, temperature):
     """
     Initializes the test of the cuda version
     against the numba implementation of the
@@ -47,21 +47,21 @@ def test_intensity_black_body_cuda(nu, T):
     is done as both results have 15 digits of precision.
     """
     actual = np.zeros(3)
-    black_body_caller[1, 3](nu, T, actual)
+    black_body_caller[1, 3](nu, temperature, actual)
 
-    expected = formal_integral_numba.intensity_black_body(nu, T)
+    expected = formal_integral_numba.intensity_black_body(nu, temperature)
 
     ntest.assert_allclose(actual, expected, rtol=1e-14)
 
 
 @cuda.jit
-def black_body_caller(nu, T, actual):
+def black_body_caller(nu, temperature, actual):
     """
     This calls the CUDA function and fills out
     the array
     """
     x = cuda.grid(1)
-    actual[x] = formal_integral_cuda.intensity_black_body_cuda(nu, T)
+    actual[x] = formal_integral_cuda.intensity_black_body_cuda(nu, temperature)
 
 
 @pytest.mark.skipif(

--- a/tardis/montecarlo/montecarlo_numba/tests/test_numba_formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_numba_formal_integral.py
@@ -12,18 +12,18 @@ from tardis.model.geometry.radial1d import NumbaRadial1DGeometry
 
 
 @pytest.mark.parametrize(
-    ["nu", "T"],
+    ["nu", "temperature"],
     [
         (1e14, 1e4),
         (0, 1),
         (1, 1),
     ],
 )
-def test_intensity_black_body(nu, T):
+def test_intensity_black_body(nu, temperature):
     func = formal_integral.intensity_black_body
-    actual = func(nu, T)
+    actual = func(nu, temperature)
     print(actual, type(actual))
-    expected = intensity_black_body(nu, T)
+    expected = intensity_black_body(nu, temperature)
     ntest.assert_almost_equal(actual, expected)
 
 

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -57,40 +57,30 @@ class BasePacketSource(abc.ABC):
         temperature, no_of_packets, rng, l_samples=1000
     ):
         """
-                Create packet :math:`\\nu` distributed using the algorithm described in
-                Bjorkman & Wood 2001 (page 4) which references
-                Carter & Cashwell 1975:
-                First, generate a uniform random number, :math:`\\xi_0 \\in [0, 1]` and
-                determine the minimum value of
-                :math:`l, l_{\\rm min}`, that satisfies the condition
-
-                .. math::
-                    \\sum_{i=1}^{l} i^{-4} \\ge {{\\pi^4}\\over{90}} m_0 \\;.
-
-                Next obtain four additional uniform random numbers (in the range 0
-                to 1) :math:`\\xi_1, \\xi_2, \\xi_3, {\\rm and } \\xi_4`.
-                Finally, the packet frequency is given by
-
-                .. math::
-                    x = -\\ln{(\\xi_1\\xi_2\\xi_3\\xi_4)}/l_{\\rm min}\\;.
-
-                where :math:`x=h\\nu/kT`
-
-                Parameters
-                ----------
-                temperature : float
-        <<<<<<< HEAD
-                    Absolute Temperature.
-        =======
-                    Temperature.
-        >>>>>>> 0dd73af4228a30060c775173df83bcdf9544d858
-                no_of_packets : int
-                l_samples : int
-                    number of l_samples needed in the algorithm
-
-                Returns
-                -------
-                    array of frequencies: numpy.ndarray
+        Create packet :math:`\\nu` distributed using the algorithm described in
+        Bjorkman & Wood 2001 (page 4) which references
+        Carter & Cashwell 1975:
+        First, generate a uniform random number, :math:`\\xi_0 \\in [0, 1]` and
+        determine the minimum value of
+        :math:`l, l_{\\rm min}`, that satisfies the condition
+        .. math::
+            \\sum_{i=1}^{l} i^{-4} \\ge {{\\pi^4}\\over{90}} m_0 \\;.
+        Next obtain four additional uniform random numbers (in the range 0
+        to 1) :math:`\\xi_1, \\xi_2, \\xi_3, {\\rm and } \\xi_4`.
+        Finally, the packet frequency is given by
+        .. math::
+            x = -\\ln{(\\xi_1\\xi_2\\xi_3\\xi_4)}/l_{\\rm min}\\;.
+        where :math:`x=h\\nu/kT`
+        Parameters
+        ----------
+        temperature : float
+            Absolute Temperature.
+        no_of_packets : int
+        l_samples : int
+            number of l_samples needed in the algorithm
+        Returns
+        -------
+            array of frequencies: numpy.ndarray
         """
         l_samples = l_samples
         l_array = np.cumsum(np.arange(1, l_samples, dtype=np.float64) ** -4)

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -82,38 +82,6 @@ class BasePacketSource(abc.ABC):
         Returns
         -------
             array of frequencies: numpy.ndarray
-=======
-                Create packet :math:`\\nu` distributed using the algorithm described in
-                Bjorkman & Wood 2001 (page 4) which references
-                Carter & Cashwell 1975:
-                First, generate a uniform random number, :math:`\\xi_0 \\in [0, 1]` and
-                determine the minimum value of
-                :math:`l, l_{\\rm min}`, that satisfies the condition
-
-                .. math::
-                    \\sum_{i=1}^{l} i^{-4} \\ge {{\\pi^4}\\over{90}} m_0 \\;.
-
-                Next obtain four additional uniform random numbers (in the range 0
-                to 1) :math:`\\xi_1, \\xi_2, \\xi_3, {\\rm and } \\xi_4`.
-                Finally, the packet frequency is given by
-
-                .. math::
-                    x = -\\ln{(\\xi_1\\xi_2\\xi_3\\xi_4)}/l_{\\rm min}\\;.
-
-                where :math:`x=h\\nu/kT`
-
-                Parameters
-                ----------
-                temperature : float
-                    Absolute Temperature.
-                no_of_packets : int
-                l_samples : int
-                    number of l_samples needed in the algorithm
-
-                Returns
-                -------
-                    array of frequencies: numpy.ndarray
->>>>>>> 7084e1277d195935e5469bf3d0c2b4482d8f3424
         """
         l_samples = l_samples
         l_array = np.cumsum(np.arange(1, l_samples, dtype=np.float64) ** -4)

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -53,42 +53,44 @@ class BasePacketSource(abc.ABC):
         return np.ones(no_of_packets) / no_of_packets
 
     @staticmethod
-    def create_blackbody_packet_nus(temperature, no_of_packets, rng, l_samples=1000):
+    def create_blackbody_packet_nus(
+        temperature, no_of_packets, rng, l_samples=1000
+    ):
         """
-        Create packet :math:`\\nu` distributed using the algorithm described in
-        Bjorkman & Wood 2001 (page 4) which references
-        Carter & Cashwell 1975:
-        First, generate a uniform random number, :math:`\\xi_0 \\in [0, 1]` and
-        determine the minimum value of
-        :math:`l, l_{\\rm min}`, that satisfies the condition
+                Create packet :math:`\\nu` distributed using the algorithm described in
+                Bjorkman & Wood 2001 (page 4) which references
+                Carter & Cashwell 1975:
+                First, generate a uniform random number, :math:`\\xi_0 \\in [0, 1]` and
+                determine the minimum value of
+                :math:`l, l_{\\rm min}`, that satisfies the condition
 
-        .. math::
-            \\sum_{i=1}^{l} i^{-4} \\ge {{\\pi^4}\\over{90}} m_0 \\;.
+                .. math::
+                    \\sum_{i=1}^{l} i^{-4} \\ge {{\\pi^4}\\over{90}} m_0 \\;.
 
-        Next obtain four additional uniform random numbers (in the range 0
-        to 1) :math:`\\xi_1, \\xi_2, \\xi_3, {\\rm and } \\xi_4`.
-        Finally, the packet frequency is given by
+                Next obtain four additional uniform random numbers (in the range 0
+                to 1) :math:`\\xi_1, \\xi_2, \\xi_3, {\\rm and } \\xi_4`.
+                Finally, the packet frequency is given by
 
-        .. math::
-            x = -\\ln{(\\xi_1\\xi_2\\xi_3\\xi_4)}/l_{\\rm min}\\;.
+                .. math::
+                    x = -\\ln{(\\xi_1\\xi_2\\xi_3\\xi_4)}/l_{\\rm min}\\;.
 
-        where :math:`x=h\\nu/kT`
+                where :math:`x=h\\nu/kT`
 
-        Parameters
-        ----------
-        temperature : float
-<<<<<<< HEAD
-            Absolute Temperature.
-=======
-            Temperature.
->>>>>>> 0dd73af4228a30060c775173df83bcdf9544d858
-        no_of_packets : int
-        l_samples : int
-            number of l_samples needed in the algorithm
+                Parameters
+                ----------
+                temperature : float
+        <<<<<<< HEAD
+                    Absolute Temperature.
+        =======
+                    Temperature.
+        >>>>>>> 0dd73af4228a30060c775173df83bcdf9544d858
+                no_of_packets : int
+                l_samples : int
+                    number of l_samples needed in the algorithm
 
-        Returns
-        -------
-            array of frequencies: numpy.ndarray
+                Returns
+                -------
+                    array of frequencies: numpy.ndarray
         """
         l_samples = l_samples
         l_array = np.cumsum(np.arange(1, l_samples, dtype=np.float64) ** -4)
@@ -145,7 +147,9 @@ class BlackBodySimpleSource(BasePacketSource):
 
 
 class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
-    def create_packets(self, temperature, no_of_packets, rng, radius, time_explosion):
+    def create_packets(
+        self, temperature, no_of_packets, rng, radius, time_explosion
+    ):
         """Generate relativistic black-body packet properties as arrays
 
         Parameters

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -77,6 +77,7 @@ class BasePacketSource(abc.ABC):
         Parameters
         ----------
         temperature : float
+            Absolute Temperature.
         no_of_packets : int
         l_samples : int
             number of l_samples needed in the algorithm
@@ -146,6 +147,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
         Parameters
         ----------
         temperature : float64
+            Absolute Temperature
         no_of_packets : int
             Number of packets
         rng : numpy random number generator

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -57,7 +57,6 @@ class BasePacketSource(abc.ABC):
         temperature, no_of_packets, rng, l_samples=1000
     ):
         """
-<<<<<<< HEAD
         Create packet :math:`\\nu` distributed using the algorithm described in
         Bjorkman & Wood 2001 (page 4) which references
         Carter & Cashwell 1975:

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -53,7 +53,7 @@ class BasePacketSource(abc.ABC):
         return np.ones(no_of_packets) / no_of_packets
 
     @staticmethod
-    def create_blackbody_packet_nus(T, no_of_packets, rng, l_samples=1000):
+    def create_blackbody_packet_nus(temperature, no_of_packets, rng, l_samples=1000):
         """
         Create packet :math:`\\nu` distributed using the algorithm described in
         Bjorkman & Wood 2001 (page 4) which references
@@ -76,8 +76,7 @@ class BasePacketSource(abc.ABC):
 
         Parameters
         ----------
-        T : float
-            temperature
+        temperature : float
         no_of_packets : int
         l_samples : int
             number of l_samples needed in the algorithm
@@ -100,7 +99,7 @@ class BasePacketSource(abc.ABC):
         xis_prod = np.prod(xis[1:], 0)
         x = ne.evaluate("-log(xis_prod)/l")
 
-        return x * (const.k_B.cgs.value * T) / const.h.cgs.value
+        return x * (const.k_B.cgs.value * temperature) / const.h.cgs.value
 
 
 class BlackBodySimpleSource(BasePacketSource):
@@ -109,13 +108,12 @@ class BlackBodySimpleSource(BasePacketSource):
     part.
     """
 
-    def create_packets(self, T, no_of_packets, rng, radius):
+    def create_packets(self, temperature, no_of_packets, rng, radius):
         """Generate black-body packet properties as arrays
 
         Parameters
         ----------
-        T : float64
-            Temperature
+        temperature : float64
         no_of_packets : int
             Number of packets
         rng : numpy random number generator
@@ -134,7 +132,7 @@ class BlackBodySimpleSource(BasePacketSource):
             Packet energies
         """
         radii = np.ones(no_of_packets) * radius
-        nus = self.create_blackbody_packet_nus(T, no_of_packets, rng)
+        nus = self.create_blackbody_packet_nus(temperature, no_of_packets, rng)
         mus = self.create_zero_limb_darkening_packet_mus(no_of_packets, rng)
         energies = self.create_uniform_packet_energies(no_of_packets, rng)
 
@@ -142,13 +140,12 @@ class BlackBodySimpleSource(BasePacketSource):
 
 
 class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
-    def create_packets(self, T, no_of_packets, rng, radius, time_explosion):
+    def create_packets(self, temperature, no_of_packets, rng, radius, time_explosion):
         """Generate relativistic black-body packet properties as arrays
 
         Parameters
         ----------
-        T : float64
-            Temperature
+        temperature : float64
         no_of_packets : int
             Number of packets
         rng : numpy random number generator
@@ -169,7 +166,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
             Packet energies
         """
         self.beta = ((radius / time_explosion) / const.c).to("")
-        return super().create_packets(T, no_of_packets, rng, radius)
+        return super().create_packets(temperature, no_of_packets, rng, radius)
 
     def create_zero_limb_darkening_packet_mus(self, no_of_packets, rng):
         """

--- a/tardis/plasma/properties/continuum_processes.py
+++ b/tardis/plasma/properties/continuum_processes.py
@@ -990,9 +990,9 @@ class FreeFreeFrequencySampler(ProcessingPlasmaProperty):
         @njit(error_model="numpy", fastmath=True)
         def nu_ff(shell):
 
-            T = t_electrons[shell]
+            temperature = t_electrons[shell]
             zrand = np.random.random()
-            return -K_B * T / H * np.log(zrand)
+            return -K_B * temperature / H * np.log(zrand)
 
         return nu_ff
 

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -285,19 +285,19 @@ def create_synpp_yaml(radial1d_mdl, fname, shell_no=0, lines_db=None):
         yaml.dump(yaml_reference, stream=f, explicit_start=True)
 
 
-def intensity_black_body(nu, T):
+def intensity_black_body(nu, temperature):
     """
     Calculate the intensity of a black-body according to the following formula
 
     .. math::
-        I(\\nu, T) = \\frac{2h\\nu^3}{c^2}\\frac{1}
+        I(\\nu, temperature) = \\frac{2h\\nu^3}{c^2}\\frac{1}
         {e^{h\\nu \\beta_\\textrm{rad}} - 1}
 
     Parameters
     ----------
     nu : float
         Frequency of light
-    T : float
+    temperature : float
         Temperature in kelvin
 
     Returns
@@ -305,7 +305,7 @@ def intensity_black_body(nu, T):
     Intensity : float
         Returns the intensity of the black body
     """
-    beta_rad = 1 / (k_B_cgs * T)
+    beta_rad = 1 / (k_B_cgs * temperature)
     coefficient = 2 * h_cgs / c_cgs**2
     intensity = ne.evaluate(
         "coefficient * nu**3 / " "(exp(h_cgs * nu * beta_rad) -1 )"


### PR DESCRIPTION
### :pencil: Description
:memo: `documentation` 
T is not a descriptive variable name, especially for non-scientists, inside the Python code
Rename T variables to temperature in the code

fixes #1600 



### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
