### PR TITLE
Fix doc failure after restructuring packet source seed

### DIFF
--- a/docs/physics/montecarlo/initialization.ipynb
+++ b/docs/physics/montecarlo/initialization.ipynb
@@ -81,10 +81,7 @@
     "from tardis.montecarlo.packet_source import BlackBodySimpleSource\n",
     "from astropy import units as u\n",
     "from tardis import constants as const\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "#The random number generator that will be used\n",
-    "rng = np.random.default_rng()"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -103,8 +100,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Seed for the pseudo-random number generator\n",
-    "seed = 1\n",
+    "# Base seed for the packet source\n",
+    "base_seed = 1\n",
+    "# Seed offset resets the Pseudo Random Number Generator with a new seed at each iteration\n",
+    "seed_offset = 0\n",
     "\n",
     "# Number of packets generated\n",
     "n_packets = 40000\n",
@@ -157,7 +156,9 @@
    "outputs": [],
    "source": [
     "# We define our packet source\n",
-    "packet_source = BlackBodySimpleSource(seed)\n",
+    "packet_source = BlackBodySimpleSource(base_seed)\n",
+    "\n",
+    "packet_seeds = packet_source.create_packet_seeds(n_packets, seed_offset)\n",
     "\n",
     "radii, nus, mus, energies = packet_source.create_packets(\n",
     "    temperature_inner.value, \n",


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :vertical_traffic_light: `testing`

This PR fixes the lingering doc failure caused by https://github.com/tardis-sn/tardis/pull/2329 .

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
