### PR TITLE
[GSoC] Simulation Object Restructure: First Objective

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -232,3 +232,9 @@ Le Truong <katrintruong@gmail.com>
 
 Kim Lingemann <kim@tg-lingemann.de> kimsina <kim@tg-lingemann.de>
 Kim Lingemann <kim@tg-lingemann.de> kim <kim@tg-lingemann.de>
+
+Ayushi Daksh <aayusheedaksh@gmail.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> AyushiDaksh <aayusheedaksh@gmail.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> AyushiDaksh <ayushida@buffalo.edu>
+Ayushi Daksh <aayusheedaksh@gmail.com> AyushiDaksh <37770155+AyushiDaksh@users.noreply.github.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> Ayushi <aayusheedaksh@gmail.com>

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -344,9 +344,8 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             if hasattr(self, "convergence_plots"):
                 self.convergence_plots.update()
             self._call_back()
-            if self.convergence_strategy.converged:
-                if self.convergence_strategy.stop_if_converged:
-                    break
+            if self.convergence_strategy.should_stop:
+                break
         # Last iteration
         self.store_plasma_state(
             self.iterations_executed,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -6,11 +6,11 @@ import tardis
 from astropy import units as u
 from tardis import constants as const
 from collections import OrderedDict
-from tardis import model
 
 from tardis.montecarlo import MontecarloRunner
 from tardis.model import Radial1DModel
 from tardis.plasma.standard_plasmas import assemble_plasma
+from tardis.simulation.convergence_strategy import ConvergenceStrategy
 from tardis.io.util import HDFWriterMixin
 from tardis.io.config_reader import ConfigurationError
 from tardis.util.base import is_notebook
@@ -23,150 +23,6 @@ from tardis.montecarlo.montecarlo_numba.r_packet import (
 
 # Adding logging support
 logger = logging.getLogger(__name__)
-
-
-class ConvergenceStrategy(object):
-    def __init__(self, config, model):
-        """
-        Create a new ConvergenceStrategy instance from a Configuration object and Model object.
-
-        Parameters
-        ----------
-        config : tardis.io.config_reader.Configuration
-        model: tardis.model.Radial1DModel
-        """
-        self.config = config.montecarlo.convergence_strategy
-        self.model = model
-        self._converged = (
-            False  # Whether the convergence has truly converged or not
-        )
-        self._consecutive_converges_count = (
-            0  # Counts the number of consecutive converges
-        )
-
-    @property
-    def converged(self):
-        return self._converged
-
-    def convergence_step(
-        self,
-        estimated_t_rad,
-        estimated_w,
-        estimated_t_inner,
-        iterations_executed,
-    ):
-        """
-        Performs a single convergence step
-
-        Parameters
-        ----------
-        estimated_t_rad : astropy.units.Quantity
-            The estimated value of t_rad
-        estimated_w : np.ndarray
-            The estimated value of w
-        estimated_t_inner : astropy.units.Quantity
-            The estimated value of t_inner
-        iterations_executed : int
-            Number of iterations elapsed in the simulation (to decide if t_inner should be updated)
-        """
-        # Compute convergence status
-        self._converged = self._get_convergence_status(
-            estimated_t_rad, estimated_w, estimated_t_inner
-        )
-
-        # Get new values
-        if self.config.type in ("damped"):
-            next_t_rad = self.damped_converge(
-                self.model.t_rad,
-                estimated_t_rad,
-                self.config.t_rad.damping_constant,
-            )
-            next_w = self.damped_converge(
-                self.model.w, estimated_w, self.config.w.damping_constant
-            )
-            if (iterations_executed + 1) % self.config.lock_t_inner_cycles == 0:
-                next_t_inner = self.damped_converge(
-                    self.model.t_inner,
-                    estimated_t_inner,
-                    self.config.t_inner.damping_constant,
-                )
-            else:
-                next_t_inner = self.model.t_inner
-        elif self.config.type in ("custom"):
-            raise NotImplementedError(
-                "Convergence strategy type is custom; "
-                "you need to implement your specific treatment!"
-            )
-        else:
-            raise ValueError(
-                f"Convergence strategy type is "
-                f"not damped or custom "
-                f"- input is {self.config.type}"
-            )
-
-        return next_t_rad, next_w, next_t_inner
-
-    @staticmethod
-    def damped_converge(value, estimated_value, damping_factor):
-        return value + damping_factor * (estimated_value - value)
-
-    def _get_convergence_status(
-        self, estimated_t_rad, estimated_w, estimated_t_inner
-    ):
-        """
-        Returns whether the convergence has truly converged or not
-
-        Parameters
-        ----------
-        estimated_t_rad : astropy.units.Quantity
-            The estimated value of t_rad
-        estimated_w : np.ndarray
-            The estimated value of w
-        estimated_t_inner : astropy.units.Quantity
-            The estimated value of t_inner
-        """
-        no_of_shells = self.model.no_of_shells
-
-        t_rad, w, t_inner = self.model.t_rad, self.model.w, self.model.t_inner
-
-        convergence_t_rad = (
-            abs(t_rad - estimated_t_rad) / estimated_t_rad
-        ).value
-        convergence_w = abs(w - estimated_w) / estimated_w
-        convergence_t_inner = (
-            abs(t_inner - estimated_t_inner) / estimated_t_inner
-        ).value
-
-        fraction_t_rad_converged = (
-            np.count_nonzero(convergence_t_rad < self.config.t_rad.threshold)
-            / no_of_shells
-        )
-
-        t_rad_converged = fraction_t_rad_converged > self.config.fraction
-
-        fraction_w_converged = (
-            np.count_nonzero(convergence_w < self.config.w.threshold)
-            / no_of_shells
-        )
-
-        w_converged = fraction_w_converged > self.config.fraction
-
-        t_inner_converged = convergence_t_inner < self.config.t_inner.threshold
-
-        if np.all([t_rad_converged, w_converged, t_inner_converged]):
-            hold_iterations = self.config.hold_iterations
-            self._consecutive_converges_count += 1
-            logger.info(
-                f"Iteration converged {self._consecutive_converges_count:d}/{(hold_iterations + 1):d} consecutive "
-                f"times."
-            )
-            # If an iteration has converged, require hold_iterations more
-            # iterations to converge before we conclude that the Simulation
-            # is converged.
-            return self._consecutive_converges_count == hold_iterations + 1
-        else:
-            self._consecutive_converges_count = 0
-            return False
 
 
 class PlasmaStateStorerMixin(object):

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -204,6 +204,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         """
         Advances the state of the model and the plasma for the next
         iteration of the simulation.
+        Also updates the convergence status (bool) in self.convergence_strategy.converged
         """
         (
             estimated_t_rad,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -212,7 +212,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         estimated_t_inner = self.estimate_t_inner(
             self.model.t_inner,
             self.luminosity_requested,
-            t_inner_update_exponent=self.convergence_strategy.config.t_inner_update_exponent,
+            t_inner_update_exponent=self.convergence_strategy.t_inner_update_exponent,
         )
 
         # Perform convergence step
@@ -344,7 +344,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 self.convergence_plots.update()
             self._call_back()
             if self.convergence_strategy.converged:
-                if self.convergence_strategy.config.stop_if_converged:
+                if self.convergence_strategy.stop_if_converged:
                     break
         # Last iteration
         self.store_plasma_state(

--- a/tardis/simulation/convergence_strategy.py
+++ b/tardis/simulation/convergence_strategy.py
@@ -31,6 +31,10 @@ class ConvergenceStrategy(object):
     def converged(self):
         return self._converged
 
+    @property
+    def should_stop(self):
+        return self.stop_if_converged and self._converged
+
     def convergence_step(
         self,
         estimated_t_rad,

--- a/tardis/simulation/convergence_strategy.py
+++ b/tardis/simulation/convergence_strategy.py
@@ -1,0 +1,150 @@
+import logging
+import numpy as np
+from IPython.display import display
+
+# Adding logging support
+logger = logging.getLogger(__name__)
+
+
+class ConvergenceStrategy(object):
+    def __init__(self, config, model):
+        """
+        Create a new ConvergenceStrategy instance from a Configuration object and Model object.
+
+        Parameters
+        ----------
+        config : tardis.io.config_reader.Configuration
+        model: tardis.model.Radial1DModel
+        """
+        self.config = config.montecarlo.convergence_strategy
+        self.model = model
+        self._converged = (
+            False  # Whether the convergence has truly converged or not
+        )
+        self._consecutive_converges_count = (
+            0  # Counts the number of consecutive converges
+        )
+
+    @property
+    def converged(self):
+        return self._converged
+
+    def convergence_step(
+        self,
+        estimated_t_rad,
+        estimated_w,
+        estimated_t_inner,
+        iterations_executed,
+    ):
+        """
+        Performs a single convergence step
+
+        Parameters
+        ----------
+        estimated_t_rad : astropy.units.Quantity
+            The estimated value of t_rad
+        estimated_w : np.ndarray
+            The estimated value of w
+        estimated_t_inner : astropy.units.Quantity
+            The estimated value of t_inner
+        iterations_executed : int
+            Number of iterations elapsed in the simulation (to decide if t_inner should be updated)
+        """
+        # Compute convergence status
+        self._converged = self._get_convergence_status(
+            estimated_t_rad, estimated_w, estimated_t_inner
+        )
+
+        # Get new values
+        if self.config.type in ("damped"):
+            next_t_rad = self.damped_converge(
+                self.model.t_rad,
+                estimated_t_rad,
+                self.config.t_rad.damping_constant,
+            )
+            next_w = self.damped_converge(
+                self.model.w, estimated_w, self.config.w.damping_constant
+            )
+            if (iterations_executed + 1) % self.config.lock_t_inner_cycles == 0:
+                next_t_inner = self.damped_converge(
+                    self.model.t_inner,
+                    estimated_t_inner,
+                    self.config.t_inner.damping_constant,
+                )
+            else:
+                next_t_inner = self.model.t_inner
+        elif self.config.type in ("custom"):
+            raise NotImplementedError(
+                "Convergence strategy type is custom; "
+                "you need to implement your specific treatment!"
+            )
+        else:
+            raise ValueError(
+                f"Convergence strategy type is "
+                f"not damped or custom "
+                f"- input is {self.config.type}"
+            )
+
+        return next_t_rad, next_w, next_t_inner
+
+    @staticmethod
+    def damped_converge(value, estimated_value, damping_factor):
+        return value + damping_factor * (estimated_value - value)
+
+    def _get_convergence_status(
+        self, estimated_t_rad, estimated_w, estimated_t_inner
+    ):
+        """
+        Returns whether the convergence has truly converged or not
+
+        Parameters
+        ----------
+        estimated_t_rad : astropy.units.Quantity
+            The estimated value of t_rad
+        estimated_w : np.ndarray
+            The estimated value of w
+        estimated_t_inner : astropy.units.Quantity
+            The estimated value of t_inner
+        """
+        no_of_shells = self.model.no_of_shells
+
+        t_rad, w, t_inner = self.model.t_rad, self.model.w, self.model.t_inner
+
+        convergence_t_rad = (
+            abs(t_rad - estimated_t_rad) / estimated_t_rad
+        ).value
+        convergence_w = abs(w - estimated_w) / estimated_w
+        convergence_t_inner = (
+            abs(t_inner - estimated_t_inner) / estimated_t_inner
+        ).value
+
+        fraction_t_rad_converged = (
+            np.count_nonzero(convergence_t_rad < self.config.t_rad.threshold)
+            / no_of_shells
+        )
+
+        t_rad_converged = fraction_t_rad_converged > self.config.fraction
+
+        fraction_w_converged = (
+            np.count_nonzero(convergence_w < self.config.w.threshold)
+            / no_of_shells
+        )
+
+        w_converged = fraction_w_converged > self.config.fraction
+
+        t_inner_converged = convergence_t_inner < self.config.t_inner.threshold
+
+        if np.all([t_rad_converged, w_converged, t_inner_converged]):
+            hold_iterations = self.config.hold_iterations
+            self._consecutive_converges_count += 1
+            logger.info(
+                f"Iteration converged {self._consecutive_converges_count:d}/{(hold_iterations + 1):d} consecutive "
+                f"times."
+            )
+            # If an iteration has converged, require hold_iterations more
+            # iterations to converge before we conclude that the Simulation
+            # is converged.
+            return self._consecutive_converges_count == hold_iterations + 1
+        else:
+            self._consecutive_converges_count = 0
+            return False


### PR DESCRIPTION
### :pencil: Description

**Type:** 🌞 `GSoC`

This is my solution to the first objective of the GSoC'23 project: Simulation Object Restructure.

Here, I have created a separate class called ConvergenceStrategy which is called internally by the Simulation class.

### :pushpin: Resources
[GSoC'23 Page](https://summerofcode.withgoogle.com/)
[GSoC'23 Ideas Page](https://tardis-sn.github.io/gsoc_2023/ideas/)

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
