### PR TITLE
Fix team reviewers on workflows

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -125,7 +125,7 @@ jobs:
             >
             > This pull request should be auto-merged.
           labels: automated, build-docs
-          team-reviewers: tardis-sn/tardis-infrastructure
+          team-reviewers: tardis-infrastructure
         id: create-pr
 
       - name: Wait for pull request

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -135,7 +135,7 @@ jobs:
             >
             > Once all the checks pass, you can safely merge this pull request manually.
           labels: automated, build-docs
-          team-reviewers: tardis-sn/tardis-infrastructure
+          team-reviewers: tardis-infrastructure
         id: create-pr
 
       - name: Wait for pull request


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

Changed the way we invoke team reviewers on pre and post release pipelines, according to the action documentation.

### :pushpin: Resources


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
