### PR TITLE
Fix for widgets displaying code in commandline

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -172,22 +172,29 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             )
 
         if show_convergence_plots:
-            self.convergence_plots = ConvergencePlots(
-                iterations=self.iterations, **convergence_plots_kwargs
-            )
-
-            if "export_convergence_plots" in convergence_plots_kwargs:
-                if not isinstance(
-                    convergence_plots_kwargs["export_convergence_plots"], bool
-                ):
-                    raise TypeError(
-                        "Expected bool in export_convergence_plots argument"
-                    )
-                self.export_convergence_plots = convergence_plots_kwargs[
-                    "export_convergence_plots"
-                ]
+            if not is_notebook():
+                raise RuntimeError(
+                    "Convergence Plots cannot be displayed in command-line. Set show_convergence_plots "
+                    "to False."
+                )
             else:
-                self.export_convergence_plots = False
+                self.convergence_plots = ConvergencePlots(
+                    iterations=self.iterations, **convergence_plots_kwargs
+                )
+
+        if "export_convergence_plots" in convergence_plots_kwargs:
+            if not isinstance(
+                convergence_plots_kwargs["export_convergence_plots"],
+                bool,
+            ):
+                raise TypeError(
+                    "Expected bool in export_convergence_plots argument"
+                )
+            self.export_convergence_plots = convergence_plots_kwargs[
+                "export_convergence_plots"
+            ]
+        else:
+            self.export_convergence_plots = False
 
         self._callbacks = OrderedDict()
         self._cb_next_id = 0
@@ -633,7 +640,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         config,
         packet_source=None,
         virtual_packet_logging=False,
-        show_convergence_plots=True,
+        show_convergence_plots=False,
         show_progress_bars=True,
         **kwargs,
     ):

--- a/tardis/tests/test_util.py
+++ b/tardis/tests/test_util.py
@@ -30,6 +30,15 @@ def artis_abundances_fname(example_model_file_dir):
     return example_model_file_dir / "artis_abundances.dat"
 
 
+@pytest.fixture(scope="session")
+def monkeysession():
+    """
+    Creates a session-scoped fixture to be used to mock functions dependent on the user.
+    """
+    with pytest.MonkeyPatch.context() as mp:
+        yield mp
+
+
 def test_malformed_species_error():
     malformed_species_error = MalformedSpeciesError("He")
     assert malformed_species_error.malformed_element_symbol == "He"

--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 
 import pytest
