### PR TITLE
Reading in decay radiation data in atom data

### DIFF
--- a/tardis/data/atomic_data_repo.yml
+++ b/tardis/data/atomic_data_repo.yml
@@ -6,4 +6,4 @@ kurucz_cd23_chianti_H_He:
     - https://dev.azure.com/tardis-sn/TARDIS/_apis/git/repositories/tardis-refdata/items?path=atom_data/kurucz_cd23_chianti_H_He.h5&resolveLfs=true
     - https://media.githubusercontent.com/media/tardis-sn/tardis-refdata/master/atom_data/kurucz_cd23_chianti_H_He.h5
   uuid: NA
-  md5: 69a304e1e85e06508fe02dd8c5ba9397
+  md5: b95b862ef9f06ac20ad4fa70070af59d

--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -139,6 +139,7 @@ class AtomData(object):
         "yg_data",
         "two_photon_data",
         "linelist",
+        "decay_radiation_data",
     ]
 
     # List of tuples of the related dataframes.
@@ -275,6 +276,7 @@ class AtomData(object):
         yg_data=None,
         two_photon_data=None,
         linelist=None,
+        decay_radiation_data=None,
     ):
         self.prepared = False
 
@@ -337,6 +339,8 @@ class AtomData(object):
         if linelist is not None:
             self.linelist = linelist
 
+        if decay_radiation_data is not None:
+            self.decay_radiation_data = decay_radiation_data
         self._check_related()
 
         self.symbol2atomic_number = OrderedDict(

--- a/tardis/io/atom_data/base.py
+++ b/tardis/io/atom_data/base.py
@@ -93,6 +93,12 @@ class AtomData(object):
         index: atomic_number, ion_number, level_number_lower, level_number_upper
         columns: A_ul[1/s], nu0[Hz], alpha, beta, gamma
 
+    decay_radiation_data : pandas.DataFrame
+    A dataframe containing the *decay radiation data* with:
+        index: Isotope names
+        columns: atomic_number, element, Rad energy, Rad intensity decay mode.
+        Curated from nndc
+
     Attributes
     ----------
     prepared : bool
@@ -108,6 +114,7 @@ class AtomData(object):
     atomic_number2symbol : OrderedDict
     photoionization_data : pandas.DataFrame
     two_photon_data : pandas.DataFrame
+    decay_radiation_data : pandas.DataFrame
 
     Methods
     -------


### PR DESCRIPTION
Type: | 🚦 new feature

Added "decay_radiation_data" as an hdf name in atomdata class.
This makes it easier to use the atomic data file to store both atomic and nuclear data.
📌 Resources

🚦 Testing

How did you test these changes?

 Testing pipeline
 Other method (describe)
 My changes can't be tested (explain why)
☑️ Checklist

 I requested two reviewers for this pull request
 I updated the documentation according to my changes
 I built the documentation by applying the build_docs label
Note: If you are not allowed to perform any of these actions, ping (@) a contributor.