### PR TITLE
Update docstr-cov.yml to fix failing action

### DIFF
--- a/.github/workflows/docstr-cov.yml
+++ b/.github/workflows/docstr-cov.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: 3.x
 
       - name: Install interrogate
-        run: pip install interrogate==1.5.0 parse==1.19.0
+        run: pip install interrogate==1.5.0 parse==1.19.0 setuptools
 
       - name: Get SHAs
         run: |

--- a/.github/workflows/docstr-cov.yml
+++ b/.github/workflows/docstr-cov.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

docstr-cov is broken. This fixes it. The error is related to changes in Python/pip versions and setuptools, which `interrogate` relies on. Note that `interrogate` was last released in 2021, though it is maintained on GitHub.

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
