### PR TITLE
Check MD5 sums of downloaded atom data

### DIFF
--- a/tardis/data/atomic_data_repo.yml
+++ b/tardis/data/atomic_data_repo.yml
@@ -6,3 +6,4 @@ kurucz_cd23_chianti_H_He:
     - https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=atom_data/kurucz_cd23_chianti_H_He.h5&resolveLfs=true
     - https://media.githubusercontent.com/media/tardis-sn/tardis-refdata/master/atom_data/kurucz_cd23_chianti_H_He.h5
   uuid: NA
+  md5: 69a304e1e85e06508fe02dd8c5ba9397

--- a/tardis/io/atom_data/atom_web_download.py
+++ b/tardis/io/atom_data/atom_web_download.py
@@ -41,7 +41,7 @@ def download_atom_data(atomic_data_name=None):
 
     if atomic_data_name not in atomic_repo:
         raise ValueError(f"Atomic Data name {atomic_data_name} not known")
-    
+
     dst_dir = os.path.join(get_data_dir(), f"{atomic_data_name}.h5")
     src_url = atomic_repo[atomic_data_name]["url"]
     mirrors = tuple(atomic_repo[atomic_data_name]["mirrors"])

--- a/tardis/io/atom_data/atom_web_download.py
+++ b/tardis/io/atom_data/atom_web_download.py
@@ -41,10 +41,11 @@ def download_atom_data(atomic_data_name=None):
 
     if atomic_data_name not in atomic_repo:
         raise ValueError(f"Atomic Data name {atomic_data_name} not known")
-
+    
     dst_dir = os.path.join(get_data_dir(), f"{atomic_data_name}.h5")
     src_url = atomic_repo[atomic_data_name]["url"]
-    mirrors = atomic_repo[atomic_data_name]["mirrors"]
+    mirrors = tuple(atomic_repo[atomic_data_name]["mirrors"])
+    checksum = atomic_repo[atomic_data_name]["md5"]
 
     logger.info(f"Downloading atomic data from {src_url} to {dst_dir}")
-    download_from_url(src_url, dst_dir, mirrors)
+    download_from_url(src_url, dst_dir, checksum, mirrors)

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -411,7 +411,9 @@ def download_from_url(url, dst, checksum, src=None, retries=3):
 
     elif checksum != new_checksum and retries > 0:
         retries -= 1
-        logger.warning(f"Incorrect checksum, retrying... ({retries+1} attempts remaining)")
+        logger.warning(
+            f"Incorrect checksum, retrying... ({retries+1} attempts remaining)"
+        )
         download_from_url(url, dst, checksum, src, retries)
 
     else:

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -1,24 +1,22 @@
 # Utility functions for the IO part of TARDIS
 
+import collections.abc as collections_abc
+import hashlib
+import logging
 import os
 import re
 import shutil
-import hashlib
-import logging
+from collections import OrderedDict
 from functools import lru_cache
 
-import pandas as pd
 import numpy as np
-import collections.abc as collections_abc
-from collections import OrderedDict
-
+import pandas as pd
 import yaml
-
-from tardis import constants as const
 from astropy import units as u
 from astropy.utils.data import download_file
 
 from tardis import __path__ as TARDIS_PATH
+from tardis import constants as const
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

This is an attempt to fix the random failure of the documentation pipeline. I always had the suspicion that HDF5 files sometimes are corrupted, but I can't be sure (`libhdf5` is an awful library).

In this PR I made the changes necessary to compare the known MD5 checksums of atomic files with the downloaded ones through the `download_atom_data` function. Also, allows to set a maximum number of retries.

Fixes #2252


### :pushpin: Resources


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Locally, modify a digit in the `md5` key of the `tardis/data/atomic_data_repo.yml` file and call the function, see how in behaves until reaches the limit.

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
