### PR TITLE
Fix frame transformations of continuum opacity

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -105,7 +105,10 @@ def single_packet_loop(
                 numba_plasma, comov_nu, r_packet.current_shell_id
             )
             chi_continuum = chi_e + chi_bf_tot + chi_ff
+
             escat_prob = chi_e / chi_continuum  # probability of e-scatter
+            if montecarlo_configuration.full_relativity:
+                chi_continuum *= doppler_factor
             distance, interaction_type, delta_shell = trace_packet(
                 r_packet,
                 numba_radial_1d_geometry,
@@ -129,6 +132,8 @@ def single_packet_loop(
         else:
             escat_prob = 1.0
             chi_continuum = chi_e
+            if montecarlo_configuration.full_relativity:
+                chi_continuum *= doppler_factor
             distance, interaction_type, delta_shell = trace_packet(
                 r_packet,
                 numba_radial_1d_geometry,

--- a/tardis/montecarlo/montecarlo_numba/vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/vpacket.py
@@ -115,6 +115,9 @@ def trace_vpacket_within_shell(
     else:
         chi_continuum = chi_e
 
+    if montecarlo_configuration.full_relativity:
+        chi_continuum *= doppler_factor
+
     tau_continuum = chi_continuum * distance_boundary
     tau_trace_combined = tau_continuum
 


### PR DESCRIPTION
### :pencil: Description
The frame transformations of the continuum opacity have been lost while porting the Monte Carlo code from C to numba. This PR adds them back in.

**Type:** :beetle: `bugfix`


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (locally)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
