### PR TITLE
Add FAQ section to documentation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,26 @@
+.. _installation:
+
+**************************
+Frequently Asked Questions
+**************************
+
+Usage
+-----
+
+.. _faq-usage:
+
+My simulation seems to consume excessive amounts of memory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+High memory usage can have many reasons. Both your model
+and certain simulation settings can increase the memory
+usage significantly
+
+1. Enabling ``track_rpacket: true`` will take up substantial
+   amounts of memory, in particular for higher packet counts.
+   Consider turning this feature off or only use it with a
+   small amount of packets.
+2. Both the number of shells and the number of packets
+   increase the memory requirements. Consider using only
+   as many shells/ packets as are required to converge
+   on a result.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -4,6 +4,23 @@
 Frequently Asked Questions
 **************************
 
+Overview
+--------
+
+Welcome to the FAQ section! Here, you'll find answers to common questions about TARDIS.
+
+- :ref:`faq-usage` - Questions related to the usage of TARDIS
+
+     - :ref:`faq-usage-memory` - My simulation seems to consume excessive amounts of memory
+
+Overview
+--------
+
+Welcome to our FAQ section! Here, you'll find answers to common questions about our software.
+
+- :ref:`faq-installation` - How do I install the software?
+- :ref:`faq-usage` - How do I perform a specific task?
+
 Usage
 -----
 
@@ -11,6 +28,8 @@ Usage
 
 My simulation seems to consume excessive amounts of memory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _faq-usage-memory:
 
 High memory usage can have many reasons. Both your model
 and certain simulation settings can increase the memory

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,27 +9,21 @@ Overview
 
 Welcome to the FAQ section! Here, you'll find answers to common questions about TARDIS.
 
-- :ref:`faq-usage` - Questions related to the usage of TARDIS
+- :ref:`faq-usage`
 
-     - :ref:`faq-usage-memory` - My simulation seems to consume excessive amounts of memory
+     - :ref:`faq-usage-memory`
 
-Overview
---------
 
-Welcome to our FAQ section! Here, you'll find answers to common questions about our software.
-
-- :ref:`faq-installation` - How do I install the software?
-- :ref:`faq-usage` - How do I perform a specific task?
+.. _faq-usage:
 
 Usage
 -----
 
-.. _faq-usage:
+.. _faq-usage-memory:
 
 My simulation seems to consume excessive amounts of memory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _faq-usage-memory:
 
 High memory usage can have many reasons. Both your model
 and certain simulation settings can increase the memory

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,7 @@ Mission Statement
     installation
     quickstart
     tutorials
+    faq
     API <api/modules>
 
 


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation`
Adds a FAQ section in the documentation. Serves as a place to centrally collect hints about how to run TARDIS.
Specifically this adds a hint that using rpacket_tracking may use significant amounts of memory. 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
