### PR TITLE
Dispatch Compare Refdata Event to Refdata Repo

### DIFF
--- a/.github/workflows/dispatcher.yml
+++ b/.github/workflows/dispatcher.yml
@@ -12,9 +12,20 @@ jobs:
         with:
           token: ${{ secrets.BOT_TOKEN }}
           commands: |
-            compare-refdata
             update-refdata
           repository: tardis-sn/tardis
+          issue-type: pull-request
+          permission: triage
+          reaction-token: ${{ secrets.BOT_TOKEN }}
+          allow-edits: true
+
+      - name: Slash Command Dispatcher
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          commands: |
+            compare-refdata
+          repository: tardis-sn/tardis-refdata
           issue-type: pull-request
           permission: triage
           reaction-token: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
### :pencil: Description

:vertical_traffic_light: `testing` :roller_coaster: `infrastructure`
The command /compare-refdata doesn't work because the current workflow dispatches events only to the TARDIS repo. This change adds another step to trigger the compare-refdata workflow command in the refdata repo.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
