### PR TITLE
Fix for release dates

### DIFF
--- a/.ci-helpers/get_next_version.py
+++ b/.ci-helpers/get_next_version.py
@@ -14,8 +14,11 @@ release = scm_version[0:3]
 iso_date = date(*release).isoformat()
 iso_date = iso_date.replace("-",".")
 
-version = f"{iso_date}.{str(build)}"
-version = version.rstrip(".0") if version.endswith(".0") else version
+if build > 0:
+    version = f"{iso_date}.{str(build)}"
+
+else:
+    version = iso_date
 
 print(version)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

I noticed the release date is incorrect when the day number ends with 0, for example `release-2023.02.2` corresponds to February 20th, 2023.

This was my mistake while trying to remove the `.0` of every new release, as Jaladh suggested. 

This was requested because to have a `.1` in the release name we should make two releases on the same day, and that does not happen frequently. Then, to simplify the names of most of our releases we stripped the trailing zero.

I don't know why `.rstrip()` works in that way. I used a simpler approach now that seems to work fine.

### :pushpin: Resources


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Tested locally. 

If you want to test it by yourself, use a custom `scm_version` variable:

```python3
#scm_version = version_from_scm(".").tag.public
#scm_version = guess_next_date_ver(scm_version)
#scm_version = [ int(i) for i in scm_version.split(".") ]
scm_version = [2023, 2, 20, 0] 
```

and run `python .ci-helpers/get_next_version.py`. 

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
