### PR TITLE
Docs Fix: Download Atom Data in rpacket_tracking.ipynb

### DIFF
--- a/docs/io/output/rpacket_tracking.ipynb
+++ b/docs/io/output/rpacket_tracking.ipynb
@@ -150,7 +150,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tardis import run_tardis"
+    "from tardis import run_tardis\n",
+    "from tardis.io.atom_data.util import download_atom_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d8471c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "download_atom_data('kurucz_cd23_chianti_H_He')"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

The [rpacket_tracking.ipynb](https://github.com/tardis-sn/tardis/blob/master/docs/io/output/rpacket_tracking.ipynb) notebook doesn't run the `download_atom_data` function to download atom data which is why docs are failing now. 
However, it's still unclear to me why docs passed in previous commits- since no recent commits have edited the notebook.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
