### PR TITLE
Downloading nlte_atom_data in ref data

### DIFF
--- a/.ci-helpers/download_reference_data.sh
+++ b/.ci-helpers/download_reference_data.sh
@@ -12,10 +12,12 @@ FILES=('atom_data/kurucz_cd23_chianti_H_He.h5'
        'sdec_ref.h5'
        'unit_test_data.h5'
        'arepo_data/arepo_snapshot.hdf5'
-       'arepo_data/arepo_snapshot.json')
+       'arepo_data/arepo_snapshot.json'
+       'nlte_atom_data/TestNLTE_He_Ti.h5')
 
 mkdir -p $REF_PATH/atom_data
 mkdir -p $REF_PATH/arepo_data
+mkdir -p $REF_PATH/nlte_atom_data
 
 for FILE in "${FILES[@]}"
 do


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR makes sure that `nlte_atom_data` is downloaded from `tardis-ref-data` for usage in NLTE solver tests.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
