### PR TITLE
`asv run` continue on error

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -71,6 +71,7 @@ jobs:
       
       - name: Run benchmarks for last 5 commits if not PR
         if: github.event_name != 'pull_request_target'
+        continue-on-error: true
         run: |
           git log -n 5  --pretty=format:"%H" >> tag_commits.txt
           asv run HASHFILE:tag_commits.txt | tee asv-output.log  


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :vertical_traffic_light: `testing` |  :roller_coaster: `infrastructure`

`asv run` doesn't work if all the commits pass. This should still build the asv website even if some of the benchmarks fail.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
