### PR TITLE
Download Slice of Reference Data

### DIFF
--- a/.ci-helpers/download_reference_data.sh
+++ b/.ci-helpers/download_reference_data.sh
@@ -17,9 +17,17 @@ FILES=('atom_data/kurucz_cd23_chianti_H_He.h5'
 mkdir -p $REF_PATH/atom_data
 mkdir -p $REF_PATH/arepo_data
 
-for FILE in "${FILES[@]}"
-do
-    wget -q "$REPO_URL/items?path=$FILE&resolveLfs=true" -O $REF_PATH/$FILE
-done
+if [ -z "$1" ]
+then
+    echo "Downloading all files."
+    for FILE in "${FILES[@]}"
+    do
+        wget -q "$REPO_URL/items?path=$FILE&resolveLfs=true" -O $REF_PATH/$FILE
+    done
+      
+else
+    echo "Downloading: $1"
+    wget -q "$REPO_URL/items?path=$1&resolveLfs=true" -O $REF_PATH/$1
+fi
 
 exit 0

--- a/.ci-helpers/download_reference_data.sh
+++ b/.ci-helpers/download_reference_data.sh
@@ -26,7 +26,6 @@ then
     done
       
 else
-    echo "Downloading: $1"
     wget -q "$REPO_URL/items?path=$1&resolveLfs=true" -O $REF_PATH/$1
 fi
 

--- a/.ci-helpers/download_reference_data.sh
+++ b/.ci-helpers/download_reference_data.sh
@@ -2,8 +2,13 @@
 
 set -e
 
-REF_PATH="$GITHUB_WORKSPACE/tardis-refdata"
 REPO_URL="https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata"
+
+if [ -z "$GITHUB_WORKSPACE" ]; then
+    REF_PATH="./tardis-refdata"
+else
+    REF_PATH="$GITHUB_WORKSPACE/tardis-refdata"
+fi 
 
 FILES=('atom_data/kurucz_cd23_chianti_H_He.h5'
        'atom_data/chianti_He.h5'


### PR DESCRIPTION
### :pencil: Description

Had made this previously but forgot to open a pull request. One can download a slice of reference data by:

`bash .ci-helpers/download_reference_data.sh atom_data/kurucz_cd23_chianti_H_He.h5`

Partially fixes https://github.com/tardis-sn/tardis/issues/2129 
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
