### PR TITLE
Disabled formal integral for continuum interaction

### DIFF
--- a/tardis/montecarlo/montecarlo_numba/formal_integral.py
+++ b/tardis/montecarlo/montecarlo_numba/formal_integral.py
@@ -12,6 +12,7 @@ from numba.experimental import jitclass
 import pdb
 
 from tardis.montecarlo.montecarlo_numba.numba_config import SIGMA_THOMSON
+from tardis.montecarlo import montecarlo_configuration as mc_config_module
 from tardis.montecarlo.montecarlo_numba import njit_dict, njit_dict_no_parallel
 from tardis.montecarlo.montecarlo_numba.numba_interface import (
     opacity_state_initialize,
@@ -357,6 +358,12 @@ class FormalIntegrator(object):
                 "The FormalIntegrator currently only works for "
                 'line_interaction_type == "downbranch"'
                 'and line_interaction_type == "macroatom"'
+            )
+
+        if mc_config_module.CONTINUUM_PROCESSES_ENABLED:
+            return raise_or_return(
+                "The FormalIntegrator currently does not work for "
+                "continuum interactions."
             )
 
         return True


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

The formal integral does not work correctly for the continuum treatment. The code really should raise an error instead of producing an result.

### :pushpin: Resources

None.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
