### PR TITLE
Fixing the shape of the solution vector to be accurate in NLTE excitation treatment

### DIFF
--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -671,14 +671,15 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         """Block of the solution vector for the current atomic number.
 
         Block for the solution vector has the form (0, 0, ..., 0, number_density).
-        Length is equal to atomic_number+1.
+        Length is equal to the number of present ions and number of
+        levels, if treated with NLTE excitation.
 
         Parameters
         ----------
         number_density : float
             Number density of the current atomic number.
         needed_number_of_elements : int
-            Number of needed elements for current atomic number.
+            Number of needed elements in the solution vector for current atomic number.
 
         Returns
         -------
@@ -697,6 +698,8 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         ----------
         number_density : pandas.DataFrame
             Number densities of all present species.
+        rate_matrix_index : pandas.MultiIndex
+            (atomic_number, ion_number, treatment type)
 
         Returns
         -------
@@ -706,10 +709,10 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         atomic_numbers = number_density.index
         solution_array = []
         for atomic_number in atomic_numbers:
-            needed_number_of_elements = rate_matrix_index[
+            needed_number_of_elements = (
                 rate_matrix_index.get_level_values("atomic_number")
                 == atomic_number
-            ].size
+            ).sum()
             solution_array.append(
                 self.solution_vector_block(
                     number_density.loc[atomic_number],

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -667,7 +667,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
             jacobian_matrix,
         )
 
-    def solution_vector_block(self, number_density, needed_number):
+    def solution_vector_block(self, number_density, needed_number_of_elements):
         """Block of the solution vector for the current atomic number.
 
         Block for the solution vector has the form (0, 0, ..., 0, number_density).
@@ -677,7 +677,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         ----------
         number_density : float
             Number density of the current atomic number.
-        needed_number : int
+        needed_number_of_elements : int
             Number of needed elements for current atomic number.
 
         Returns
@@ -685,7 +685,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         numpy.array
             Block of the solution vector corresponding to the current atomic number.
         """
-        solution_vector = np.zeros(needed_number)
+        solution_vector = np.zeros(needed_number_of_elements)
         solution_vector[-1] = number_density
         return solution_vector
 

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -668,7 +668,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         )
 
     def solution_vector_block(
-        self, atomic_number, number_density, rate_matrix_index
+        self, atomic_number, number_density, needed_number
     ):
         """Block of the solution vector for the current atomic number.
 
@@ -687,7 +687,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         numpy.array
             Block of the solution vector corresponding to the current atomic number.
         """
-        solution_vector = pd.Series(0.0, index=rate_matrix_index).values
+        solution_vector = np.zeros(needed_number)
         solution_vector[-1] = number_density
         return solution_vector
 
@@ -708,15 +708,15 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         atomic_numbers = number_density.index
         solution_array = []
         for atomic_number in atomic_numbers:
-            atomic_number_rate_matrix_index = rate_matrix_index[
+            needed_number_of_elements = rate_matrix_index[
                 rate_matrix_index.get_level_values("atomic_number")
                 == atomic_number
-            ]
+            ].size
             solution_array.append(
                 self.solution_vector_block(
                     atomic_number,
                     number_density.loc[atomic_number],
-                    atomic_number_rate_matrix_index,
+                    needed_number_of_elements,
                 )
             )
         solution_vector = np.hstack(solution_array + [0])

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -101,7 +101,8 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
 
         for shell in phi.columns:
             solution_vector = self.prepare_solution_vector(
-                number_density[shell], rate_matrix_index,
+                number_density[shell],
+                rate_matrix_index,
             )
             first_guess = self.prepare_first_guess(
                 rate_matrix_index,
@@ -666,7 +667,9 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
             jacobian_matrix,
         )
 
-    def solution_vector_block(self, atomic_number, number_density, rate_matrix_index):
+    def solution_vector_block(
+        self, atomic_number, number_density, rate_matrix_index
+    ):
         """Block of the solution vector for the current atomic number.
 
         Block for the solution vector has the form (0, 0, ..., 0, number_density).
@@ -705,10 +708,15 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         atomic_numbers = number_density.index
         solution_array = []
         for atomic_number in atomic_numbers:
-            atomic_number_rate_matrix_index = rate_matrix_index[rate_matrix_index.get_level_values("atomic_number")==atomic_number]
+            atomic_number_rate_matrix_index = rate_matrix_index[
+                rate_matrix_index.get_level_values("atomic_number")
+                == atomic_number
+            ]
             solution_array.append(
                 self.solution_vector_block(
-                    atomic_number, number_density.loc[atomic_number], atomic_number_rate_matrix_index,
+                    atomic_number,
+                    number_density.loc[atomic_number],
+                    atomic_number_rate_matrix_index,
                 )
             )
         solution_vector = np.hstack(solution_array + [0])

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -667,9 +667,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
             jacobian_matrix,
         )
 
-    def solution_vector_block(
-        self, number_density, needed_number
-    ):
+    def solution_vector_block(self, number_density, needed_number):
         """Block of the solution vector for the current atomic number.
 
         Block for the solution vector has the form (0, 0, ..., 0, number_density).

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -101,7 +101,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
 
         for shell in phi.columns:
             solution_vector = self.prepare_solution_vector(
-                number_density[shell]
+                number_density[shell], rate_matrix_index,
             )
             first_guess = self.prepare_first_guess(
                 rate_matrix_index,
@@ -666,7 +666,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
             jacobian_matrix,
         )
 
-    def solution_vector_block(self, atomic_number, number_density):
+    def solution_vector_block(self, atomic_number, number_density, rate_matrix_index):
         """Block of the solution vector for the current atomic number.
 
         Block for the solution vector has the form (0, 0, ..., 0, number_density).
@@ -684,11 +684,11 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         numpy.array
             Block of the solution vector corresponding to the current atomic number.
         """
-        solution_vector = np.zeros(atomic_number + 1)
+        solution_vector = pd.Series(0.0, index=rate_matrix_index).values
         solution_vector[-1] = number_density
         return solution_vector
 
-    def prepare_solution_vector(self, number_density):
+    def prepare_solution_vector(self, number_density, rate_matrix_index):
         """Constructs the solution vector for the NLTE ionization solver set of equations by combining
         all solution verctor blocks.
 
@@ -705,9 +705,10 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         atomic_numbers = number_density.index
         solution_array = []
         for atomic_number in atomic_numbers:
+            atomic_number_rate_matrix_index = rate_matrix_index[rate_matrix_index.get_level_values("atomic_number")==atomic_number]
             solution_array.append(
                 self.solution_vector_block(
-                    atomic_number, number_density.loc[atomic_number]
+                    atomic_number, number_density.loc[atomic_number], atomic_number_rate_matrix_index,
                 )
             )
         solution_vector = np.hstack(solution_array + [0])

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -668,7 +668,7 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
         )
 
     def solution_vector_block(
-        self, atomic_number, number_density, needed_number
+        self, number_density, needed_number
     ):
         """Block of the solution vector for the current atomic number.
 
@@ -677,10 +677,10 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
 
         Parameters
         ----------
-        atomic_number : int
-            Current atomic number.
         number_density : float
             Number density of the current atomic number.
+        needed_number : int
+            Number of needed elements for current atomic number.
 
         Returns
         -------
@@ -714,7 +714,6 @@ class NLTERateEquationSolver(ProcessingPlasmaProperty):
             ].size
             solution_array.append(
                 self.solution_vector_block(
-                    atomic_number,
                     number_density.loc[atomic_number],
                     needed_number_of_elements,
                 )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR makes sure that the solution vector shape for the NLTE solver is general enough to be used in NLTE excitation treatment.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
