### PR TITLE
Reading fully ionized species with species_string_to_tuple

### DIFF
--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -389,7 +389,7 @@ def species_string_to_tuple(species_string):
                 f"Given ion number ('{ion_number_string}') could not be parsed"
             )
 
-    if ion_number-1 > atomic_number:
+    if ion_number - 1 > atomic_number:
         raise ValueError(
             "Species given does not exist: ion number > atomic number"
         )

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -389,7 +389,7 @@ def species_string_to_tuple(species_string):
                 f"Given ion number ('{ion_number_string}') could not be parsed"
             )
 
-    if ion_number > atomic_number:
+    if ion_number-1 > atomic_number:
         raise ValueError(
             "Species given does not exist: ion number > atomic number"
         )


### PR DESCRIPTION


### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

`species_string_to_tuple` can't read species where ion number is equal to atomic number (screenshot below). This PR fixes that
![Screen Shot 2023-08-29 at 2 25 07 PM](https://github.com/tardis-sn/tardis/assets/24611712/2d6ce4ad-dae1-4b12-8113-ee81c8a51dc5)



Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
