### PR TITLE
Fix relative atom data path to eliminate use of configuration directory

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -169,6 +169,9 @@ Sampark Sharma <samparksharma2000@gmail.com>
 Shilpi Prasad <shilpiprd@gmail.com>
 Shilpi Prasad <shilpiprd@gmail.com> Shilpi <72646134+shilpiprd@users.noreply.github.com>
 
+Shreyas Singh <shreyashsingh31@gmail.com>
+Shreyas Singh <shreyashsingh31@gmail.com> shreyas3156 <shreyashsingh31@gmail.com>
+
 Satwik Kambham <satwik.kambham@gmail.com>
 Satwik Kambham <satwik.kambham@gmail.com> code-explorer <satwik.kambham@gmail.com>
 

--- a/tardis/io/atom_data/util.py
+++ b/tardis/io/atom_data/util.py
@@ -25,14 +25,15 @@ def resolve_atom_data_fname(fname):
         resolved fpath
     """
 
-    if os.path.exists(fname):
-        return fname
+    if os.path.isabs(fname):
+        if os.path.exists(fname):
+            return fname
+        else:
+            logger.info(f"\n\tAtom data not found in {fname}")
 
     fpath = os.path.join(os.path.join(get_data_dir(), fname))
     if os.path.exists(fpath):
-        logger.info(
-            f"\n\tAtom Data {fname} not found in local path.\n\tExists in TARDIS Data repo {fpath}"
-        )
+        logger.info(f"\n\tExists in TARDIS Data repo {fpath}")
         return fpath
 
     atom_data_name = fname.replace(".h5", "")

--- a/tardis/io/atom_data/util.py
+++ b/tardis/io/atom_data/util.py
@@ -33,7 +33,7 @@ def resolve_atom_data_fname(fname):
 
     fpath = os.path.join(os.path.join(get_data_dir(), fname))
     if os.path.exists(fpath):
-        logger.info(f"\n\tExists in TARDIS Data repo {fpath}")
+        logger.info(f"\n\tAtomic Data exists in TARDIS Data repo {fpath}")
         return fpath
 
     atom_data_name = fname.replace(".h5", "")

--- a/tardis/io/tests/test_resolve_atom_data_fname.py
+++ b/tardis/io/tests/test_resolve_atom_data_fname.py
@@ -6,13 +6,23 @@ from tardis.io.atom_data.util import resolve_atom_data_fname
 
 @pytest.fixture
 def atom_data_fname_absolute(tmp_path):
-    # create a temp file to mock fname
+    """
+    Creates a temp absolute path to mock fname.
+    """
     fname = tmp_path / "mock_atom_data.h5"
     fname.touch()
     return fname
 
 
 def test_absolute_path_atom_data(atom_data_fname_absolute):
+    """
+    Checks whether the absolute path provided in the config exists or not.
+
+    Parameters
+    ----------
+    atom_data_fname_absolute : tmp_path
+        Absolute path to the atomic data
+    """
     fpath = str(atom_data_fname_absolute)
     assert resolve_atom_data_fname(fpath) == fpath
 
@@ -23,9 +33,38 @@ def test_absolute_path_atom_data(atom_data_fname_absolute):
         resolve_atom_data_fname(non_existent_fpath)
 
 
-def test_relative_atom_data_fname(tardis_ref_data):
-    fname = "kurucz_cd23_chianti_H_He.h5"
-    assert resolve_atom_data_fname(fname) == tardis_ref_data
+@pytest.fixture
+def data_path(tmp_path):
+    """
+    Creates a temporary directory that contains the atomic data.
+    """
+    # Create a temporary directory
+    data_dir = tmp_path / "data_dir"
+    data_dir.mkdir()
+    fname = data_dir / "mock_atom_data.h5"
+    fname.touch()
+    return data_dir
+
+
+def test_relative_atom_data_fname(data_path, monkeypatch):
+    """
+    Checks whether the file name in config is searched in the atomic-data directory.
+
+    Parameters
+    ----------
+    data_path : tmp_path
+        Atomic Data directory that is used to stub the return value of 'get_data_dir()'
+    monkeypatch : Monkeypatch pytest fixture
+        Replaces get_data_dir() with a mock function
+    """
+
+    monkeypatch.setattr(
+        "tardis.io.atom_data.util.get_data_dir", lambda: str(data_path)
+    )
+    resolved_fname = resolve_atom_data_fname("mock_atom_data.h5")
+
+    expected_fname = os.path.join(str(data_path), "mock_atom_data.h5")
+    assert resolved_fname == expected_fname
 
     with pytest.raises(IOError):
-        resolve_atom_data_fname("test_file.h5")
+        resolve_atom_data_fname("non_existent_data.h5")

--- a/tardis/io/tests/test_resolve_atom_data_fname.py
+++ b/tardis/io/tests/test_resolve_atom_data_fname.py
@@ -1,0 +1,23 @@
+import pytest
+import os
+
+from tardis.io.atom_data.util import resolve_atom_data_fname
+
+
+@pytest.fixture
+def atom_data_fname_absolute(tmp_path):
+    # create a temp file to mock fname
+    fname = tmp_path / "mock_atom_data.h5"
+    fname.touch()
+    return fname
+
+
+def test_absolute_path_atom_data(atom_data_fname_absolute):
+    fpath = str(atom_data_fname_absolute)
+    assert resolve_atom_data_fname(fpath) == fpath
+
+    non_existent_fpath = str(
+        atom_data_fname_absolute.with_name("non_existent_file.txt")
+    )
+    with pytest.raises(IOError):
+        resolve_atom_data_fname(non_existent_fpath)

--- a/tardis/io/tests/test_resolve_atom_data_fname.py
+++ b/tardis/io/tests/test_resolve_atom_data_fname.py
@@ -21,3 +21,11 @@ def test_absolute_path_atom_data(atom_data_fname_absolute):
     )
     with pytest.raises(IOError):
         resolve_atom_data_fname(non_existent_fpath)
+
+
+def test_relative_atom_data_fname(tardis_ref_data):
+    fname = "kurucz_cd23_chianti_H_He.h5"
+    assert resolve_atom_data_fname(fname) == tardis_ref_data
+
+    with pytest.raises(IOError):
+        resolve_atom_data_fname("test_file.h5")

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -83,12 +83,7 @@ def assemble_plasma(config, model, atom_data=None):
 
     if atom_data is None:
         if "atom_data" in config:
-            if os.path.isabs(config.atom_data):
-                atom_data_fname = config.atom_data
-            else:
-                atom_data_fname = os.path.join(
-                    config.config_dirname, config.atom_data
-                )
+            atom_data_fname = config.atom_data
         else:
             raise ValueError("No atom_data option found in the configuration.")
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

`resolves` #2102 

This PR aims to solve the Atom Data relative path issue that arises when the configuration file is not in the same directory as the notebook/file calling `run_tardis()`. The issue arises because we currently use `config.config_dirname` in `standard_plasmas.py` to find the path to the atom data file which seems counter-intuitive because config and atom data are quite unrelated.

The solution proposed in this PR:

1. Moves all logic that handles `atom_data_fname` from `standard_plasmas.py` to `tardis/io/atom_data/util.py`, with the rationale that resolution of the file path is more appropriate for the `resolve_atom_data_fname()` method in the latter.

2. Eliminates the usage of `config.config_dirname` altogether and instead relies on `data_dir` to find the atom data file.




### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
