### PR TITLE
Fix zero division handling in normalize_trans_probs (which breaks to_hdf)

### DIFF
--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -492,6 +492,13 @@ class AtomData(object):
                 .astype(np.int64)
                 .values
             )
+            self.lines_lower2macro_reference_idx = (
+                self.macro_atom_references.loc[
+                    tmp_lines_lower2level_idx, "references_idx"
+                ]
+                .astype(np.int64)
+                .values
+            )
 
             if line_interaction_type == "macroatom":
                 # Sets all

--- a/tardis/plasma/properties/atomic.py
+++ b/tardis/plasma/properties/atomic.py
@@ -459,8 +459,8 @@ class LevelIdxs2LineIdx(HiddenPlasmaProperty):
     def calculate(self, atomic_data):
         index = pd.MultiIndex.from_arrays(
             [
-                atomic_data.lines_upper2level_idx,
-                atomic_data.lines_lower2level_idx,
+                atomic_data.lines_upper2macro_reference_idx,
+                atomic_data.lines_lower2macro_reference_idx,
             ],
             names=["source_level_idx", "destination_level_idx"],
         )

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -41,6 +41,7 @@ def normalize_trans_probs(p):
         all probabilites with the same source_level_idx sum to one.
         Indexed by source_level_idx, destination_level_idx.
     """
+    p = p.astype(np.float64)
     p_summed = p.groupby(level=0).sum()
     p_summed[p_summed == 0] = 1
     index = p.index.get_level_values("source_level_idx")

--- a/tardis/plasma/properties/transition_probabilities.py
+++ b/tardis/plasma/properties/transition_probabilities.py
@@ -41,16 +41,11 @@ def normalize_trans_probs(p):
         all probabilites with the same source_level_idx sum to one.
         Indexed by source_level_idx, destination_level_idx.
     """
-    # Dtype conversion is needed for pandas to return nan instead of
-    # a ZeroDivisionError in cases where the sum is zero.
-    p = p.astype(np.float64)
-    p_summed = p.groupby(level=0).sum().astype(np.float64)
+    p_summed = p.groupby(level=0).sum()
+    p_summed[p_summed == 0] = 1
     index = p.index.get_level_values("source_level_idx")
     p_norm = p / p_summed.loc[index].values
-    p_norm = p_norm.fillna(0.0)
-    # Convert back to original dtypes to avoid typing problems later on
-    # in the numba code.
-    p_norm = p_norm.convert_dtypes()
+    assert np.all(np.isfinite(p_norm))
     return p_norm
 
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`
Currently, normalize_trans_probs performs multiple data type conversions to deal with zero divisions. The last conversion (with convert_dtypes) yields a DataFrame with an object array that breaks the to_hdf method. This PR aims to implement a simplified treatment for zero divisions that avoids this problem. However, it currently doesn't work for all atom data files for some reason.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
