### PR TITLE
Prevent empty convergence plot Error when n_iteration=1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -95,6 +95,8 @@ Jenny Yu <yuyizh1112@gmail.com>
 Jenny Yu <yuyizh1112@gmail.com> yuyizh <yuyizh1112@gmail.com>
 Jenny Yu <yuyizh1112@gmail.com> Jenny Yu <80535029+yuyizheng1112@users.noreply.github.com>
 
+Jing Lu <lujingeve158@gmail.com>
+
 John Reichenbach <56849859+jreichenbach-msu@users.noreply.github.com>
 
 Jordi Eguren <jordi.eguren.brown@gmail.com>

--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -424,7 +424,7 @@ class ConvergencePlots(object):
 
         # the display function expects a Widget, while
         # fig.show() returns None, which causes the TraitError.
-        if export_convergence_plots:
+        if export_convergence_plots and (self.plasma_plot is not None):
             with suppress(TraitError):
                 display(
                     widgets.VBox(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

When running a tardis simulation with `n_iteration =1` in the config file and `export_convergence_plots=True`, the simulation can be successfully returned due to an error that caused by a empty plot in the convergence_plots.  

Hence, adding an argument to check if the plots inside simulation.convergence_plots is empty before export the convergence_plot.

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
