### PR TITLE
Enable nlte ionization as plasma component

### DIFF
--- a/docs/io/configuration/components/plasma.rst
+++ b/docs/io/configuration/components/plasma.rst
@@ -45,3 +45,14 @@ The NLTE configuration currently allows setting ``coronal_approximation``, which
 This is useful for debugging with :term:`chianti` for example. Furthermore, one can enable 'classical_nebular' to set all
 :math:`\beta_\textrm{Sobolev}` to 1. Both options are used for checking with other codes and should not be enabled in
 normal operations.
+
+NLTE Ionization
+^^^^^^^^^^^^^^^
+
+.. code-block:: yaml
+
+    plasma:
+        nlte_ionization_species: [H I, H II, He I, He II]
+    
+This option allows the user to specify which species should be included in the NLTE ionization treatment. Note that the
+species must be present in the continuum interaction species as well.

--- a/docs/physics/setup/plasma/index.rst
+++ b/docs/physics/setup/plasma/index.rst
@@ -73,6 +73,9 @@ The next more complex class is `LTEPlasma` which will calculate the ionization b
 
 TARDIS also allows for NLTE treatments of specified species, as well as special NLTE treatments for Helium.
 
+.. note::
+    The NLTE treatment of specified species is currently incompatible with the NLTE treatment for helium and cannot be used simulataneously.
+
 .. toctree::
     :maxdepth: 2
 

--- a/tardis/montecarlo/montecarlo_numba/numba_interface.py
+++ b/tardis/montecarlo/montecarlo_numba/numba_interface.py
@@ -217,7 +217,9 @@ def opacity_state_initialize(plasma, line_interaction_type):
         ].values
 
         phot_nus = phot_nus.values
-        ff_opacity_factor = plasma.ff_cooling_factor / np.sqrt(t_electrons)
+        ff_opacity_factor = (
+            plasma.ff_cooling_factor / np.sqrt(t_electrons)
+        ).astype(np.float64)
         emissivities = plasma.fb_emission_cdf.loc[
             plasma.level2continuum_idx.index
         ].values

