### PR TITLE
Correct the description of 'no_of_packets' in Monte Carlo Configuration

### DIFF
--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -17,7 +17,7 @@ properties:
   no_of_packets:
     type: number
     multipleOf: 1.0
-    description: Seed for the random number generator
+    description: The number of packets used in each iteration depends on the specific simulation software and the input parameters provided by the user.
   iterations:
     type: number
     multipleOf: 1.0

--- a/tardis/io/schemas/montecarlo.yml
+++ b/tardis/io/schemas/montecarlo.yml
@@ -17,7 +17,7 @@ properties:
   no_of_packets:
     type: number
     multipleOf: 1.0
-    description: The number of packets used in each iteration depends on the specific simulation software and the input parameters provided by the user.
+    description: The number of packets used in each iteration.
   iterations:
     type: number
     multipleOf: 1.0


### PR DESCRIPTION
### :pencil: Description

**Type:** :| :memo: `documentation` 
Correct the description of 'no_of_packets' in Monte Carlo Configuration



closes #2066 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
