### PR TITLE
Improve Docstring of MontecarloTransport

### DIFF
--- a/tardis/montecarlo/base.py
+++ b/tardis/montecarlo/base.py
@@ -39,6 +39,10 @@ class MontecarloRunner(HDFWriterMixin):
     """
     This class is designed as an interface between the Python part and the
     montecarlo C-part
+
+    Parameters
+    ----------
+
     """
 
     hdf_properties = [


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` 

MontecarloTransport doesn't have docstring describing its parameters. This PR adds docstring coverage to the class.

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
