### PR TITLE
Fix bug in relativistic packet source

### DIFF
--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -313,7 +313,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
         self.beta = ((self.radius / self.time_explosion) / const.c).to("")
         return super().create_packets(no_of_packets)
 
-    def create_packet_nus(self, no_of_packets):
+    def create_packet_mus(self, no_of_packets):
         """
         Create zero-limb-darkening packet :math:`\mu^\prime` distributed
         according to :math:`\\mu^\\prime=2 \\frac{\\mu^\\prime + \\beta}{2 \\beta + 1}`.
@@ -327,7 +327,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
 
         Returns
         -------
-        array of frequencies
+        Directions for packets
             numpy.ndarray
         """
         z = self.rng.random(no_of_packets)


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

#2366 broke the BlackBodySimpleSourceRelativistic by changing `mus` to `nus`. The packets source thus assigns frequencies between 0 and 1. This PR fixes this.


### :pushpin: Resources


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
