### PR TITLE
removed duplicate entry of afloers

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -194,9 +194,6 @@
       "name": "Rathi, Shikha"
     },
     {
-      "name": "Floers, Andreas"
-    },
-    {
       "name": "Reichenbach, John"
     },
     {


### PR DESCRIPTION
My name appeared twice in the authors list on zenodo. This just removes the duplicate entry from .zenodo.json.