### PR TITLE
Add actionlint pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+---
+fail_fast: false
+repos:
+  #- repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    #  rev: v0.1.5
+    # hooks:
+      # Run the linter.
+      # - id: ruff
+      # args: [ --fix ]
+      # Run the formatter.
+      # - id: ruff-format
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.6.26
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
Adds actionlint (https://github.com/rhysd/actionlint) as a pre-commit hook.