### PR TITLE
Track bf and ff opacities with vpackets

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -227,6 +227,8 @@ Wolfgang Kerzendorf <wkerzendorf@gmail.com> Wolfgang Kerzendorf <wkerzend@Wolfga
 Youssef Eweis <joey070@gmail.com>
 Youssef Eweis <joey070@gmail.com> Youssef Eweis <Youssef15015@users.noreply.github.com>
 
+Yuki Matsumura <matsumurayuki725@gmail.com>
+
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com>
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> rohithvarma3000 <rohith.varma.buddaraju@gmail.com>
 Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> Rohith <rohith.varma.buddaraju@gmail.com>

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -1,7 +1,9 @@
 import math
 
 import numpy as np
-from tardis.montecarlo.montecarlo_numba.opacities import chi_continuum_calculator
+from tardis.montecarlo.montecarlo_numba.opacities import (
+    chi_continuum_calculator,
+)
 from numba import float64, int64
 from numba import njit
 from numba.experimental import jitclass
@@ -99,13 +101,19 @@ def trace_vpacket_within_shell(
     comov_nu = v_packet.nu * doppler_factor
 
     if montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED:
-        chi_bf_tot, chi_bf_contributions, current_continua, x_sect_bfs, chi_ff, = chi_continuum_calculator(
+        (
+            chi_bf_tot,
+            chi_bf_contributions,
+            current_continua,
+            x_sect_bfs,
+            chi_ff,
+        ) = chi_continuum_calculator(
             numba_plasma, comov_nu, v_packet.current_shell_id
         )
         chi_continuum = chi_e + chi_bf_tot + chi_ff
-        
+
     else:
-        chi_continuum = chi_e 
+        chi_continuum = chi_e
 
     tau_continuum = chi_continuum * distance_boundary
     tau_trace_combined = tau_continuum


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

Updated line 99 in the vpacket.py to include chi_bf_tot and chi_ff in the chi_continuum variable depending on whether continuum process is enabled or not. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- No test performed