--- a/tardis/plasma/properties/nlte_rate_equation_solver.py
+++ b/tardis/plasma/properties/nlte_rate_equation_solver.py
@@ -11,7 +11,7 @@ __all__ = [
 
 
 class NLTERateEquationSolver(ProcessingPlasmaProperty):
-    outputs = ("ion_number_density_nlte", "electron_densities_nlte")
+    outputs = ("ion_number_density", "electron_densities")
 
     def calculate(
         self,

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -84,7 +84,9 @@ class SpMatrixSeriesConverterMixin(object):
             idx2reduced_idx.loc[q_indices[1]].values,
         )
         max_idx = idx2reduced_idx.max() + 1
-        matrix = sp.coo_matrix((series, q_indices), shape=(max_idx, max_idx))
+        matrix = sp.coo_matrix(
+            (series.astype(np.float64), q_indices), shape=(max_idx, max_idx)
+        )
         return matrix
 
     @staticmethod

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -48,7 +48,9 @@ def normalize_trans_probs(p):
     index = p.index.get_level_values("source_level_idx")
     p_norm = p / p_summed.loc[index].values
     p_norm = p_norm.fillna(0.0)
-    breakpoint()
+    # Convert back to original dtypes to avoid typing problems later on
+    # in the number code.
+    p_norm = p_norm.convert_dtypes()
     return p_norm
 
 

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -49,7 +49,7 @@ def normalize_trans_probs(p):
     p_norm = p / p_summed.loc[index].values
     p_norm = p_norm.fillna(0.0)
     # Convert back to original dtypes to avoid typing problems later on
-    # in the number code.
+    # in the numba code.
     p_norm = p_norm.convert_dtypes()
     return p_norm
 

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -41,10 +41,14 @@ def normalize_trans_probs(p):
         all probabilites with the same source_level_idx sum to one.
         Indexed by source_level_idx, destination_level_idx.
     """
-    p_summed = p.groupby(level=0).sum()
+    # Dtype conversion is needed for pandas to return nan instead of
+    # a ZeroDivisionError in cases where the sum is zero.
+    p = p.astype(np.float64)
+    p_summed = p.groupby(level=0).sum().astype(np.float64)
     index = p.index.get_level_values("source_level_idx")
     p_norm = p / p_summed.loc[index].values
     p_norm = p_norm.fillna(0.0)
+    breakpoint()
     return p_norm
 
 

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -7,6 +7,9 @@ import pandas as pd
 
 from tardis.io.atom_data import AtomData
 from tardis.plasma.properties.level_population import LevelNumberDensity
+from tardis.plasma.properties.nlte_rate_equation_solver import (
+    NLTERateEquationSolver,
+)
 from tardis.plasma.properties.rate_matrix_index import NLTEIndexHelper
 from tardis.util.base import species_string_to_tuple
 from tardis.plasma import BasePlasma
@@ -315,6 +318,13 @@ def assemble_plasma(config, simulation_state, atom_data=None):
         )
         if config.plasma.helium_treatment == "numerical-nlte":
             property_kwargs[IonNumberDensityHeNLTE] = dict(
+                electron_densities=electron_densities
+            )
+        elif (
+            config.plasma.nlte_ionization_species
+            or config.plasma.nlte_excitation_species
+        ):
+            property_kwargs[NLTERateEquationSolver] = dict(
                 electron_densities=electron_densities
             )
         else:

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -267,7 +267,7 @@ def assemble_plasma(config, simulation_state, atom_data=None):
         )
 
     if (
-        config.plama.helium_treatment == "recomb-nlte"
+        config.plasma.helium_treatment == "recomb-nlte"
         or config.plasma.helium_treatment == "numerical-nlte"
     ) and (
         config.plasma.nlte_ionization_species

--- a/tardis/plasma/standard_plasmas.py
+++ b/tardis/plasma/standard_plasmas.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from tardis.io.atom_data import AtomData
+from tardis.plasma.properties.level_population import LevelNumberDensity
 from tardis.plasma.properties.rate_matrix_index import NLTEIndexHelper
 from tardis.util.base import species_string_to_tuple
 from tardis.plasma import BasePlasma
@@ -265,6 +266,26 @@ def assemble_plasma(config, simulation_state, atom_data=None):
             delta_treatment=config.plasma.delta_treatment
         )
 
+    if (
+        config.plama.helium_treatment == "recomb-nlte"
+        or config.plasma.helium_treatment == "numerical-nlte"
+    ) and (
+        config.plasma.nlte_ionization_species
+        or config.plasma.nlte_excitation_species
+    ):
+        # Prevent the user from using helium NLTE treatment with
+        # NLTE ionization and excitation treatment. This is because
+        # the helium_nlte_properties could overwrite the NLTE ionization
+        # and excitation ion number and electron densities.
+        # helium_numerical_nlte_properties is also included here because
+        # it is currently in the same if else block, and thus may block
+        # the addition of the components from the else block.
+        raise PlasmaConfigError(
+            "Helium NLTE treatment is incompatible with the NLTE eonization and excitation treatment."
+        )
+
+    # TODO: Disentangle these if else block such that compatible components
+    # can be added independently.
     if config.plasma.helium_treatment == "recomb-nlte":
         plasma_modules += helium_nlte_properties
     elif config.plasma.helium_treatment == "numerical-nlte":
@@ -277,7 +298,16 @@ def assemble_plasma(config, simulation_state, atom_data=None):
                 heating_rate_data_file=config.plasma.heating_rate_data_file
             )
     else:
-        plasma_modules += helium_lte_properties
+        # If nlte ionization species are present, we don't want to add the
+        # IonNumberDensity from helium_lte_properties, since we want
+        # to use the IonNumberDensity provided by the NLTE solver.
+        if (
+            config.plasma.nlte_ionization_species
+            or config.plasma.nlte_excitation_species
+        ):
+            plasma_modules += [LevelNumberDensity]
+        else:
+            plasma_modules += helium_lte_properties
 
     if simulation_state._electron_densities is not None:
         electron_densities = pd.Series(

--- a/tardis/plasma/tests/test_nlte_solver.py
+++ b/tardis/plasma/tests/test_nlte_solver.py
@@ -260,7 +260,7 @@ def nlte_raw_plasma_w0(
 
 def test_critical_case_w1(nlte_raw_plasma_w1):
     """Check that the LTE and NLTE solution agree for w=1.0."""
-    ion_number_density_nlte = nlte_raw_plasma_w1.ion_number_density_nlte.values
+    ion_number_density_nlte = nlte_raw_plasma_w1.ion_number_density.values
     ion_number_density_nlte[ion_number_density_nlte < 1e-10] = 0.0
 
     ind = IonNumberDensity(nlte_raw_plasma_w1)


### PR DESCRIPTION
### :pencil: Description

**Type:**  :rocket: `feature` 

Enables the use of NLTE ionization (and implicitly excitation) treatment during the plasma construction. In the current implementation, it is not compatible with the ``helium_treatment`` options ``recomb-nlte`` and ``numerical-nlte``. This is due to the fact that both ``recomb-nlte`` and the NLTE rate equation solver provide ``ion_number_density`` and ``electron_densities``, potentially overwriting each other. As this could lead to unexpected behavior, I decided to simply disallow the simultaneous use of these options to prevent unintended results. (I could not find an obvious incompatibility with ``numerical-nlte`` since this does not seem to provide the above mentioned quantities.. However, since it is in the same if else block, having this option enabled would block the addition of the NLTE ionizaition/excitation properties.) 

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
