### PR TITLE
Add assert statement to catch negative abundances

### DIFF
--- a/tardis/io/model/readers/csvy.py
+++ b/tardis/io/model/readers/csvy.py
@@ -150,8 +150,6 @@ def parse_csv_abundances(csvy_data):
     )
     assert (
         isotope_abundance < 0.0
-    ).sum().sum() == 0, (
-        "Isotope abundances must be positive. Negative abundances found csvy."
-    )
+    ).sum().sum() == 0, "Isotope abundances must be positive. Negative abundances found in csvy."
 
     return abundance.index, abundance, isotope_abundance

--- a/tardis/io/model/readers/csvy.py
+++ b/tardis/io/model/readers/csvy.py
@@ -143,4 +143,15 @@ def parse_csv_abundances(csvy_data):
                 element_symbol_string
             ].tolist()
 
+    assert (
+        abundance < 0.0
+    ).sum().sum() == 0, (
+        "Abundances must be positive. Negative abundances found in csvy."
+    )
+    assert (
+        isotope_abundance < 0.0
+    ).sum().sum() == 0, (
+        "Isotope abundances must be positive. Negative abundances found csvy."
+    )
+
     return abundance.index, abundance, isotope_abundance

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -152,4 +152,15 @@ def parse_abundance_section(config, atom_data, geometry):
     if atom_data is not None:
         elemental_mass = atom_data.atom_data.mass
 
+    assert (
+        abundance < 0.0
+    ).sum().sum() == 0, (
+        "Abundances must be positive. Negative abundances found in csvy."
+    )
+    assert (
+        isotope_abundance < 0.0
+    ).sum().sum() == 0, (
+        "Isotope abundances must be positive. Negative abundances found csvy."
+    )
+
     return isotope_abundance, abundance, elemental_mass

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -155,12 +155,12 @@ def parse_abundance_section(config, atom_data, geometry):
     assert (
         abundance < 0.0
     ).sum().sum() == 0, (
-        "Abundances must be positive. Negative abundances found in csvy."
+        "Abundances must be positive. Negative abundances found."
     )
     assert (
         isotope_abundance < 0.0
     ).sum().sum() == 0, (
-        "Isotope abundances must be positive. Negative abundances found csvy."
+        "Isotope abundances must be positive. Negative abundances found."
     )
 
     return isotope_abundance, abundance, elemental_mass


### PR DESCRIPTION
Adds some assert statements to catch negative abundances in the input, preventing the simulation from running with nonsensical inputs.

Covers at least the csvy input where something like this is probably the most likely place to occur.