### PR TITLE
Allow Simulation Tests to Run Independently 

### DIFF
--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -4,33 +4,37 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tardis.montecarlo.packet_source import BlackBodySimpleSource
+from tardis.montecarlo.packet_source import BlackBodySimpleSource, BasePacketSource
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
 
+class TestPacketSource():
+    @pytest.fixture(scope="class")
+    def packet_unit_test_fpath(self, tardis_ref_path):
+        return os.path.abspath(os.path.join(tardis_ref_path, "packet_unittest.h5"))
 
-@pytest.fixture
-def packet_unit_test_fpath(tardis_ref_path):
-    return os.path.abspath(os.path.join(tardis_ref_path, "packet_unittest.h5"))
+    @pytest.fixture(scope="class")
+    def blackbodysimplesource(self, request):
+        cls = type(self)
+        montecarlo_configuration.LEGACY_MODE_ENABLED = True
+        cls.bb = BlackBodySimpleSource(base_seed=1963, legacy_second_seed=2508)
+        yield cls.bb
+        montecarlo_configuration.LEGACY_MODE_ENABLED = False
 
+    def test_bb_packet_sampling(self, request, tardis_ref_data, packet_unit_test_fpath, blackbodysimplesource):
+        if request.config.getoption("--generate-reference"):
+            ref_bb = pd.read_hdf(packet_unit_test_fpath, key="/blackbody")
+            ref_bb.to_hdf(
+                tardis_ref_data, key="/packet_unittest/blackbody", mode="a"
+            )
+            pytest.skip("Reference data was generated during this run.")
 
-def test_bb_packet_sampling(request, tardis_ref_data, packet_unit_test_fpath):
-    montecarlo_configuration.LEGACY_MODE_ENABLED = True
-    bb = BlackBodySimpleSource(base_seed=1963, legacy_second_seed=2508)
-    # ref_df = pd.read_hdf('test_bb_sampling.h5')
-    if request.config.getoption("--generate-reference"):
-        ref_bb = pd.read_hdf(packet_unit_test_fpath, key="/blackbody")
-        ref_bb.to_hdf(
-            tardis_ref_data, key="/packet_unittest/blackbody", mode="a"
-        )
-        pytest.skip("Reference data was generated during this run.")
-
-    ref_df = tardis_ref_data["/packet_unittest/blackbody"]
-    bb.temperature = 10000
-    nus = bb.create_packet_nus(100)
-    mus = bb.create_packet_mus(100)
-    unif_energies = bb.create_packet_energies(100)
-    assert np.all(np.isclose(nus, ref_df["nus"]))
-    assert np.all(np.isclose(mus, ref_df["mus"]))
-    assert np.all(np.isclose(unif_energies, ref_df["energies"]))
+        ref_df = tardis_ref_data["/packet_unittest/blackbody"]
+        self.bb.temperature = 10000
+        nus = self.bb.create_packet_nus(100)
+        mus = self.bb.create_packet_mus(100)
+        unif_energies = self.bb.create_packet_energies(100)
+        assert np.all(np.isclose(nus, ref_df["nus"]))
+        assert np.all(np.isclose(mus, ref_df["mus"]))
+        assert np.all(np.isclose(unif_energies, ref_df["energies"]))

--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -13,12 +13,30 @@ from tardis.montecarlo import (
 class TestPacketSource:
     @pytest.fixture(scope="class")
     def packet_unit_test_fpath(self, tardis_ref_path):
+        """
+        Path to `packet_unittest.h5`.
+
+        Parameters
+        ----------
+        tardis_ref_path : pd.HDFStore
+
+        Returns
+        -------
+        os.path
+        """
         return os.path.abspath(
             os.path.join(tardis_ref_path, "packet_unittest.h5")
         )
 
     @pytest.fixture(scope="class")
     def blackbodysimplesource(self, request):
+        """
+        Create BlackBodySimpleSource instance.
+
+        Yields
+        -------
+        tardis.montecarlo.packet_source.BlackBodySimpleSource
+        """
         cls = type(self)
         montecarlo_configuration.LEGACY_MODE_ENABLED = True
         cls.bb = BlackBodySimpleSource(base_seed=1963, legacy_second_seed=2508)
@@ -32,6 +50,16 @@ class TestPacketSource:
         packet_unit_test_fpath,
         blackbodysimplesource,
     ):
+        """
+        Test generate_plot_mpl method.
+
+        Parameters
+        ----------
+        request : _pytest.fixtures.SubRequest
+        tardis_ref_data: pd.HDFStore
+        packet_unit_test_fpath: os.path
+        blackbodysimplesource: tardis.montecarlo.packet_source.BlackBodySimpleSource
+        """
         if request.config.getoption("--generate-reference"):
             ref_bb = pd.read_hdf(packet_unit_test_fpath, key="/blackbody")
             ref_bb.to_hdf(

--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tardis.montecarlo.packet_source import BlackBodySimpleSource, BasePacketSource
+from tardis.montecarlo.packet_source import BlackBodySimpleSource
 from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )

--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -9,10 +9,13 @@ from tardis.montecarlo import (
     montecarlo_configuration as montecarlo_configuration,
 )
 
-class TestPacketSource():
+
+class TestPacketSource:
     @pytest.fixture(scope="class")
     def packet_unit_test_fpath(self, tardis_ref_path):
-        return os.path.abspath(os.path.join(tardis_ref_path, "packet_unittest.h5"))
+        return os.path.abspath(
+            os.path.join(tardis_ref_path, "packet_unittest.h5")
+        )
 
     @pytest.fixture(scope="class")
     def blackbodysimplesource(self, request):
@@ -22,7 +25,13 @@ class TestPacketSource():
         yield cls.bb
         montecarlo_configuration.LEGACY_MODE_ENABLED = False
 
-    def test_bb_packet_sampling(self, request, tardis_ref_data, packet_unit_test_fpath, blackbodysimplesource):
+    def test_bb_packet_sampling(
+        self,
+        request,
+        tardis_ref_data,
+        packet_unit_test_fpath,
+        blackbodysimplesource,
+    ):
         if request.config.getoption("--generate-reference"):
             ref_bb = pd.read_hdf(packet_unit_test_fpath, key="/blackbody")
             ref_bb.to_hdf(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`  | :vertical_traffic_light: `testing`

`test_simulation.py`, `test_tardis_full_formal_integral.py` and `test_tardis_full.py` all failed individually because `test_packet_source.py` didn't turn off `LEGACY_MODE` once it was enabled. This PR refactors `test_packet_source.py` file and adds a fixture which turns off legacy mode after the tests have been run.

https://github.com/tardis-sn/tardis-refdata/pull/70 needs to be merged before to get this to work.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
