### PR TITLE
MonteCarlo packet progress bar completes to 100%

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -29,7 +29,7 @@ from tardis.montecarlo.montecarlo_numba.single_packet_loop import (
 )
 from tardis.montecarlo.montecarlo_numba import njit_dict
 from numba.typed import List
-from tardis.util.base import update_iterations_pbar, update_packet_pbar
+from tardis.util.base import update_iterations_pbar, update_packet_pbar, refresh_packet_pbar
 
 
 def montecarlo_radial1d(
@@ -128,6 +128,7 @@ def montecarlo_radial1d(
             virt_packet_last_line_interaction_out_id
         ).ravel()
     update_iterations_pbar(1)
+    refresh_packet_pbar()
     # Condition for Checking if RPacket Tracking is enabled
     if montecarlo_configuration.RPACKET_TRACKING:
         runner.rpacket_tracker = rpacket_trackers

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -699,6 +699,14 @@ def update_packet_pbar(i, current_iteration, no_of_packets, total_iterations):
     packet_pbar.update(i)
 
 
+def refresh_packet_pbar():
+    """
+    Refresh packet progress bar after each iteration.
+
+    """
+    packet_pbar.refresh()
+
+
 def update_iterations_pbar(i):
     """
     Update progress bar for each iteration.


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

The Monte-Carlo packet progress bar used to update during every iteration but did not complete to 100% once it was over. An update call needed to be included at the end of each iteration.

`resolves` #2216 

### :pushpin: Resources

[tqdm Docs
](https://tqdm.github.io/docs/tqdm/)

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Before:
![Before](https://user-images.githubusercontent.com/125031481/224123009-9c8b7392-d6c4-40fb-bbb1-e7afd803c723.png)

After:
![After](https://user-images.githubusercontent.com/125031481/224123126-fc46dd0f-8d24-4e52-82a5-2037d5c50e18.png)



### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
