### PR TITLE
Disable HDF5 file locking on documentation workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -25,6 +25,7 @@ on:
 env:
   CACHE_NUMBER: 0                       # increase to reset cache manually
   DEPLOY_BRANCH: gh-pages               # deployed docs branch
+  HDF5_USE_FILE_LOCKING: 'FALSE'        # disable file locking
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -76,7 +77,7 @@ jobs:
         run: pip install -e .
 
       - name: Build documentation
-        run: cd docs/ && make html CORES=auto
+        run: cd docs/ && make html NCORES=auto
 
       - name: Set destination directory
         run: |

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
-CORES         = 1
+NCORES         = 1
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -42,7 +42,7 @@ clean:
 	-rm -rf generated
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j $(CORES)
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -j $(NCORES)
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/contributing/development/documentation_guidelines.rst
+++ b/docs/contributing/development/documentation_guidelines.rst
@@ -59,7 +59,7 @@ To build TARDIS documentation locally, use the following commands:
 
     - If you're working on a fresh local copy of the TARDIS repository, you might need to do ``python setup.py develop`` before executing these commands.
     - Use ``DISABLE_NBSPHINX=1 make html`` to disable notebook rendering (fast mode).
-    - Use ``make html CORES=<number of cores>`` to have the documentation build in parallel. Using ``make html CORES=auto`` instructs Sphinx to use all of your device's cores.
+    - Use ``make html NCORES=<number of cores>`` to have the documentation build in parallel. Using ``make html NCORES=auto`` instructs Sphinx to use all of your device's cores.
     - Use ``make html SPHINXOPTS="<insert sphinx options>"`` to include additional sphinx options, which can be found `here <https://www.sphinx-doc.org/en/master/man/sphinx-build.html#options>`_.
 
 After running this command, you can find the built docs (i.e. HTML webpages) in ``docs/_build/html``. Open the ``index.html`` in your browser to see how the documentation looks like with your edits. Navigate to page where you made changes or file that you added to check whether it looks as intended or not.


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

- Use `export HDF5_USE_FILE_LOCKING='FALSE'`
- Use more standard `NCORES` name variable

Should fix #2252 (again)

### :pushpin: Resources


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Documentation pipeline :crossed_fingers: 

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
