### PR TITLE
Add astropy import guard

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,6 +5,7 @@ Alexander Holas <alexander.holas@h-its.org>
 Alexander Holas <alex.holas@gmx.de>
 Alexander Holas <alexander.holas@h-its.org> AlexHls <70367168+AlexHls@users.noreply.github.com>
 Alexander Holas <alexander.holas@h-its.org> AlexHls <alexander.holas@h-its.org>
+Alexander Holas <70367168+AlexHls@users.noreply.github.com>
 
 Alice Harpole <aliceharpole@gmail.com>
 Alice Harpole <aliceharpole@gmail.com> Alice Harpole <harpolea@users.noreply.github.com>

--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -12,13 +12,20 @@ __all__ = []
 # ----------------------------------------------------------------------------
 
 import sys
+import warnings
 
 # ----------------------------------------------------------------------------
 
-from astropy import physical_constants, astronomical_constants
+if ("astropy.units" in sys.modules) or ("astropy.constants" in sys.modules):
+    warnings.warn(
+        "Astropy is already imported externally. Astropy should be imported"
+        " after TARDIS."
+    )
+else:
+    from astropy import physical_constants, astronomical_constants
 
-physical_constants.set("codata2014")
-astronomical_constants.set("iau2012")
+    physical_constants.set("codata2014")
+    astronomical_constants.set("iau2012")
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Fixes the import issue described in #2081 or at least throws a warning that TARDIS should be imported first.