### PR TITLE
Fix config reader tests

### DIFF
--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -148,7 +148,8 @@ def test_supernova_section_config(tardis_config_verysimple):
         )
 
 
-def test_plasma_section_config(tardis_config_verysimple):
+@pytest.mark.parametrize("key", ['initial_t_inner', 'initial_t_rad'])
+def test_plasma_section_config(key, tardis_config_verysimple):
     """
     Configuration Validation Test for Plasma Section of the Tardis Config YAML File
 
@@ -164,14 +165,7 @@ def test_plasma_section_config(tardis_config_verysimple):
     ------
         Assertion based on validation for specified values
     """
-    tardis_config_verysimple["plasma"]["initial_t_inner"] = Quantity("-100 K")
-    with pytest.raises(ValueError):
-        conf = Configuration.from_config_dict(
-            tardis_config_verysimple, validate=True, config_dirname="test"
-        )
-
-    tardis_config_verysimple["plasma"]["initial_t_inner"] = Quantity("100 K")
-    tardis_config_verysimple["plasma"]["initial_t_rad"] = Quantity("-100 K")
+    tardis_config_verysimple["plasma"][key] = Quantity("-100 K")
     with pytest.raises(ValueError):
         conf = Configuration.from_config_dict(
             tardis_config_verysimple, validate=True, config_dirname="test"

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -148,7 +148,7 @@ def test_supernova_section_config(tardis_config_verysimple):
         )
 
 
-@pytest.mark.parametrize("key", ['initial_t_inner', 'initial_t_rad'])
+@pytest.mark.parametrize("key", ["initial_t_inner", "initial_t_rad"])
 def test_plasma_section_config(key, tardis_config_verysimple):
     """
     Configuration Validation Test for Plasma Section of the Tardis Config YAML File

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_almost_equal
 from jsonschema.exceptions import ValidationError
 
 from tardis.io import config_reader
+from astropy.units import Quantity
 from tardis.io.config_reader import Configuration
 from tardis.plasma.exceptions import PlasmaConfigError
 from tardis.plasma.standard_plasmas import assemble_plasma
@@ -99,17 +100,15 @@ def test_model_section_config(tardis_config_verysimple):
 
     tardis_config_verysimple["model"]["structure"]["velocity"][
         "start"
-    ] = "2.0e4 km/s"
+    ] = Quantity("2.0e4 km/s")
     tardis_config_verysimple["model"]["structure"]["velocity"][
         "stop"
-    ] = "1.1e4 km/s"
-    with pytest.raises(ValueError) as ve:
-        if (
-            conf.model.structure.velocity.start
-            < conf.model.structure.velocity.stop
-        ):
-            raise ValueError("Stop Value must be greater than Start Value")
-    assert ve.type is ValueError
+    ] = Quantity("1.1e4 km/s")
+
+    with pytest.raises(ValueError):
+        conf = Configuration.from_config_dict(
+            tardis_config_verysimple, validate=True, config_dirname="test"
+        )
 
 
 def test_supernova_section_config(tardis_config_verysimple):
@@ -128,30 +127,25 @@ def test_supernova_section_config(tardis_config_verysimple):
     ------
         Assertion based on validation for specified values
     """
-    conf = Configuration.from_config_dict(
-        tardis_config_verysimple, validate=True, config_dirname="test"
+    tardis_config_verysimple["supernova"]["time_explosion"] = Quantity(
+        "-10 day"
     )
-    tardis_config_verysimple["supernova"]["time_explosion"] = "-10 day"
+    with pytest.raises(ValueError):
+        conf = Configuration.from_config_dict(
+            tardis_config_verysimple, validate=True, config_dirname="test"
+        )
+
+    tardis_config_verysimple["supernova"]["time_explosion"] = Quantity("10 day")
     tardis_config_verysimple["supernova"][
         "luminosity_wavelength_start"
-    ] = "15 angstrom"
+    ] = Quantity("15 angstrom")
     tardis_config_verysimple["supernova"][
         "luminosity_wavelength_end"
-    ] = "0 angstrom"
-    with pytest.raises(ValueError) as ve:
-        if conf.supernova.time_explosion.value > 0:
-            raise ValueError("Time of Explosion cannot be negative")
-    assert ve.type is ValueError
-
-    with pytest.raises(ValueError) as ve:
-        if (
-            conf.supernova.luminosity_wavelength_start.value
-            < conf.supernova.luminosity_wavelength_end.value
-        ):
-            raise ValueError(
-                "End Limit must be greater than Start Limit for Luminosity"
-            )
-    assert ve.type is ValueError
+    ] = Quantity("0 angstrom")
+    with pytest.raises(ValueError):
+        conf = Configuration.from_config_dict(
+            tardis_config_verysimple, validate=True, config_dirname="test"
+        )
 
 
 def test_plasma_section_config(tardis_config_verysimple):
@@ -170,17 +164,18 @@ def test_plasma_section_config(tardis_config_verysimple):
     ------
         Assertion based on validation for specified values
     """
-    conf = Configuration.from_config_dict(
-        tardis_config_verysimple, validate=True, config_dirname="test"
-    )
-    tardis_config_verysimple["plasma"]["initial_t_inner"] = "-100 K"
-    tardis_config_verysimple["plasma"]["initial_t_rad"] = "-100 K"
-    with pytest.raises(ValueError) as ve:
-        if (conf.plasma.initial_t_inner.value >= -1) and (
-            conf.plasma.initial_t_rad.value >= -1
-        ):
-            raise ValueError("Initial Temperatures are Invalid")
-    assert ve.type is ValueError
+    tardis_config_verysimple["plasma"]["initial_t_inner"] = Quantity("-100 K")
+    with pytest.raises(ValueError):
+        conf = Configuration.from_config_dict(
+            tardis_config_verysimple, validate=True, config_dirname="test"
+        )
+
+    tardis_config_verysimple["plasma"]["initial_t_inner"] = Quantity("100 K")
+    tardis_config_verysimple["plasma"]["initial_t_rad"] = Quantity("-100 K")
+    with pytest.raises(ValueError):
+        conf = Configuration.from_config_dict(
+            tardis_config_verysimple, validate=True, config_dirname="test"
+        )
 
 
 def test_plasma_nlte_section_config(
@@ -260,12 +255,9 @@ def test_spectrum_section_config(tardis_config_verysimple):
     ------
         Assertion based on validation for specified values
     """
-    conf = Configuration.from_config_dict(
-        tardis_config_verysimple, validate=True, config_dirname="test"
-    )
-    tardis_config_verysimple["spectrum"]["start"] = "2500 angstrom"
-    tardis_config_verysimple["spectrum"]["stop"] = "500 angstrom"
-    with pytest.raises(ValueError) as ve:
-        if not conf.spectrum.stop.value < conf.spectrum.start.value:
-            raise ValueError("Start Value must be less than Stop Value")
-    assert ve.type is ValueError
+    tardis_config_verysimple["spectrum"]["start"] = Quantity("2500 angstrom")
+    tardis_config_verysimple["spectrum"]["stop"] = Quantity("500 angstrom")
+    with pytest.raises(ValueError):
+        conf = Configuration.from_config_dict(
+            tardis_config_verysimple, validate=True, config_dirname="test"
+        )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`  | :vertical_traffic_light: `testing`

A large fraction of the config reader tests do not test what they are supposed to test. This PR tries to fix this.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (ran tests locally)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
