### PR TITLE
Rename RPacketTracker.interact_id to RPacketTracker.num_interactions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -235,6 +235,14 @@ Rohith Varma Buddaraju <rohith.varma.buddaraju@gmail.com> Rohith <rohith.varma.b
 
 Le Truong <katrintruong@gmail.com>
 
+Ayushi Daksh <aayusheedaksh@gmail.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> AyushiDaksh <aayusheedaksh@gmail.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> AyushiDaksh <ayushida@buffalo.edu>
+Ayushi Daksh <aayusheedaksh@gmail.com> AyushiDaksh <37770155+AyushiDaksh@users.noreply.github.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> Ayushi Daksh <aayusheedaksh@gmail.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> Ayushi Daksh <37770155+AyushiDaksh@users.noreply.github.com>
+Ayushi Daksh <aayusheedaksh@gmail.com> Ayushi <aayusheedaksh@gmail.com>
+
 Ansh Kumar <1928013@kiit.ac.in>
 Ansh Kumar <1928013@kiit.ac.in> xansh <1928013@kiit.ac.in>
 Ansh Kumar <1928013@kiit.ac.in> Ansh Kumar <1928013@kiit.ac.in>

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -421,7 +421,7 @@ rpacket_tracker_spec = [
     ("energy", float64[:]),
     ("shell_id", int64[:]),
     ("interaction_type", int64[:]),
-    ("interact_id", int64),
+    ("num_interactions", int64),
 ]
 
 
@@ -452,7 +452,7 @@ class RPacketTracker(object):
             Current Shell No in which the RPacket is present
         interaction_type: int
             Type of interaction the rpacket undergoes
-        interact_id : int
+        num_interactions : int
             Internal counter for the interactions that a particular RPacket undergoes
     """
 
@@ -467,10 +467,10 @@ class RPacketTracker(object):
         self.energy = np.empty(self.length, dtype=np.float64)
         self.shell_id = np.empty(self.length, dtype=np.int64)
         self.interaction_type = np.empty(self.length, dtype=np.int64)
-        self.interact_id = 0
+        self.num_interactions = 0
 
     def track(self, r_packet):
-        if self.interact_id >= self.length:
+        if self.num_interactions >= self.length:
             temp_length = self.length * 2
             temp_status = np.empty(temp_length, dtype=np.int64)
             temp_r = np.empty(temp_length, dtype=np.float64)
@@ -499,23 +499,25 @@ class RPacketTracker(object):
 
         self.index = r_packet.index
         self.seed = r_packet.seed
-        self.status[self.interact_id] = r_packet.status
-        self.r[self.interact_id] = r_packet.r
-        self.nu[self.interact_id] = r_packet.nu
-        self.mu[self.interact_id] = r_packet.mu
-        self.energy[self.interact_id] = r_packet.energy
-        self.shell_id[self.interact_id] = r_packet.current_shell_id
-        self.interaction_type[self.interact_id] = r_packet.last_interaction_type
-        self.interact_id += 1
+        self.status[self.num_interactions] = r_packet.status
+        self.r[self.num_interactions] = r_packet.r
+        self.nu[self.num_interactions] = r_packet.nu
+        self.mu[self.num_interactions] = r_packet.mu
+        self.energy[self.num_interactions] = r_packet.energy
+        self.shell_id[self.num_interactions] = r_packet.current_shell_id
+        self.interaction_type[
+            self.num_interactions
+        ] = r_packet.last_interaction_type
+        self.num_interactions += 1
 
     def finalize_array(self):
-        self.status = self.status[: self.interact_id]
-        self.r = self.r[: self.interact_id]
-        self.nu = self.nu[: self.interact_id]
-        self.mu = self.mu[: self.interact_id]
-        self.energy = self.energy[: self.interact_id]
-        self.shell_id = self.shell_id[: self.interact_id]
-        self.interaction_type = self.interaction_type[: self.interact_id]
+        self.status = self.status[: self.num_interactions]
+        self.r = self.r[: self.num_interactions]
+        self.nu = self.nu[: self.num_interactions]
+        self.mu = self.mu[: self.num_interactions]
+        self.energy = self.energy[: self.num_interactions]
+        self.shell_id = self.shell_id[: self.num_interactions]
+        self.interaction_type = self.interaction_type[: self.num_interactions]
 
 
 base_estimators_spec = [

--- a/tardis/montecarlo/tests/test_montecarlo.py
+++ b/tardis/montecarlo/tests/test_montecarlo.py
@@ -843,4 +843,4 @@ def test_rpacket_tracking(index, seed, r, nu, mu, energy):
     assert test_rpacket.nu == tracked_rpacket_properties.nu
     assert test_rpacket.mu == tracked_rpacket_properties.mu
     assert test_rpacket.energy == tracked_rpacket_properties.energy
-    assert tracked_rpacket_properties.interact_id == 1
+    assert tracked_rpacket_properties.num_interactions == 1


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

The name `interact_id` for an interaction counter in `RPacketTracker` was confusing because Interaction ID is a separate concept in the context of line interactions. More appropriate name for this counter is `num_interactions`

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
