### PR TITLE
Add version tag to simulation objects

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -113,6 +113,7 @@ Kevin Cawley <cawleyke@msu.edu> KevinCawley <72036796+KevinCawley@users.noreply.
 Kevin Yap <me@kevinyap.ca>
 
 Kim Lingemann <kim@tg-lingemann.de> kimsina <kim@tg-lingemann.de>
+Kim Lingemann <kim@tg-lingemann.de> kim <kim@tg-lingemann.de>
 
 Laud Bentil <laudbentil@gmail.com>
 Laud Bentil <laudbentil@gmail.com> Laud Bentil <laud.bentil@meltwater.org>

--- a/.mailmap
+++ b/.mailmap
@@ -112,6 +112,8 @@ Kevin Cawley <cawleyke@msu.edu> KevinCawley <72036796+KevinCawley@users.noreply.
 
 Kevin Yap <me@kevinyap.ca>
 
+Kim Lingemann <kim@tg-lingemann.de> kimsina <kim@tg-lingemann.de>
+
 Laud Bentil <laudbentil@gmail.com>
 Laud Bentil <laudbentil@gmail.com> Laud Bentil <laud.bentil@meltwater.org>
 

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -2,6 +2,7 @@ import time
 import logging
 import numpy as np
 import pandas as pd
+import tardis
 from astropy import units as u
 from tardis import constants as const
 from collections import OrderedDict
@@ -106,6 +107,8 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
     convergence_plots_kwargs: dict
     nthreads : int
         The number of threads to run montecarlo with
+    version: str
+        The TARDIS version in use when instantiating the simulation object
 
         .. note:: TARDIS must be built with OpenMP support in order for ``nthreads`` to have effect.
 
@@ -157,6 +160,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self.luminosity_requested = luminosity_requested
         self.nthreads = nthreads
         self.show_progress_bars = show_progress_bars
+        self.version = tardis.__version__
 
         if convergence_strategy.type in ("damped"):
             self.convergence_strategy = convergence_strategy

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as pdt
 import astropy.units as u
+import tardis
 
 
 @pytest.fixture(scope="module")
@@ -156,3 +157,8 @@ def test_plasma_state_storer_reshape(
 
 #     assert_quantity_allclose(
 #             t_rad, simulation_compare_data['test1/t_rad'] * u.Unit('K'), atol=0.0 * u.Unit('K'))
+
+
+def test_version_tag(simulation_without_loop):
+    simulation = simulation_without_loop
+    assert simulation.version == tardis.__version__


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

I added a version tag to TARDIS simulation objects to resolve issue #1986.
I also add a test to check if the version tag is added.


### :pushpin: Resources

The version of a tardis simulation object called `simulation` can now be checked using
`simulation.version`.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
