### PR TITLE
Fix zero density

### DIFF
--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -594,7 +594,7 @@ class SimulationState(HDFWriterMixin):
                 csvy_model_config.datatype.fields[density_field_index]["unit"]
             )
             density_0 = csvy_model_data["density"].values * density_unit
-            density_0 = density_0.to("g/cm^3")[1:]
+            density_0 = density_0.to("g/cm^3")
             density = calculate_density_after_time(
                 density_0, time_0, time_explosion
             )

--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -595,7 +595,6 @@ class SimulationState(HDFWriterMixin):
             )
             density_0 = csvy_model_data["density"].values * density_unit
             density_0 = density_0.to("g/cm^3")[1:]
-            density_0 = density_0.insert(0, 0)
             density = calculate_density_after_time(
                 density_0, time_0, time_explosion
             )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`
Removes line that sets innermost shell density to zero when reading a ``csvy`` model file. At least as far as I can tell there is no apparent reason for this to be done. In the worst case, this can lead to a ``PlasmaIonizationError: n_electron just turned "nan" - aborting`` error since ``number_density`` becomes infinite.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
