### PR TITLE
Correct the description of SDECPlotter._calculate_emission_luminosities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -227,3 +227,7 @@ Youssef Eweis <joey070@gmail.com> Youssef Eweis <Youssef15015@users.noreply.gith
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com>
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> rohithvarma3000 <rohith.varma.buddaraju@gmail.com>
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> Rohith <rohith.varma.buddaraju@gmail.com>
+
+Ansh Kumar <1928013@kiit.ac.in>
+Ansh Kumar <1928013@kiit.ac.in> xansh <1928013@kiit.ac.in>
+Ansh Kumar <1928013@kiit.ac.in> Ansh Kumar <1928013@kiit.ac.in>

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -817,7 +817,7 @@ class SDECPlotter:
         luminosities_df : pd.DataFrame
             Dataframe containing luminosities contributed by no interaction,
             only e-scattering and emission with each element present
-        elements_present: np.array
+        emission_species_present: np.array
             Atomic numbers of the elements with which packets of specified
             wavelength range interacted
         """


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Renamed the return variable "elements_present" to "emission_species_present" in the description of the method SDECPlotter._calculate_emission_luminosities

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
