### PR TITLE
Update number of shells in SimulationState

### DIFF
--- a/tardis/model/base.py
+++ b/tardis/model/base.py
@@ -305,14 +305,14 @@ class SimulationState(HDFWriterMixin):
                 )
             )
 
-        elif len(t_radiative) == self.no_of_shells + 1:
+        elif len(t_radiative) == self.no_of_raw_shells + 1:
             t_radiative = t_radiative[
                 self.geometry.v_inner_boundary_index
                 + 1 : self.geometry.v_outer_boundary_index
                 + 1
             ]
         else:
-            assert len(t_radiative) == self.no_of_shells
+            assert len(t_radiative) == self.no_of_raw_shells
 
         if dilution_factor is None:
             dilution_factor = 0.5 * (
@@ -446,7 +446,7 @@ class SimulationState(HDFWriterMixin):
 
     @property
     def no_of_shells(self):
-        return self.geometry.no_of_shells
+        return self.geometry.no_of_shells_active
 
     @property
     def no_of_raw_shells(self):
@@ -479,7 +479,8 @@ class SimulationState(HDFWriterMixin):
             t_radiative = temperature
         elif config.plasma.initial_t_rad > 0 * u.K:
             t_radiative = (
-                np.ones(geometry.no_of_shells + 1) * config.plasma.initial_t_rad
+                np.ones(geometry.no_of_shells_active + 1)
+                * config.plasma.initial_t_rad
             )
         else:
             t_radiative = None
@@ -600,7 +601,7 @@ class SimulationState(HDFWriterMixin):
                 density_0, time_0, time_explosion
             )
 
-        no_of_shells = geometry.no_of_shells
+        no_of_shells = geometry.no_of_shells_active
 
         # TODO -- implement t_radiative
         # t_radiative = None
@@ -628,9 +629,7 @@ class SimulationState(HDFWriterMixin):
                 )
 
         elif config.plasma.initial_t_rad > 0 * u.K:
-            t_radiative = (
-                np.ones(geometry.no_of_shells) * config.plasma.initial_t_rad
-            )
+            t_radiative = np.ones(no_of_shells) * config.plasma.initial_t_rad
         else:
             t_radiative = None
 
@@ -644,7 +643,7 @@ class SimulationState(HDFWriterMixin):
         if hasattr(csvy_model_config, "abundance"):
             abundances_section = csvy_model_config.abundance
             abundance, isotope_abundance = read_uniform_abundances(
-                abundances_section, geometry.no_of_shells
+                abundances_section, no_of_shells
             )
         else:
             index, abundance, isotope_abundance = parse_csv_abundances(

--- a/tardis/model/tests/test_csvy_model.py
+++ b/tardis/model/tests/test_csvy_model.py
@@ -7,6 +7,7 @@ import os
 from astropy import units as u
 from tardis.io.configuration.config_reader import Configuration
 from tardis.model import SimulationState
+from tardis.io.atom_data.base import AtomData
 import pytest
 
 
@@ -82,10 +83,11 @@ def test_dimensionality_after_update_v_inner_boundary(
     in the context of csvy models specifically"""
     csvy_config_file, _ = model_config_fnames
     config = Configuration.from_yaml(csvy_config_file)
-    csvy_model = SimulationState.from_csvy(config)
+    atom_data = AtomData.from_hdf(config.atom_data)
+    csvy_model = SimulationState.from_csvy(config, atom_data=atom_data)
 
     config.model.v_inner_boundary = csvy_model.velocity[1]
-    new_csvy_model = SimulationState.from_csvy(config)
+    new_csvy_model = SimulationState.from_csvy(config, atom_data=atom_data)
 
     assert new_csvy_model.no_of_raw_shells == csvy_model.no_of_raw_shells
     assert new_csvy_model.no_of_shells == csvy_model.no_of_shells - 1

--- a/tardis/model/tests/test_csvy_model.py
+++ b/tardis/model/tests/test_csvy_model.py
@@ -75,6 +75,25 @@ def test_compare_models(model_config_fnames):
     )
 
 
+def test_dimensionality_after_update_v_inner_boundary(
+    model_config_fnames,
+):
+    """Test that the dimensionality of SimulationState parameters after updating v_inner_boundary
+    in the context of csvy models specifically"""
+    csvy_config_file, _ = model_config_fnames
+    config = Configuration.from_yaml(csvy_config_file)
+    csvy_model = SimulationState.from_csvy(config)
+
+    config.model.v_inner_boundary = csvy_model.velocity[1]
+    new_csvy_model = SimulationState.from_csvy(config)
+
+    assert new_csvy_model.no_of_raw_shells == csvy_model.no_of_raw_shells
+    assert new_csvy_model.no_of_shells == csvy_model.no_of_shells - 1
+    assert new_csvy_model.velocity.shape[0] == csvy_model.velocity.shape[0] - 1
+    assert new_csvy_model.density.shape[0] == csvy_model.density.shape[0] - 1
+    assert new_csvy_model.volume.shape[0] == csvy_model.volume.shape[0] - 1
+
+
 @pytest.fixture(scope="module")
 def csvy_model_test_abundances(example_csvy_file_dir):
     """Returns SimulationState to use to test abundances dataframes"""

--- a/tardis/model/tests/test_csvy_model.py
+++ b/tardis/model/tests/test_csvy_model.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import numpy as np
 import pandas as pd
+import copy
 import numpy.testing as npt
 import tardis
 import os
@@ -50,7 +51,7 @@ def model_simulation_states(model_configs, kurucz_atomic_data):
     return csvy_model, config_model
 
 
-def test_compare_models(model_config_fnames):
+def test_compare_models(model_simulation_states):
     """Compare identical models produced by .from_config and
     .from_csvy to check that velocities, densities and abundances
     (pre and post decay) are the same"""
@@ -135,7 +136,7 @@ def test_dimensionality_after_update_v_inner_boundary(
     in the context of csvy models specifically"""
     config, csvy_model = csvy_model_for_test
     new_config = copy.deepcopy(config)
-    new_config.model.v_inner_boundary = csvy_model.velocity[1]
+    new_config.model.v_inner_boundary = copy.deepcopy(csvy_model.velocity[1])
     new_csvy_model = SimulationState.from_csvy(
         new_config, atom_data=kurucz_atomic_data
     )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :vertical_traffic_light: `testing` 

Update the `no_of_shells` attribute in SimulationState to be the `no_of_shells_active` in geometry. 
This can make sure the dimensionality of the attributes in the SimulationState is consistent with the activate shells after changing the v_inner_boundary value on fly. 


### :pushpin: Resources


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