-
+from tardis.tests.test_util import monkeysession
 from tardis import run_tardis
 from tardis.visualization.tools.convergence_plot import (
     ConvergencePlots,

--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -1,5 +1,9 @@
 """Tests for Convergence Plots."""
+from copy import deepcopy
+
 import pytest
+
+from tardis import run_tardis
 from tardis.visualization.tools.convergence_plot import (
     ConvergencePlots,
     transition_colors,
@@ -205,3 +209,19 @@ def test_override_plot_parameters(convergence_plots):
     assert (
         convergence_plots.plasma_plot["layout"]["xaxis2"]["showgrid"] == False
     )
+
+
+def test_convergence_plot_command_line(
+    config_verysimple, atomic_dataset, monkeysession
+):
+    monkeysession.setattr(
+        "tardis.simulation.base.is_notebook",
+        lambda: False,
+    )
+    atomic_data = deepcopy(atomic_dataset)
+    with pytest.raises(RuntimeError):
+        run_tardis(
+            config_verysimple,
+            atom_data=atomic_data,
+            show_convergence_plots=True,
+        )

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import tardis
 from tardis.io.model.readers.generic_readers import read_uniform_abundances
-from tardis.util.base import quantity_linspace, is_valid_nuclide_or_elem
+from tardis.util.base import quantity_linspace, is_valid_nuclide_or_elem, is_notebook
 from tardis.io.configuration.config_reader import Configuration
 from tardis.model import SimulationState
 from tardis.io.model.parse_density_configuration import (
@@ -1284,109 +1284,112 @@ class CustomAbundanceWidget:
         ipywidgets.widgets.widget_box.VBox
             A box that contains all the widgets in the GUI.
         """
-        # --------------Combine widget components--------------
-        self.box_editor = ipw.HBox(
-            [
-                ipw.VBox(self.input_items),
-                ipw.VBox(self.checks, layout=ipw.Layout(margin="0 0 0 10px")),
-            ]
-        )
+        if not is_notebook():
+            print("Please use a notebook to display the widget")
+        else:
+            # --------------Combine widget components--------------
+            self.box_editor = ipw.HBox(
+                [
+                    ipw.VBox(self.input_items),
+                    ipw.VBox(self.checks, layout=ipw.Layout(margin="0 0 0 10px")),
+                ]
+            )
 
-        box_add_shell = ipw.HBox(
-            [
-                self.input_v_start,
-                self.input_v_end,
-                self.btn_add_shell,
-                self.overwrite_warning,
-            ],
-            layout=ipw.Layout(margin="0 0 0 50px"),
-        )
+            box_add_shell = ipw.HBox(
+                [
+                    self.input_v_start,
+                    self.input_v_end,
+                    self.btn_add_shell,
+                    self.overwrite_warning,
+                ],
+                layout=ipw.Layout(margin="0 0 0 50px"),
+            )
 
-        box_head = ipw.HBox(
-            [self.dpd_shell_no, self.btn_prev, self.btn_next, box_add_shell]
-        )
+            box_head = ipw.HBox(
+                [self.dpd_shell_no, self.btn_prev, self.btn_next, box_add_shell]
+            )
 
-        box_add_element = ipw.HBox(
-            [self.input_symb, self.btn_add_element, self.symb_warning],
-            layout=ipw.Layout(margin="0 0 0 80px"),
-        )
+            box_add_element = ipw.HBox(
+                [self.input_symb, self.btn_add_element, self.symb_warning],
+                layout=ipw.Layout(margin="0 0 0 80px"),
+            )
 
-        help_note = ipw.HTML(
-            value="<p style='text-indent: 40px'>* Select a checkbox "
-            "to lock the abundance of corresponding element. </p>"
-            "<p style='text-indent: 40px'> On clicking the 'Normalize' "
-            "button, the locked abundance(s) will <b>not be normalized</b>."
-            " </p>",
-            indent=True,
-        )
+            help_note = ipw.HTML(
+                value="<p style='text-indent: 40px'>* Select a checkbox "
+                "to lock the abundance of corresponding element. </p>"
+                "<p style='text-indent: 40px'> On clicking the 'Normalize' "
+                "button, the locked abundance(s) will <b>not be normalized</b>."
+                " </p>",
+                indent=True,
+            )
 
-        self.abundance_note = ipw.HTML(
-            description="(The following abundances are for the innermost "
-            "shell in selected range.)",
-            layout=ipw.Layout(visibility="hidden"),
-            style={"description_width": "initial"},
-        )
+            self.abundance_note = ipw.HTML(
+                description="(The following abundances are for the innermost "
+                "shell in selected range.)",
+                layout=ipw.Layout(visibility="hidden"),
+                style={"description_width": "initial"},
+            )
 
-        box_norm = ipw.HBox([self.btn_norm, self.norm_warning])
+            box_norm = ipw.HBox([self.btn_norm, self.norm_warning])
 
-        box_apply = ipw.VBox(
-            [
-                ipw.Label(value="Apply abundance(s) to:"),
-                self.rbs_single_apply,
-                ipw.HBox(
-                    [
-                        self.rbs_multi_apply,
-                        self.irs_shell_range,
-                        self.abundance_note,
-                    ]
-                ),
-            ],
-            layout=ipw.Layout(margin="0 0 15px 50px"),
-        )
+            box_apply = ipw.VBox(
+                [
+                    ipw.Label(value="Apply abundance(s) to:"),
+                    self.rbs_single_apply,
+                    ipw.HBox(
+                        [
+                            self.rbs_multi_apply,
+                            self.irs_shell_range,
+                            self.abundance_note,
+                        ]
+                    ),
+                ],
+                layout=ipw.Layout(margin="0 0 15px 50px"),
+            )
 
-        box_features = ipw.VBox([box_norm, help_note])
-        box_abundance = ipw.VBox(
-            [
-                box_apply,
-                ipw.HBox([self.box_editor, box_features]),
-                box_add_element,
-            ]
-        )
-        box_density = self.density_editor.display()
+            box_features = ipw.VBox([box_norm, help_note])
+            box_abundance = ipw.VBox(
+                [
+                    box_apply,
+                    ipw.HBox([self.box_editor, box_features]),
+                    box_add_element,
+                ]
+            )
+            box_density = self.density_editor.display()
 
-        main_tab = ipw.Tab([box_abundance, box_density])
-        main_tab.set_title(0, "Edit Abundance")
-        main_tab.set_title(1, "Edit Density")
+            main_tab = ipw.Tab([box_abundance, box_density])
+            main_tab.set_title(0, "Edit Abundance")
+            main_tab.set_title(1, "Edit Density")
 
-        hint = ipw.HTML(
-            value="<b><font size='3'>Save model as file: </font></b>"
-        )
-        box_output = ipw.VBox(
-            [
-                hint,
-                self.input_i_time_0,
-                ipw.HBox(
-                    [self.input_path, self.btn_output, self.ckb_overwrite]
-                ),
-            ]
-        )
+            hint = ipw.HTML(
+                value="<b><font size='3'>Save model as file: </font></b>"
+            )
+            box_output = ipw.VBox(
+                [
+                    hint,
+                    self.input_i_time_0,
+                    ipw.HBox(
+                        [self.input_path, self.btn_output, self.ckb_overwrite]
+                    ),
+                ]
+            )
 
-        # Initialize the widget and plot colormap
-        self.plot_cmap = cmap
-        self.update_line_color()
-        self.read_abundance()
-        self.density_editor.read_density()
+            # Initialize the widget and plot colormap
+            self.plot_cmap = cmap
+            self.update_line_color()
+            self.read_abundance()
+            self.density_editor.read_density()
 
-        return ipw.VBox(
-            [
-                self.tbs_scale,
-                self.fig,
-                box_head,
-                main_tab,
-                box_output,
-                self.error_view,
-            ]
-        )
+            return ipw.VBox(
+                [
+                    self.tbs_scale,
+                    self.fig,
+                    box_head,
+                    main_tab,
+                    box_output,
+                    self.error_view,
+                ]
+            )
 
     @error_view.capture(clear_output=True)
     def to_csvy(self, path, overwrite):

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -1291,7 +1291,9 @@ class CustomAbundanceWidget:
             self.box_editor = ipw.HBox(
                 [
                     ipw.VBox(self.input_items),
-                    ipw.VBox(self.checks, layout=ipw.Layout(margin="0 0 0 10px")),
+                    ipw.VBox(
+                        self.checks, layout=ipw.Layout(margin="0 0 0 10px")
+                    ),
                 ]
             )
 

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 import tardis
 from tardis.io.model.readers.generic_readers import read_uniform_abundances
-from tardis.util.base import quantity_linspace, is_valid_nuclide_or_elem, is_notebook
+from tardis.util.base import (
+    quantity_linspace,
+    is_valid_nuclide_or_elem,
+    is_notebook,
+)
 from tardis.io.configuration.config_reader import Configuration
 from tardis.model import SimulationState
 from tardis.io.model.parse_density_configuration import (

--- a/tardis/visualization/widgets/line_info.py
+++ b/tardis/visualization/widgets/line_info.py
@@ -10,7 +10,11 @@ from plotly.callbacks import BoxSelector
 import ipywidgets as ipw
 
 from tardis.analysis import LastLineInteraction
-from tardis.util.base import species_tuple_to_string, species_string_to_tuple
+from tardis.util.base import (
+    species_tuple_to_string,
+    species_string_to_tuple,
+    is_notebook,
+)
 from tardis.visualization.widgets.util import (
     create_table_widget,
     TableSummaryLabel,
@@ -668,68 +672,71 @@ class LineInfoWidget:
         ipywidgets.Box
             Line info widget containing all component widgets
         """
-        # Set widths of widgets
-        self.species_interactions_table.layout.width = "350px"
-        self.last_line_counts_table.layout.width = "450px"
-        self.total_packets_label.update_and_resize(0)
-        self.group_mode_dropdown.layout.width = "auto"
+        if not is_notebook():
+            print("Please use a notebook to display the widget")
+        else:
+            # Set widths of widgets
+            self.species_interactions_table.layout.width = "350px"
+            self.last_line_counts_table.layout.width = "450px"
+            self.total_packets_label.update_and_resize(0)
+            self.group_mode_dropdown.layout.width = "auto"
 
-        # Attach event listeners to widgets
-        spectrum_trace = self.figure_widget.data[0]
-        spectrum_trace.on_selection(self._spectrum_selection_handler)
-        self.filter_mode_buttons.observe(
-            self._filter_mode_toggle_handler, names="index"
-        )
-        self.species_interactions_table.on(
-            "selection_changed", self._species_intrctn_selection_handler
-        )
-        self.group_mode_dropdown.observe(
-            self._group_mode_dropdown_handler, names="index"
-        )
+            # Attach event listeners to widgets
+            spectrum_trace = self.figure_widget.data[0]
+            spectrum_trace.on_selection(self._spectrum_selection_handler)
+            self.filter_mode_buttons.observe(
+                self._filter_mode_toggle_handler, names="index"
+            )
+            self.species_interactions_table.on(
+                "selection_changed", self._species_intrctn_selection_handler
+            )
+            self.group_mode_dropdown.observe(
+                self._group_mode_dropdown_handler, names="index"
+            )
 
-        selection_box_symbol = (
-            "<span style='display: inline-block; "
-            f"background-color: {self.COLORS['selection_area']}; "
-            f"border: 1px solid {self.COLORS['selection_border']}; "
-            "width: 0.8em; height: 1.2em; vertical-align: middle;'></span>"
-        )
+            selection_box_symbol = (
+                "<span style='display: inline-block; "
+                f"background-color: {self.COLORS['selection_area']}; "
+                f"border: 1px solid {self.COLORS['selection_border']}; "
+                "width: 0.8em; height: 1.2em; vertical-align: middle;'></span>"
+            )
 
-        table_container_left = ipw.VBox(
-            [
-                self.ui_control_description(
-                    "Filter selected wavelength range "
-                    f"( {selection_box_symbol} ) by"
-                ),
-                self.filter_mode_buttons,
-                self.species_interactions_table,
-            ],
-            layout=dict(margin="0px 15px"),
-        )
-
-        table_container_right = ipw.VBox(
-            [
-                self.ui_control_description("Group packet counts by"),
-                self.group_mode_dropdown,
-                self.last_line_counts_table,
-                self.total_packets_label.widget,
-            ],
-            layout=dict(margin="0px 15px"),
-        )
-
-        return ipw.VBox(
-            [
-                self.figure_widget,
-                ipw.Box(
-                    [
-                        table_container_left,
-                        table_container_right,
-                    ],
-                    layout=dict(
-                        display="flex",
-                        align_items="flex-start",
-                        justify_content="center",
-                        height="420px",
+            table_container_left = ipw.VBox(
+                [
+                    self.ui_control_description(
+                        "Filter selected wavelength range "
+                        f"( {selection_box_symbol} ) by"
                     ),
-                ),
-            ]
-        )
+                    self.filter_mode_buttons,
+                    self.species_interactions_table,
+                ],
+                layout=dict(margin="0px 15px"),
+            )
+
+            table_container_right = ipw.VBox(
+                [
+                    self.ui_control_description("Group packet counts by"),
+                    self.group_mode_dropdown,
+                    self.last_line_counts_table,
+                    self.total_packets_label.widget,
+                ],
+                layout=dict(margin="0px 15px"),
+            )
+
+            return ipw.VBox(
+                [
+                    self.figure_widget,
+                    ipw.Box(
+                        [
+                            table_container_left,
+                            table_container_right,
+                        ],
+                        layout=dict(
+                            display="flex",
+                            align_items="flex-start",
+                            justify_content="center",
+                            height="420px",
+                        ),
+                    ),
+                ]
+            )

--- a/tardis/visualization/widgets/shell_info.py
+++ b/tardis/visualization/widgets/shell_info.py
@@ -2,7 +2,7 @@ from tardis.base import run_tardis
 from tardis.io.atom_data.atom_web_download import download_atom_data
 from tardis.util.base import (
     atomic_number2element_symbol,
-    species_tuple_to_string,
+    species_tuple_to_string, is_notebook,
 )
 
 from tardis.visualization.widgets.util import create_table_widget
@@ -438,53 +438,56 @@ class ShellInfoWidget:
         ipywidgets.Box
             Shell info widget containing all component widgets
         """
-        # CSS properties of the layout of shell info tables container
-        tables_container_layout = dict(
-            display="flex",
-            align_items="flex-start",
-            justify_content="space-between",
-        )
-        tables_container_layout.update(layout_kwargs)
+        if not is_notebook():
+            print("Please use a notebook to display the widget")
+        else:
+            # CSS properties of the layout of shell info tables container
+            tables_container_layout = dict(
+                display="flex",
+                align_items="flex-start",
+                justify_content="space-between",
+            )
+            tables_container_layout.update(layout_kwargs)
 
-        # Setting tables' widths
-        self.shells_table.layout.width = shells_table_width
-        self.element_count_table.layout.width = element_count_table_width
-        self.ion_count_table.layout.width = ion_count_table_width
-        self.level_count_table.layout.width = level_count_table_width
+            # Setting tables' widths
+            self.shells_table.layout.width = shells_table_width
+            self.element_count_table.layout.width = element_count_table_width
+            self.ion_count_table.layout.width = ion_count_table_width
+            self.level_count_table.layout.width = level_count_table_width
 
-        # Attach event listeners to table widgets
-        self.shells_table.on(
-            "selection_changed", self.update_element_count_table
-        )
-        self.element_count_table.on(
-            "selection_changed", self.update_ion_count_table
-        )
-        self.ion_count_table.on(
-            "selection_changed", self.update_level_count_table
-        )
+            # Attach event listeners to table widgets
+            self.shells_table.on(
+                "selection_changed", self.update_element_count_table
+            )
+            self.element_count_table.on(
+                "selection_changed", self.update_ion_count_table
+            )
+            self.ion_count_table.on(
+                "selection_changed", self.update_level_count_table
+            )
 
-        # Putting all table widgets in a container styled with tables_container_layout
-        shell_info_tables_container = ipw.Box(
-            [
-                self.shells_table,
-                self.element_count_table,
-                self.ion_count_table,
-                self.level_count_table,
-            ],
-            layout=ipw.Layout(**tables_container_layout),
-        )
-        self.shells_table.change_selection([1])
+            # Putting all table widgets in a container styled with tables_container_layout
+            shell_info_tables_container = ipw.Box(
+                [
+                    self.shells_table,
+                    self.element_count_table,
+                    self.ion_count_table,
+                    self.level_count_table,
+                ],
+                layout=ipw.Layout(**tables_container_layout),
+            )
+            self.shells_table.change_selection([1])
 
-        # Notes text explaining how to interpret tables widgets' data
-        text = ipw.HTML(
-            "<b>Frac. Ab.</b> denotes <i>Fractional Abundances</i> (i.e all "
-            "values sum to 1)<br><b>W</b> denotes <i>Dilution Factor</i> and "
-            "<b>Rad. Temp.</b> is <i>Radiative Temperature (in K)</i>"
-        )
+            # Notes text explaining how to interpret tables widgets' data
+            text = ipw.HTML(
+                "<b>Frac. Ab.</b> denotes <i>Fractional Abundances</i> (i.e all "
+                "values sum to 1)<br><b>W</b> denotes <i>Dilution Factor</i> and "
+                "<b>Rad. Temp.</b> is <i>Radiative Temperature (in K)</i>"
+            )
 
-        # Put text horizontally before shell info container
-        shell_info_widget = ipw.VBox([text, shell_info_tables_container])
-        return shell_info_widget
+            # Put text horizontally before shell info container
+            shell_info_widget = ipw.VBox([text, shell_info_tables_container])
+            return shell_info_widget
 
 
 def shell_info_from_simulation(sim_model):

--- a/tardis/visualization/widgets/shell_info.py
+++ b/tardis/visualization/widgets/shell_info.py
@@ -2,7 +2,8 @@ from tardis.base import run_tardis
 from tardis.io.atom_data.atom_web_download import download_atom_data
 from tardis.util.base import (
     atomic_number2element_symbol,
-    species_tuple_to_string, is_notebook,
+    species_tuple_to_string,
+    is_notebook,
 )
 
 from tardis.visualization.widgets.util import create_table_widget

--- a/tardis/visualization/widgets/tests/test_custom_abundance.py
+++ b/tardis/visualization/widgets/tests/test_custom_abundance.py
@@ -5,6 +5,7 @@ import tardis
 import numpy as np
 import numpy.testing as npt
 
+from tardis.tests.test_util import monkeysession
 from tardis.visualization.widgets.custom_abundance import (
     CustomAbundanceWidgetData,
     CustomYAML,
@@ -30,7 +31,7 @@ def yml_data(example_configuration_dir: Path, atomic_dataset):
 
 
 @pytest.fixture(scope="module")
-def caw(yml_data):
+def caw(yml_data, monkeysession):
     """Fixture to contain a CustomAbundanceWidget
     instance generated from a YAML file tardis_configv1_verysimple.yml.
 
@@ -40,6 +41,10 @@ def caw(yml_data):
         CustomAbundanceWidget generated from a YAML
     """
     caw = CustomAbundanceWidget(yml_data)
+    monkeysession.setattr(
+        "tardis.visualization.widgets.custom_abundance.is_notebook",
+        lambda: True,
+    )
     caw.display()
     return caw
 

--- a/tardis/visualization/widgets/tests/test_line_info.py
+++ b/tardis/visualization/widgets/tests/test_line_info.py
@@ -4,6 +4,7 @@ import numpy as np
 from plotly.callbacks import Points, BoxSelector
 from tardis.visualization.widgets.line_info import LineInfoWidget
 from tardis.util.base import species_string_to_tuple
+from tardis.tests.test_util import monkeysession
 
 
 @pytest.fixture(scope="class")
@@ -141,12 +142,15 @@ class TestLineInfoWidgetEvents:
             None,  # No selection of wavelength range
         ],
     )
-    def liw_with_selection(self, simulation_verysimple, request):
+    def liw_with_selection(self, simulation_verysimple, request, monkeysession):
         """
         Makes different wavelength range selection on figure (specified by
         params) after creating a LineInfoWidget object.
         """
         liw = LineInfoWidget.from_simulation(simulation_verysimple)
+        monkeysession.setattr(
+            "tardis.visualization.widgets.line_info.is_notebook", lambda: True
+        )
         # To attach event listeners to component widgets of line_info_widget
         _ = liw.display()
 

--- a/tardis/visualization/widgets/tests/test_shell_info.py
+++ b/tardis/visualization/widgets/tests/test_shell_info.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import pandas.testing as pdt
 
+from tardis.tests.test_util import monkeysession
 from tardis.visualization.widgets.shell_info import (
     BaseShellInfo,
     SimulationShellInfo,
@@ -138,8 +139,11 @@ class TestShellInfoWidget:
     select_ion_num = 3
 
     @pytest.fixture(scope="class")
-    def shell_info_widget(self, base_shell_info):
+    def shell_info_widget(self, base_shell_info, monkeysession):
         shell_info_widget = ShellInfoWidget(base_shell_info)
+        monkeysession.setattr(
+            "tardis.visualization.widgets.shell_info.is_notebook", lambda: True
+        )
         # To attach event listeners to table widgets of shell_info_widget
         _ = shell_info_widget.display()
         return shell_info_widget


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

`resolves` #1976 

The widgets displayed code when called from the command-line as shown in the issue above. This PR adds a check so that the `display()` methods in the widgets run only for notebooks. When called from command-line, a message "Please use a notebook to display the widget" is printed.

For the tests, I have used a pytest.Monkeypatch context manager to use a session-scoped fixture and mock the `is_notebook()` response.

### :pushpin: Resources

[Monkeypatch.context](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.MonkeyPatch.context)

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method - Ran the widgets in the command-line
- [ ] My changes can't be tested (explain why)

![image](https://user-images.githubusercontent.com/125031481/227041445-a6d19706-62f0-4807-861a-93829290f1d1.png)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

@wkerzendorf @atharva-2001 