### PR TITLE
Adding doppler factor function for nonhomologous expansion

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
+++ b/tardis/montecarlo/montecarlo_numba/tests/test_packet.py
@@ -177,6 +177,19 @@ def test_get_doppler_factor(mu, r, inv_t_exp, expected):
 
 
 @pytest.mark.parametrize(
+    ["v", "mu", "expected"],
+    [
+        (1.4e7, 0.3, 0.999859903),
+        (0.0, -0.3, 1.0),
+        (1 / 2.6e7, 0, 1.0),
+    ],
+)
+def test_get_doppler_factor_nonhomologous(v, mu, expected):
+    obtained = frame_transformations.get_doppler_factor_nonhomologous(v, mu)
+    assert_almost_equal(obtained, expected)
+
+
+@pytest.mark.parametrize(
     ["mu", "r", "inv_t_exp", "expected"],
     [
         (0.3, 7.5e14, 1 / 5.2e7, 1 / 0.9998556693818854),
@@ -197,6 +210,21 @@ def test_get_inverse_doppler_factor(mu, r, inv_t_exp, expected):
     )
 
     # Perform required assertions
+    assert_almost_equal(obtained, expected)
+
+
+@pytest.mark.parametrize(
+    ["v", "mu", "expected"],
+    [
+        (1.4e7, 0.3, 1 / 0.999859903),
+        (0.0, -0.3, 1.0),
+        (1 / 2.6e7, 0, 1.0),
+    ],
+)
+def test_get_inverse_doppler_factor_nonhomologous(v, mu, expected):
+    obtained = frame_transformations.get_inverse_doppler_factor_nonhomologous(
+        v, mu
+    )
     assert_almost_equal(obtained, expected)
 
 

--- a/tardis/transport/frame_transformations.py
+++ b/tardis/transport/frame_transformations.py
@@ -7,6 +7,7 @@ from tardis.montecarlo.montecarlo_numba import (
 )
 
 from tardis.montecarlo.montecarlo_numba import numba_config as nc
+from tardis.montecarlo.montecarlo_numba.nonhomologous_grid import velocity_dvdr
 from tardis.montecarlo.montecarlo_numba.numba_config import C_SPEED_OF_LIGHT
 
 
@@ -29,6 +30,23 @@ def get_doppler_factor_partial_relativity(mu, beta):
 @njit(**njit_dict_no_parallel)
 def get_doppler_factor_full_relativity(mu, beta):
     return (1.0 - mu * beta) / math.sqrt(1 - beta * beta)
+
+@njit(**njit_dict_no_parallel)
+def get_doppler_factor_nonhomologous(v, mu):
+    """
+    Calculate the doppler factor(nonhomologous expansion)
+
+    Parameters
+    ----------
+    v : float
+    mu : float
+    """
+    inv_c = 1 / C_SPEED_OF_LIGHT
+    beta = v * inv_c
+    if not nc.ENABLE_FULL_RELATIVITY:
+        return get_doppler_factor_partial_relativity(mu, beta)
+    else:
+        return get_doppler_factor_full_relativity(mu, beta)
 
 
 @njit(**njit_dict_no_parallel)
@@ -59,6 +77,23 @@ def get_inverse_doppler_factor_partial_relativity(mu, beta):
 @njit(**njit_dict_no_parallel)
 def get_inverse_doppler_factor_full_relativity(mu, beta):
     return (1.0 + mu * beta) / math.sqrt(1 - beta * beta)
+
+@njit(**njit_dict_no_parallel)
+def get_inverse_doppler_factor_nonhomologous(v, mu):
+    """
+    Calculate the inverse doppler factor(nonhomologous expansion)
+
+    Parameters
+    ----------
+    v : float
+    mu : float
+    """
+    inv_c = 1 / C_SPEED_OF_LIGHT
+    beta = v * inv_c
+    if not nc.ENABLE_FULL_RELATIVITY:
+        return get_inverse_doppler_factor_partial_relativity(mu, beta)
+    else:
+        return get_inverse_doppler_factor_full_relativity(mu, beta)
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/transport/frame_transformations.py
+++ b/tardis/transport/frame_transformations.py
@@ -31,6 +31,7 @@ def get_doppler_factor_partial_relativity(mu, beta):
 def get_doppler_factor_full_relativity(mu, beta):
     return (1.0 - mu * beta) / math.sqrt(1 - beta * beta)
 
+
 @njit(**njit_dict_no_parallel)
 def get_doppler_factor_nonhomologous(v, mu):
     """
@@ -77,6 +78,7 @@ def get_inverse_doppler_factor_partial_relativity(mu, beta):
 @njit(**njit_dict_no_parallel)
 def get_inverse_doppler_factor_full_relativity(mu, beta):
     return (1.0 + mu * beta) / math.sqrt(1 - beta * beta)
+
 
 @njit(**njit_dict_no_parallel)
 def get_inverse_doppler_factor_nonhomologous(v, mu):

--- a/tardis/transport/frame_transformations.py
+++ b/tardis/transport/frame_transformations.py
@@ -41,6 +41,11 @@ def get_doppler_factor_nonhomologous(v, mu):
     ----------
     v : float
     mu : float
+
+    Returns
+    -------
+    float
+        Doppler factor for velocity v at angle mu
     """
     inv_c = 1 / C_SPEED_OF_LIGHT
     beta = v * inv_c
@@ -89,6 +94,11 @@ def get_inverse_doppler_factor_nonhomologous(v, mu):
     ----------
     v : float
     mu : float
+
+    Returns
+    -------
+    float
+        Inverse doppler factor for velocity v at angle mu
     """
     inv_c = 1 / C_SPEED_OF_LIGHT
     beta = v * inv_c


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Adding an alternative version of doppler factor that uses v and mu instead of r, mu and t_exp. This will be used in the nonhomologous expansion case.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
