### PR TITLE
Rename NumbaPlasma to OpacityState

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/base.py
+++ b/tardis/montecarlo/montecarlo_numba/base.py
@@ -16,7 +16,7 @@ from tardis.montecarlo.montecarlo_numba.numba_interface import (
     VPacketCollection,
     RPacketTracker,
     NumbaModel,
-    numba_plasma_initialize,
+    opacity_state_initialize,
     Estimators,
 )
 
@@ -57,7 +57,7 @@ def montecarlo_radial1d(
     numba_model = NumbaModel(
         model.model_state.time_explosion.to("s").value,
     )
-    numba_plasma = numba_plasma_initialize(
+    opacity_state = opacity_state_initialize(
         plasma, transport.line_interaction_type
     )
     estimators = Estimators(
@@ -95,7 +95,7 @@ def montecarlo_radial1d(
         packet_collection,
         numba_radial_1d_geometry,
         numba_model,
-        numba_plasma,
+        opacity_state,
         estimators,
         transport.spectrum_frequency.value,
         number_of_vpackets,
@@ -151,7 +151,7 @@ def montecarlo_main_loop(
     packet_collection,
     numba_radial_1d_geometry,
     numba_model,
-    numba_plasma,
+    opacity_state,
     estimators,
     spectrum_frequency,
     number_of_vpackets,
@@ -171,7 +171,7 @@ def montecarlo_main_loop(
     packet_collection : PacketCollection
     numba_radial_1d_geometry : NumbaRadial1DGeometry
     numba_model : NumbaModel
-    numba_plasma : NumbaPlasma
+    opacity_state : OpacityState
     estimators : NumbaEstimators
     spectrum_frequency : astropy.units.Quantity
         frequency binspas
@@ -280,7 +280,7 @@ def montecarlo_main_loop(
             r_packet,
             numba_radial_1d_geometry,
             numba_model,
-            numba_plasma,
+            opacity_state,
             estimators,
             vpacket_collection,
             rpacket_tracker,

--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -14,9 +14,9 @@ import pdb
 from tardis.montecarlo.montecarlo_numba.numba_config import SIGMA_THOMSON
 from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
-    numba_plasma_initialize,
+    opacity_state_initialize,
     NumbaModel,
-    NumbaPlasma,
+    OpacityState,
 )
 from tardis.montecarlo.montecarlo_numba.formal_integral_cuda import (
     CudaFormalIntegrator,
@@ -211,7 +211,7 @@ def numba_formal_integral(
 
 # integrator_spec = [
 #    ("model", NumbaModel.class_type.instance_type),
-#    ("plasma", NumbaPlasma.class_type.instance_type),
+#    ("plasma", OpacityState.class_type.instance_type),
 #    ("points", int64),
 # ]
 
@@ -285,7 +285,7 @@ class FormalIntegrator(object):
         self.transport = transport
         self.points = points
         if plasma:
-            self.plasma = numba_plasma_initialize(
+            self.plasma = opacity_state_initialize(
                 plasma, transport.line_interaction_type
             )
             self.atomic_data = plasma.atomic_data
@@ -306,21 +306,21 @@ class FormalIntegrator(object):
         self.numba_model = NumbaModel(
             self.model.time_explosion.cgs.value,
         )
-        self.numba_plasma = numba_plasma_initialize(
+        self.opacity_state = opacity_state_initialize(
             self.original_plasma, self.transport.line_interaction_type
         )
         if self.transport.use_gpu:
             self.integrator = CudaFormalIntegrator(
                 self.numba_radial_1d_geometry,
                 self.numba_model,
-                self.numba_plasma,
+                self.opacity_state,
                 self.points,
             )
         else:
             self.integrator = NumbaFormalIntegrator(
                 self.numba_radial_1d_geometry,
                 self.numba_model,
-                self.numba_plasma,
+                self.opacity_state,
                 self.points,
             )
 

--- a/tardis/montecarlo/montecarlo_numba/interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/interaction.py
@@ -30,7 +30,7 @@ H = const.h.cgs.value
 
 @njit(**njit_dict_no_parallel)
 def determine_bf_macro_activation_idx(
-    numba_plasma, nu, chi_bf_contributions, active_continua
+    opacity_state, nu, chi_bf_contributions, active_continua
 ):
     """
     Determine the macro atom activation level after bound-free absorption.
@@ -56,22 +56,22 @@ def determine_bf_macro_activation_idx(
 
     # Perform a MC experiment to determine whether thermal or
     # ionization energy is created
-    nu_threshold = numba_plasma.photo_ion_nu_threshold_mins[continuum_id]
+    nu_threshold = opacity_state.photo_ion_nu_threshold_mins[continuum_id]
     fraction_ionization = nu_threshold / nu
     if (
         np.random.random() < fraction_ionization
     ):  # Create ionization energy (i-packet)
-        destination_level_idx = numba_plasma.photo_ion_activation_idx[
+        destination_level_idx = opacity_state.photo_ion_activation_idx[
             continuum_id
         ]
     else:  # Create thermal energy (k-packet)
-        destination_level_idx = numba_plasma.k_packet_idx
+        destination_level_idx = opacity_state.k_packet_idx
     return destination_level_idx
 
 
 @njit(**njit_dict_no_parallel)
 def determine_continuum_macro_activation_idx(
-    numba_plasma, nu, chi_bf, chi_ff, chi_bf_contributions, active_continua
+    opacity_state, nu, chi_bf, chi_ff, chi_bf_contributions, active_continua
 ):
     """
     Determine the macro atom activation level after a continuum absorption.
@@ -100,15 +100,15 @@ def determine_continuum_macro_activation_idx(
     # scattering event happens and need one less RNG call.
     if np.random.random() < fraction_bf:  # Bound-free absorption
         destination_level_idx = determine_bf_macro_activation_idx(
-            numba_plasma, nu, chi_bf_contributions, active_continua
+            opacity_state, nu, chi_bf_contributions, active_continua
         )
     else:  # Free-free absorption (i.e. k-packet creation)
-        destination_level_idx = numba_plasma.k_packet_idx
+        destination_level_idx = opacity_state.k_packet_idx
     return destination_level_idx
 
 
 @njit(**njit_dict_no_parallel)
-def sample_nu_free_free(numba_plasma, shell):
+def sample_nu_free_free(opacity_state, shell):
     """
     Attributes
     ----------
@@ -116,13 +116,13 @@ def sample_nu_free_free(numba_plasma, shell):
         Frequency of the free-free emission process
 
     """
-    temperature = numba_plasma.t_electrons[shell]
+    temperature = opacity_state.t_electrons[shell]
     zrand = np.random.random()
     return -K_B * temperature / H * np.log(zrand)
 
 
 @njit(**njit_dict_no_parallel)
-def sample_nu_free_bound(numba_plasma, shell, continuum_id):
+def sample_nu_free_bound(opacity_state, shell, continuum_id):
     """
     Attributes
     ----------
@@ -130,10 +130,10 @@ def sample_nu_free_bound(numba_plasma, shell, continuum_id):
         Frequency of the free-bounds emission process
     """
 
-    start = numba_plasma.photo_ion_block_references[continuum_id]
-    end = numba_plasma.photo_ion_block_references[continuum_id + 1]
-    phot_nus_block = numba_plasma.phot_nus[start:end]
-    em = numba_plasma.emissivities[start:end, shell]
+    start = opacity_state.photo_ion_block_references[continuum_id]
+    end = opacity_state.photo_ion_block_references[continuum_id + 1]
+    phot_nus_block = opacity_state.phot_nus[start:end]
+    em = opacity_state.emissivities[start:end, shell]
 
     zrand = np.random.random()
     idx = np.searchsorted(em, zrand, side="right")
@@ -147,7 +147,7 @@ def sample_nu_free_bound(numba_plasma, shell, continuum_id):
 def continuum_event(
     r_packet,
     time_explosion,
-    numba_plasma,
+    opacity_state,
     chi_bf_tot,
     chi_ff,
     chi_bf_contributions,
@@ -160,7 +160,7 @@ def continuum_event(
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     time_explosion : float
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     continuum : tardis.montecarlo.montecarlo_numba.numba_interface.Continuum
     """
     old_doppler_factor = get_doppler_factor(
@@ -179,7 +179,7 @@ def continuum_event(
     r_packet.nu = comov_nu * inverse_doppler_factor
 
     destination_level_idx = determine_continuum_macro_activation_idx(
-        numba_plasma,
+        opacity_state,
         comov_nu,
         chi_bf_tot,
         chi_ff,
@@ -188,13 +188,13 @@ def continuum_event(
     )
 
     macro_atom_event(
-        destination_level_idx, r_packet, time_explosion, numba_plasma
+        destination_level_idx, r_packet, time_explosion, opacity_state
     )
 
 
 @njit(**njit_dict_no_parallel)
 def macro_atom_event(
-    destination_level_idx, r_packet, time_explosion, numba_plasma
+    destination_level_idx, r_packet, time_explosion, opacity_state
 ):
     """
     Macroatom event handler - run the macroatom and handle the result
@@ -204,31 +204,31 @@ def macro_atom_event(
     destination_level_idx : int
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     time_explosion : float
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     """
 
     transition_id, transition_type = macro_atom(
-        destination_level_idx, r_packet.current_shell_id, numba_plasma
+        destination_level_idx, r_packet.current_shell_id, opacity_state
     )
 
     if (
         montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED
         and transition_type == MacroAtomTransitionType.FF_EMISSION
     ):
-        free_free_emission(r_packet, time_explosion, numba_plasma)
+        free_free_emission(r_packet, time_explosion, opacity_state)
 
     elif (
         montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED
         and transition_type == MacroAtomTransitionType.BF_EMISSION
     ):
         bound_free_emission(
-            r_packet, time_explosion, numba_plasma, transition_id
+            r_packet, time_explosion, opacity_state, transition_id
         )
     elif (
         montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED
         and transition_type == MacroAtomTransitionType.BF_COOLING
     ):
-        bf_cooling(r_packet, time_explosion, numba_plasma)
+        bf_cooling(r_packet, time_explosion, opacity_state)
 
     elif (
         montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED
@@ -237,13 +237,13 @@ def macro_atom_event(
         adiabatic_cooling(r_packet)
 
     elif transition_type == MacroAtomTransitionType.BB_EMISSION:
-        line_emission(r_packet, transition_id, time_explosion, numba_plasma)
+        line_emission(r_packet, transition_id, time_explosion, opacity_state)
     else:
         raise Exception("No Interaction Found!")
 
 
 @njit(**njit_dict_no_parallel)
-def bf_cooling(r_packet, time_explosion, numba_plasma):
+def bf_cooling(r_packet, time_explosion, opacity_state):
     """
     Bound-Free Cooling - Determine and run bf emission from cooling
 
@@ -251,10 +251,10 @@ def bf_cooling(r_packet, time_explosion, numba_plasma):
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     time_explosion : float
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     """
 
-    fb_cooling_prob = numba_plasma.p_fb_deactivation[
+    fb_cooling_prob = opacity_state.p_fb_deactivation[
         :, r_packet.current_shell_id
     ]
     p = fb_cooling_prob[0]
@@ -264,7 +264,7 @@ def bf_cooling(r_packet, time_explosion, numba_plasma):
         i += 1
         p += fb_cooling_prob[i]
     continuum_idx = i
-    bound_free_emission(r_packet, time_explosion, numba_plasma, continuum_idx)
+    bound_free_emission(r_packet, time_explosion, opacity_state, continuum_idx)
 
 
 @njit(**njit_dict_no_parallel)
@@ -301,7 +301,7 @@ def get_current_line_id(nu, line_list):
 
 
 @njit(**njit_dict_no_parallel)
-def free_free_emission(r_packet, time_explosion, numba_plasma):
+def free_free_emission(r_packet, time_explosion, opacity_state):
     """
     Free-Free emission - set the frequency from electron-ion interaction
 
@@ -309,15 +309,15 @@ def free_free_emission(r_packet, time_explosion, numba_plasma):
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     time_explosion : float
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     """
 
     inverse_doppler_factor = get_inverse_doppler_factor(
         r_packet.r, r_packet.mu, time_explosion
     )
-    comov_nu = sample_nu_free_free(numba_plasma, r_packet.current_shell_id)
+    comov_nu = sample_nu_free_free(opacity_state, r_packet.current_shell_id)
     r_packet.nu = comov_nu * inverse_doppler_factor
-    current_line_id = get_current_line_id(comov_nu, numba_plasma.line_list_nu)
+    current_line_id = get_current_line_id(comov_nu, opacity_state.line_list_nu)
     r_packet.next_line_id = current_line_id
 
     if montecarlo_configuration.full_relativity:
@@ -327,7 +327,7 @@ def free_free_emission(r_packet, time_explosion, numba_plasma):
 
 
 @njit(**njit_dict_no_parallel)
-def bound_free_emission(r_packet, time_explosion, numba_plasma, continuum_id):
+def bound_free_emission(r_packet, time_explosion, opacity_state, continuum_id):
     """
     Bound-Free emission - set the frequency from photo-ionization
 
@@ -335,7 +335,7 @@ def bound_free_emission(r_packet, time_explosion, numba_plasma, continuum_id):
     ----------
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     time_explosion : float
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     continuum_id : int
     """
 
@@ -344,10 +344,10 @@ def bound_free_emission(r_packet, time_explosion, numba_plasma, continuum_id):
     )
 
     comov_nu = sample_nu_free_bound(
-        numba_plasma, r_packet.current_shell_id, continuum_id
+        opacity_state, r_packet.current_shell_id, continuum_id
     )
     r_packet.nu = comov_nu * inverse_doppler_factor
-    current_line_id = get_current_line_id(comov_nu, numba_plasma.line_list_nu)
+    current_line_id = get_current_line_id(comov_nu, opacity_state.line_list_nu)
     r_packet.next_line_id = current_line_id
 
     if montecarlo_configuration.full_relativity:
@@ -394,7 +394,9 @@ def thomson_scatter(r_packet, time_explosion):
 
 
 @njit(**njit_dict_no_parallel)
-def line_scatter(r_packet, time_explosion, line_interaction_type, numba_plasma):
+def line_scatter(
+    r_packet, time_explosion, line_interaction_type, opacity_state
+):
     """
     Line scatter function that handles the scattering itself, including new angle drawn, and calculating nu out using macro atom
 
@@ -403,7 +405,7 @@ def line_scatter(r_packet, time_explosion, line_interaction_type, numba_plasma):
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     time_explosion : float
     line_interaction_type : enum
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     """
 
     old_doppler_factor = get_doppler_factor(
@@ -420,21 +422,21 @@ def line_scatter(r_packet, time_explosion, line_interaction_type, numba_plasma):
 
     if line_interaction_type == LineInteractionType.SCATTER:
         line_emission(
-            r_packet, r_packet.next_line_id, time_explosion, numba_plasma
+            r_packet, r_packet.next_line_id, time_explosion, opacity_state
         )
     else:  # includes both macro atom and downbranch - encoded in the transition probabilities
         comov_nu = r_packet.nu * old_doppler_factor  # Is this necessary?
         r_packet.nu = comov_nu * inverse_new_doppler_factor
-        activation_level_id = numba_plasma.line2macro_level_upper[
+        activation_level_id = opacity_state.line2macro_level_upper[
             r_packet.next_line_id
         ]
         macro_atom_event(
-            activation_level_id, r_packet, time_explosion, numba_plasma
+            activation_level_id, r_packet, time_explosion, opacity_state
         )
 
 
 @njit(**njit_dict_no_parallel)
-def line_emission(r_packet, emission_line_id, time_explosion, numba_plasma):
+def line_emission(r_packet, emission_line_id, time_explosion, opacity_state):
     """
     Sets the frequency of the RPacket properly given the emission channel
 
@@ -443,7 +445,7 @@ def line_emission(r_packet, emission_line_id, time_explosion, numba_plasma):
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     emission_line_id : int
     time_explosion : float
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     """
 
     r_packet.last_line_interaction_out_id = emission_line_id
@@ -455,10 +457,10 @@ def line_emission(r_packet, emission_line_id, time_explosion, numba_plasma):
         r_packet.r, r_packet.mu, time_explosion
     )
     r_packet.nu = (
-        numba_plasma.line_list_nu[emission_line_id] * inverse_doppler_factor
+        opacity_state.line_list_nu[emission_line_id] * inverse_doppler_factor
     )
     r_packet.next_line_id = emission_line_id + 1
-    nu_line = numba_plasma.line_list_nu[emission_line_id]
+    nu_line = opacity_state.line_list_nu[emission_line_id]
 
     if montecarlo_configuration.full_relativity:
         r_packet.mu = angle_aberration_CMF_to_LF(

--- a/tardis/montecarlo/montecarlo_numba/macro_atom.py
+++ b/tardis/montecarlo/montecarlo_numba/macro_atom.py
@@ -21,14 +21,14 @@ class MacroAtomTransitionType(IntEnum):
 
 
 @njit(**njit_dict_no_parallel)
-def macro_atom(activation_level_id, current_shell_id, numba_plasma):
+def macro_atom(activation_level_id, current_shell_id, opacity_state):
     """
     Parameters
     ----------
     activation_level_id : int
         Activation level idx of the macro atom.
     current_shell_id : int
-    numba_plasma : tardis.montecarlo.numba_interface.numba_plasma.NumbaPlasma
+    opacity_state : tardis.montecarlo.numba_interface.opacity_state.OpacityState
 
     Returns
     -------
@@ -38,23 +38,25 @@ def macro_atom(activation_level_id, current_shell_id, numba_plasma):
         probability = 0.0
         probability_event = np.random.random()
 
-        block_start = numba_plasma.macro_block_references[activation_level_id]
-        block_end = numba_plasma.macro_block_references[activation_level_id + 1]
+        block_start = opacity_state.macro_block_references[activation_level_id]
+        block_end = opacity_state.macro_block_references[
+            activation_level_id + 1
+        ]
 
         # looping through the transition probabilities
         for transition_id in range(block_start, block_end):
 
-            transition_probability = numba_plasma.transition_probabilities[
+            transition_probability = opacity_state.transition_probabilities[
                 transition_id, current_shell_id
             ]
 
             probability += transition_probability
 
             if probability > probability_event:
-                activation_level_id = numba_plasma.destination_level_id[
+                activation_level_id = opacity_state.destination_level_id[
                     transition_id
                 ]
-                current_transition_type = numba_plasma.transition_type[
+                current_transition_type = opacity_state.transition_type[
                     transition_id
                 ]
                 break
@@ -68,6 +70,6 @@ def macro_atom(activation_level_id, current_shell_id, numba_plasma):
 
     # current_transition_type = MacroAtomTransitionType(current_transition_type)
     return (
-        numba_plasma.transition_line_id[transition_id],
+        opacity_state.transition_line_id[transition_id],
         current_transition_type,
     )

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -32,7 +32,7 @@ class NumbaModel(object):
         self.time_explosion = time_explosion
 
 
-numba_plasma_spec = [
+opacity_state_spec = [
     ("electron_density", float64[:]),
     ("t_electrons", float64[:]),
     ("line_list_nu", float64[:]),
@@ -58,8 +58,8 @@ numba_plasma_spec = [
 ]
 
 
-@jitclass(numba_plasma_spec)
-class NumbaPlasma(object):
+@jitclass(opacity_state_spec)
+class OpacityState(object):
     def __init__(
         self,
         electron_density,
@@ -135,9 +135,9 @@ class NumbaPlasma(object):
         self.k_packet_idx = k_packet_idx
 
 
-def numba_plasma_initialize(plasma, line_interaction_type):
+def opacity_state_initialize(plasma, line_interaction_type):
     """
-    Initialize the NumbaPlasma object and copy over the data over from TARDIS Plasma
+    Initialize the OpacityState object and copy over the data over from TARDIS Plasma
 
     Parameters
     ----------
@@ -239,7 +239,7 @@ def numba_plasma_initialize(plasma, line_interaction_type):
         photo_ion_activation_idx = np.zeros(0, dtype=np.int64)
         k_packet_idx = np.int64(-1)
 
-    return NumbaPlasma(
+    return OpacityState(
         electron_densities,
         t_electrons,
         line_list_nu,

--- a/tardis/montecarlo/montecarlo_numba/r_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/r_packet.py
@@ -64,16 +64,16 @@ class RPacket(object):
         self.last_line_interaction_out_id = -1
         self.last_line_interaction_shell_id = -1
 
-    def initialize_line_id(self, numba_plasma, numba_model):
-        inverse_line_list_nu = numba_plasma.line_list_nu[::-1]
+    def initialize_line_id(self, opacity_state, numba_model):
+        inverse_line_list_nu = opacity_state.line_list_nu[::-1]
         doppler_factor = get_doppler_factor(
             self.r, self.mu, numba_model.time_explosion
         )
         comov_nu = self.nu * doppler_factor
-        next_line_id = len(numba_plasma.line_list_nu) - np.searchsorted(
+        next_line_id = len(opacity_state.line_list_nu) - np.searchsorted(
             inverse_line_list_nu, comov_nu
         )
-        if next_line_id == len(numba_plasma.line_list_nu):
+        if next_line_id == len(opacity_state.line_list_nu):
             next_line_id -= 1
         self.next_line_id = next_line_id
 

--- a/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/single_packet_loop.py
@@ -42,7 +42,7 @@ def single_packet_loop(
     r_packet,
     numba_radial_1d_geometry,
     numba_model,
-    numba_plasma,
+    opacity_state,
     estimators,
     vpacket_collection,
     rpacket_tracker,
@@ -53,7 +53,7 @@ def single_packet_loop(
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     numba_radial_1d_geometry : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaRadial1DGeometry
     numba_model : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaModel
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     estimators : tardis.montecarlo.montecarlo_numba.numba_interface.Estimators
     vpacket_collection : tardis.montecarlo.montecarlo_numba.numba_interface.VPacketCollection
     rpacket_collection : tardis.montecarlo.montecarlo_numba.numba_interface.RPacketCollection
@@ -70,14 +70,14 @@ def single_packet_loop(
         set_packet_props_full_relativity(r_packet, numba_model)
     else:
         set_packet_props_partial_relativity(r_packet, numba_model)
-    r_packet.initialize_line_id(numba_plasma, numba_model)
+    r_packet.initialize_line_id(opacity_state, numba_model)
 
     trace_vpacket_volley(
         r_packet,
         vpacket_collection,
         numba_radial_1d_geometry,
         numba_model,
-        numba_plasma,
+        opacity_state,
     )
 
     if montecarlo_configuration.RPACKET_TRACKING:
@@ -92,7 +92,7 @@ def single_packet_loop(
         )
         comov_nu = r_packet.nu * doppler_factor
         chi_e = chi_electron_calculator(
-            numba_plasma, comov_nu, r_packet.current_shell_id
+            opacity_state, comov_nu, r_packet.current_shell_id
         )
         if montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED:
             (
@@ -102,7 +102,7 @@ def single_packet_loop(
                 x_sect_bfs,
                 chi_ff,
             ) = chi_continuum_calculator(
-                numba_plasma, comov_nu, r_packet.current_shell_id
+                opacity_state, comov_nu, r_packet.current_shell_id
             )
             chi_continuum = chi_e + chi_bf_tot + chi_ff
 
@@ -113,7 +113,7 @@ def single_packet_loop(
                 r_packet,
                 numba_radial_1d_geometry,
                 numba_model,
-                numba_plasma,
+                opacity_state,
                 estimators,
                 chi_continuum,
                 escat_prob,
@@ -124,10 +124,10 @@ def single_packet_loop(
                 r_packet.current_shell_id,
                 distance,
                 estimators,
-                numba_plasma.t_electrons[r_packet.current_shell_id],
+                opacity_state.t_electrons[r_packet.current_shell_id],
                 x_sect_bfs,
                 current_continua,
-                numba_plasma.bf_threshold_list_nu,
+                opacity_state.bf_threshold_list_nu,
             )
         else:
             escat_prob = 1.0
@@ -138,7 +138,7 @@ def single_packet_loop(
                 r_packet,
                 numba_radial_1d_geometry,
                 numba_model,
-                numba_plasma,
+                opacity_state,
                 estimators,
                 chi_continuum,
                 escat_prob,
@@ -163,14 +163,14 @@ def single_packet_loop(
                 r_packet,
                 numba_model.time_explosion,
                 line_interaction_type,
-                numba_plasma,
+                opacity_state,
             )
             trace_vpacket_volley(
                 r_packet,
                 vpacket_collection,
                 numba_radial_1d_geometry,
                 numba_model,
-                numba_plasma,
+                opacity_state,
             )
 
         elif interaction_type == InteractionType.ESCATTERING:
@@ -186,7 +186,7 @@ def single_packet_loop(
                 vpacket_collection,
                 numba_radial_1d_geometry,
                 numba_model,
-                numba_plasma,
+                opacity_state,
             )
         elif (
             montecarlo_configuration.CONTINUUM_PROCESSES_ENABLED
@@ -199,7 +199,7 @@ def single_packet_loop(
             continuum_event(
                 r_packet,
                 numba_model.time_explosion,
-                numba_plasma,
+                opacity_state,
                 chi_bf_tot,
                 chi_ff,
                 chi_bf_contributions,
@@ -211,7 +211,7 @@ def single_packet_loop(
                 vpacket_collection,
                 numba_radial_1d_geometry,
                 numba_model,
-                numba_plasma,
+                opacity_state,
             )
         else:
             pass

--- a/tardis/montecarlo/montecarlo_numba/tests/conftest.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/conftest.py
@@ -10,7 +10,7 @@ from tardis.montecarlo.montecarlo_numba.numba_interface import Estimators
 
 
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
-    numba_plasma_initialize,
+    opacity_state_initialize,
     NumbaModel,
     Estimators,
     VPacketCollection,
@@ -26,8 +26,8 @@ def nb_simulation_verysimple(config_verysimple, atomic_dataset):
 
 
 @pytest.fixture(scope="package")
-def verysimple_numba_plasma(nb_simulation_verysimple):
-    return numba_plasma_initialize(
+def verysimple_opacity_state(nb_simulation_verysimple):
+    return opacity_state_initialize(
         nb_simulation_verysimple.plasma, line_interaction_type="macroatom"
     )
 

--- a/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_cuda_formal_integral.py
@@ -258,7 +258,7 @@ def test_calculate_p_values(N):
     not GPUs_available, reason="No GPU is available to test CUDA function"
 )
 @pytest.mark.parametrize("nu_insert", np.linspace(3e12, 3e16, 10))
-def test_line_search_cuda(nu_insert, verysimple_numba_plasma):
+def test_line_search_cuda(nu_insert, verysimple_opacity_state):
     """
     Initializes the test of the cuda version
     against the numba implementation of the
@@ -266,7 +266,7 @@ def test_line_search_cuda(nu_insert, verysimple_numba_plasma):
     """
     actual = np.zeros(1)
     expected = np.zeros(1)
-    line_list_nu = verysimple_numba_plasma.line_list_nu
+    line_list_nu = verysimple_opacity_state.line_list_nu
 
     expected[0] = formal_integral_numba.line_search(
         line_list_nu, nu_insert, len(line_list_nu)
@@ -295,7 +295,7 @@ def line_search_cuda_caller(line_list_nu, nu_insert, actual):
 @pytest.mark.parametrize(
     "nu_insert", [*np.linspace(3e12, 3e16, 10), 288786721666522.1]
 )
-def test_reverse_binary_search(nu_insert, verysimple_numba_plasma):
+def test_reverse_binary_search(nu_insert, verysimple_opacity_state):
     """
     Initializes the test of the cuda version
     against the numba implementation of the
@@ -304,7 +304,7 @@ def test_reverse_binary_search(nu_insert, verysimple_numba_plasma):
     """
     actual = np.zeros(1)
     expected = np.zeros(1)
-    line_list_nu = verysimple_numba_plasma.line_list_nu
+    line_list_nu = verysimple_opacity_state.line_list_nu
 
     imin = 0
     imax = len(line_list_nu) - 1
@@ -382,7 +382,7 @@ def test_full_formal_integral(
     formal_integrator_numba.integrator = NumbaFormalIntegrator(
         formal_integrator_numba.numba_radial_1d_geometry,
         formal_integrator_numba.numba_model,
-        formal_integrator_numba.numba_plasma,
+        formal_integrator_numba.opacity_state,
         formal_integrator_numba.points,
     )
 

--- a/tardis/montecarlo/montecarlo_numba/tests/test_interaction.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_interaction.py
@@ -32,16 +32,16 @@ def test_line_scatter(
     line_interaction_type,
     packet,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
 ):
     init_mu = packet.mu
     init_nu = packet.nu
     init_energy = packet.energy
-    packet.initialize_line_id(verysimple_numba_plasma, verysimple_numba_model)
+    packet.initialize_line_id(verysimple_opacity_state, verysimple_numba_model)
     time_explosion = verysimple_numba_model.time_explosion
 
     interaction.line_scatter(
-        packet, time_explosion, line_interaction_type, verysimple_numba_plasma
+        packet, time_explosion, line_interaction_type, verysimple_opacity_state
     )
 
     assert np.abs(packet.mu - init_mu) > 1e-7
@@ -82,19 +82,19 @@ def test_line_scatter(
 def test_line_emission(
     packet,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
     test_packet,
     expected,
 ):
     emission_line_id = test_packet["emission_line_id"]
     packet.mu = test_packet["mu"]
     packet.energy = test_packet["energy"]
-    packet.initialize_line_id(verysimple_numba_plasma, verysimple_numba_model)
+    packet.initialize_line_id(verysimple_opacity_state, verysimple_numba_model)
 
     time_explosion = verysimple_numba_model.time_explosion
 
     interaction.line_emission(
-        packet, emission_line_id, time_explosion, verysimple_numba_plasma
+        packet, emission_line_id, time_explosion, verysimple_opacity_state
     )
 
     assert packet.next_line_id == emission_line_id + 1

--- a/tardis/montecarlo/montecarlo_numba/tests/test_macro_atom.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_macro_atom.py
@@ -9,7 +9,7 @@ import numpy as np
 )
 def test_macro_atom(
     static_packet,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
     verysimple_numba_model,
     set_seed_fixture,
     seed,
@@ -17,15 +17,15 @@ def test_macro_atom(
 ):
     set_seed_fixture(seed)
     static_packet.initialize_line_id(
-        verysimple_numba_plasma, verysimple_numba_model
+        verysimple_opacity_state, verysimple_numba_model
     )
-    activation_level_id = verysimple_numba_plasma.line2macro_level_upper[
+    activation_level_id = verysimple_opacity_state.line2macro_level_upper[
         static_packet.next_line_id
     ]
     result, transition_type = macro_atom.macro_atom(
         activation_level_id,
         static_packet.current_shell_id,
-        verysimple_numba_plasma,
+        verysimple_opacity_state,
     )
     assert result == expected
     assert transition_type == -1  # line transition

--- a/tardis/montecarlo/montecarlo_numba/tests/test_numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_numba_interface.py
@@ -5,10 +5,10 @@ import numpy as np
 
 
 @pytest.mark.parametrize("input_params", ["scatter", "macroatom", "downbranch"])
-def test_numba_plasma_initialize(nb_simulation_verysimple, input_params):
+def test_opacity_state_initialize(nb_simulation_verysimple, input_params):
     line_interaction_type = input_params
     plasma = nb_simulation_verysimple.plasma
-    actual = numba_interface.numba_plasma_initialize(
+    actual = numba_interface.opacity_state_initialize(
         plasma, line_interaction_type
     )
 

--- a/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
@@ -268,17 +268,17 @@ def test_update_line_estimators(
 def test_trace_packet(
     packet,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
     verysimple_estimators,
     set_seed_fixture,
 ):
 
     set_seed_fixture(1963)
-    packet.initialize_line_id(verysimple_numba_plasma, verysimple_numba_model)
+    packet.initialize_line_id(verysimple_opacity_state, verysimple_numba_model)
     distance, interaction_type, delta_shell = r_packet_transport.trace_packet(
         packet,
         verysimple_numba_model,
-        verysimple_numba_plasma,
+        verysimple_opacity_state,
         verysimple_estimators,
     )
 

--- a/tardis/montecarlo/montecarlo_numba/tests/test_single_packet_loop.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_single_packet_loop.py
@@ -13,7 +13,7 @@ from tardis.montecarlo.montecarlo_numba.single_packet_loop import (
 def test_verysimple_single_packet_loop(
     verysimple_numba_radial_1d_geometry,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
     verysimple_estimators,
     verysimple_vpacket_collection,
     verysimple_packet_collection,
@@ -22,7 +22,7 @@ def test_verysimple_single_packet_loop(
     packet_collection = verysimple_packet_collection
     vpacket_collection = verysimple_vpacket_collection
     numba_model = verysimple_numba_model
-    numba_plasma = verysimple_numba_plasma
+    opacity_state = verysimple_opacity_state
     numba_estimators = verysimple_estimators
 
     i = 0
@@ -37,7 +37,7 @@ def test_verysimple_single_packet_loop(
         r_packet,
         numba_radial_1d_geometry,
         numba_model,
-        numba_plasma,
+        opacity_state,
         numba_estimators,
         vpacket_collection,
     )

--- a/tardis/montecarlo/montecarlo_numba/tests/test_vpacket.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_vpacket.py
@@ -31,13 +31,13 @@ def v_packet():
     )
 
 
-def v_packet_initialize_line_id(v_packet, numba_plasma, numba_model):
-    inverse_line_list_nu = numba_plasma.line_list_nu[::-1]
+def v_packet_initialize_line_id(v_packet, opacity_state, numba_model):
+    inverse_line_list_nu = opacity_state.line_list_nu[::-1]
     doppler_factor = get_doppler_factor(
         v_packet.r, v_packet.mu, numba_model.time_explosion
     )
     comov_nu = v_packet.nu * doppler_factor
-    next_line_id = len(numba_plasma.line_list_nu) - np.searchsorted(
+    next_line_id = len(opacity_state.line_list_nu) - np.searchsorted(
         inverse_line_list_nu, comov_nu
     )
     v_packet.next_line_id = next_line_id
@@ -47,11 +47,11 @@ def test_trace_vpacket_within_shell(
     v_packet,
     verysimple_numba_radial_1d_geometry,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
 ):
     # Give the vpacket a reasonable line ID
     v_packet_initialize_line_id(
-        v_packet, verysimple_numba_plasma, verysimple_numba_model
+        v_packet, verysimple_opacity_state, verysimple_numba_model
     )
 
     (
@@ -62,7 +62,7 @@ def test_trace_vpacket_within_shell(
         v_packet,
         verysimple_numba_radial_1d_geometry,
         verysimple_numba_model,
-        verysimple_numba_plasma,
+        verysimple_opacity_state,
     )
 
     npt.assert_almost_equal(tau_trace_combined, 8164850.891288479)
@@ -74,21 +74,21 @@ def test_trace_vpacket(
     v_packet,
     verysimple_numba_radial_1d_geometry,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
 ):
     # Set seed because of RNG in trace_vpacket
     np.random.seed(1)
 
     # Give the vpacket a reasonable line ID
     v_packet_initialize_line_id(
-        v_packet, verysimple_numba_plasma, verysimple_numba_model
+        v_packet, verysimple_opacity_state, verysimple_numba_model
     )
 
     tau_trace_combined = vpacket.trace_vpacket(
         v_packet,
         verysimple_numba_radial_1d_geometry,
         verysimple_numba_model,
-        verysimple_numba_plasma,
+        verysimple_opacity_state,
     )
 
     npt.assert_almost_equal(tau_trace_combined, 8164850.891288479)
@@ -108,19 +108,19 @@ def test_trace_vpacket_volley(
     verysimple_3vpacket_collection,
     verysimple_numba_radial_1d_geometry,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
 ):
     # Set seed because of RNG in trace_vpacket
     np.random.seed(1)
 
-    packet.initialize_line_id(verysimple_numba_plasma, verysimple_numba_model)
+    packet.initialize_line_id(verysimple_opacity_state, verysimple_numba_model)
 
     vpacket.trace_vpacket_volley(
         packet,
         verysimple_3vpacket_collection,
         verysimple_numba_radial_1d_geometry,
         verysimple_numba_model,
-        verysimple_numba_plasma,
+        verysimple_opacity_state,
     )
 
 
@@ -141,11 +141,11 @@ def test_trace_bad_vpacket(
     broken_packet,
     verysimple_numba_radial_1d_geometry,
     verysimple_numba_model,
-    verysimple_numba_plasma,
+    verysimple_opacity_state,
 ):
     vpacket.trace_vpacket(
         broken_packet,
         verysimple_numba_radial_1d_geometry,
         verysimple_numba_model,
-        verysimple_numba_plasma,
+        verysimple_opacity_state,
     )

--- a/tardis/transport/r_packet_transport.py
+++ b/tardis/transport/r_packet_transport.py
@@ -28,7 +28,7 @@ def trace_packet(
     r_packet,
     numba_radial_1d_geometry,
     numba_model,
-    numba_plasma,
+    opacity_state,
     estimators,
     chi_continuum,
     escat_prob,
@@ -41,7 +41,7 @@ def trace_packet(
     r_packet : tardis.montecarlo.montecarlo_numba.r_packet.RPacket
     numba_radial_1d_geometry : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaRadial1DGeometry
     numba_model : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaModel
-    numba_plasma : tardis.montecarlo.montecarlo_numba.numba_interface.NumbaPlasma
+    opacity_state : tardis.montecarlo.montecarlo_numba.numba_interface.OpacityState
     estimators : tardis.montecarlo.montecarlo_numba.numba_interface.Estimators
 
     Returns
@@ -72,13 +72,13 @@ def trace_packet(
     distance_continuum = tau_event / chi_continuum
     cur_line_id = start_line_id  # initializing varibale for Numba
     # - do not remove
-    last_line_id = len(numba_plasma.line_list_nu) - 1
-    for cur_line_id in range(start_line_id, len(numba_plasma.line_list_nu)):
+    last_line_id = len(opacity_state.line_list_nu) - 1
+    for cur_line_id in range(start_line_id, len(opacity_state.line_list_nu)):
         # Going through the lines
-        nu_line = numba_plasma.line_list_nu[cur_line_id]
+        nu_line = opacity_state.line_list_nu[cur_line_id]
 
         # Getting the tau for the next line
-        tau_trace_line = numba_plasma.tau_sobolev[
+        tau_trace_line = opacity_state.tau_sobolev[
             cur_line_id, r_packet.current_shell_id
         ]
 
@@ -158,7 +158,7 @@ def trace_packet(
     else:  # Executed when no break occurs in the for loop
         # We are beyond the line list now and the only next thing is to see
         # if we are interacting with the boundary or electron scattering
-        if cur_line_id == (len(numba_plasma.line_list_nu) - 1):
+        if cur_line_id == (len(opacity_state.line_list_nu) - 1):
             # Treatment for last line
             cur_line_id += 1
         if distance_continuum < distance_boundary:


### PR DESCRIPTION
Including places where it is referred to as numba_plasma

### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

The NumbaPlasma is effectively the OpacityState that contains a great deal of information regarding sources of opacity. This is a basic rename.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
