### PR TITLE
Save LFS Objects `always()` 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   build:
-    if: github.repository_owner == 'tardis-sn'
+    # if: github.repository_owner == 'tardis-sn'
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   build:
-    if: github.repository_owner==tardis-sn
+    if: github.repository_owner=='tardis-sn'
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   build:
-    # if: github.repository_owner == 'tardis-sn'
+    if: github.repository_owner == 'tardis-sn'
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   build:
-
+    if: github.repository_owner==tardis-sn
     strategy:
       matrix:
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,9 @@ jobs:
         if: steps.lfs-cache.outputs.cache-hit == 'true'
       
       - name: Save LFS cache if not found
-        if: ${{ steps.lfs-cache.outputs.cache-hit != 'true'  && always() || 'false' }}
+        # uses fake ternary 
+        # for reference: https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
+        if: ${{ steps.lfs-cache.outputs.cache-hit != 'true'  && always() || false }}
         uses: actions/cache/save@v3
         id: lfs-cache-save
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
         working-directory: tardis-refdata
 
       - name: Restore LFS cache
-        uses: actions/cache@v2
+        uses: actions/cache/restore@v3
         id: lfs-cache
         with:
           path: tardis-refdata/.git/lfs
@@ -74,6 +74,14 @@ jobs:
         run: git lfs checkout
         working-directory: tardis-refdata
         if: steps.lfs-cache.outputs.cache-hit == 'true'
+      
+      - name: Save LFS cache if not found
+        if: ${{ steps.lfs-cache.outputs.cache-hit != 'true'  && always() || 'false' }}
+        uses: actions/cache/save@v3
+        id: lfs-cache-save
+        with:
+          path: tardis-refdata/.git/lfs
+          key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-refdata/.lfs-assets-id') }}-v1
 
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ defaults:
 
 jobs:
   build:
-    if: github.repository_owner=='tardis-sn'
+    if: github.repository_owner == 'tardis-sn'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
### :pencil: Description

:vertical_traffic_light: `testing`| :roller_coaster: `infrastructure`

Add a step which saves LFS cache even if the workflow fails.

### :pushpin: Resources
Uses a fake ternary operator:
https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
Save: https://github.com/actions/cache/tree/main/save
Restore: https://github.com/actions/cache/tree/main/restore

Please merge https://github.com/tardis-sn/tardis/pull/2280 before.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [X] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
