### PR TITLE
Pin Sphinx to <= 7.1

### DIFF
--- a/tardis_env3.yml
+++ b/tardis_env3.yml
@@ -47,7 +47,7 @@ dependencies:
   - lxml
 
   # Documentation
-  - sphinx
+  - sphinx <=7.1
   - sphinx-astropy
   - sphinx_bootstrap_theme
   - sphinx-jsonschema


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :biohazard: `breaking change` |  :memo: `documentation` | :roller_coaster: `infrastructure`

Pin sphinx to <=7.1 because it dropped support for Python 3.8 in 7.2 release.



### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
