### PR TITLE
Generate Lockfiles Manually

### DIFF
--- a/.github/workflows/generate-lockfiles.yml
+++ b/.github/workflows/generate-lockfiles.yml
@@ -1,0 +1,122 @@
+name: generate-lockfiles
+
+on:
+  workflow_dispatch:  # manual trigger
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            auto-activate-base: true
+            activate-environment: ""
+            use-mamba: true
+
+      - name: Install conda-lock
+        run: mamba install -c conda-forge conda-lock=1.0.5
+
+      - name: Generate lockfiles
+        run: |
+          conda-lock -f tardis_env3.yml -p linux-64 -p osx-64
+          conda lock render conda-lock.yml
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: lockfiles
+          path: |
+              conda-linux-64.lock
+              conda-osx-64.lock
+              conda-lock.yml
+
+
+
+  pull_request:
+    needs: lock
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: /tmp
+
+      - name: Copy files to repository
+        run: |
+          cp /tmp/lockfiles/conda-linux-64.lock .
+          cp /tmp/lockfiles/conda-osx-64.lock .
+          cp /tmp/lockfiles/conda-lock.yml .
+
+      - name: Get current date
+        run: echo "DATE=$(date +'%Y.%m.%d')" >> $GITHUB_ENV
+
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          committer: TARDIS Bot <tardis.sn.bot@gmail.com>
+          author: TARDIS Bot <tardis.sn.bot@gmail.com>
+          branch: generate-lockfiles-${{ env.DATE }}
+          base: master
+          push-to-fork: tardis-bot/tardis
+          commit-message: Generate lock files ${{ env.DATE }}
+          title: Generate Lock Files ${{ env.DATE }}
+          body: |
+            *\*beep\* \*bop\**
+
+            Hi, human.
+
+            This PR contains lock files that were generated from the `generate-lockfiles.yml` workflow.
+
+            <br>
+
+            > :warning: **WARNING:** 
+            >
+            > This pull request should be auto-merged. **Do not merge manually if any check fails**.
+            >
+            > Instead, disable auto-merge and push your fixes to the [`generate-lockfiles-${{ env.DATE }}`](https://github.com/tardis-bot/tardis/tree/generate-lockfiles-${{ env.DATE }}) branch on [**tardis-bot/tardis**](https://github.com/tardis-bot/tardis).
+            >
+            > ```
+            > $ git remote add tardis-bot git@github.com:tardis-bot/tardis.git
+            > $ git fetch tardis-bot
+            > $ git checkout tardis-bot/generate-lockfiles-${{ env.DATE }}
+            > $ git add <file_1> <file_2> ...
+            > $ git commit -m "<your_commit_message>"
+            > $ git push tardis-bot HEAD:generate-lockfiles-${{ env.DATE }}
+            > ```
+            >
+            > Once all the checks pass, you can safely merge this pull request manually.
+          labels: automated, build-docs
+          team-reviewers: tardis-infrastructure
+        id: create-pr
+
+      - name: Wait for pull request
+        run: sleep 30
+
+      - name: Approve pull request (I)
+        run: gh pr review ${{ steps.create-pr.outputs.pull-request-number }} --approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.INFRASTRUCTURE_COORDINATOR_TOKEN }}
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+
+      - name: Approve pull request (II)
+        run: gh pr review ${{ steps.create-pr.outputs.pull-request-number }} --approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.CORE_COORDINATOR_TOKEN }}
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+
+      - name: Enable automerge
+        uses: peter-evans/enable-pull-request-automerge@v2
+        with:
+          token: ${{ secrets.INFRASTRUCTURE_COORDINATOR_TOKEN }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash
+        if: steps.create-pr.outputs.pull-request-operation == 'created'


### PR DESCRIPTION
### :pencil: Description

**Type:* :vertical_traffic_light: `testing` | :roller_coaster: `infrastructure`

@wkerzendorf says we don't need to generate lockfiles every release. This PR steals code that generates lockfiles from the pre release workflow and puts it into a separate workflow.

At the moment I am duplicating a lot of code- is it possible to reuse actions from other workflows?

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
