### PR TITLE
prevent float overflow when calculating He I population

### DIFF
--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -678,6 +678,11 @@ def parse_csvy_radiation_field_state(
             geometry, packet_source
         )
 
+    if np.any(t_radiative < 1000 * u.K):
+        raise ValueError(
+            f"Radiative temperature is too low in shell {np.argmin(t_radiative)} (T_rad = {t_radiative[np.argmin(t_radiative)]})"
+        )
+
     if hasattr(csvy_model_data, "columns") and (
         "dilution_factor" in csvy_model_data.columns
     ):

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -679,10 +679,10 @@ def parse_csvy_radiation_field_state(
         )
 
     if np.any(t_radiative < 1000 * u.K):
-        logging.warn(
+        logging.critical(
             "Radiative temperature is too low in some of the shells, temperatures below 1000K "
             f"(e.g., T_rad = {t_radiative[np.argmin(t_radiative)]} in shell {np.argmin(t_radiative)} in your model) "
-            "are not accurately handled by Tardis.",
+            "are not accurately handled by TARDIS.",
         )
 
     if hasattr(csvy_model_data, "columns") and (

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -680,7 +680,9 @@ def parse_csvy_radiation_field_state(
 
     if np.any(t_radiative < 1000 * u.K):
         raise ValueError(
-            f"Radiative temperature is too low in shell {np.argmin(t_radiative)} (T_rad = {t_radiative[np.argmin(t_radiative)]})"
+            "Radiative temperature is too low in some of the shells, temperatures below 1000K "
+            f"(e.g., T_rad = {t_radiative[np.argmin(t_radiative)]} in shell {np.argmin(t_radiative)} in your model) "
+            "are not accurately handled by Tardis.",
         )
 
     if hasattr(csvy_model_data, "columns") and (

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -680,7 +679,7 @@ def parse_csvy_radiation_field_state(
         )
 
     if np.any(t_radiative < 1000 * u.K):
-        warnings.warn(
+        logging.warn(
             "Radiative temperature is too low in some of the shells, temperatures below 1000K "
             f"(e.g., T_rad = {t_radiative[np.argmin(t_radiative)]} in shell {np.argmin(t_radiative)} in your model) "
             "are not accurately handled by Tardis.",

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -679,10 +680,10 @@ def parse_csvy_radiation_field_state(
         )
 
     if np.any(t_radiative < 1000 * u.K):
-        raise ValueError(
+        warnings.warn(
             "Radiative temperature is too low in some of the shells, temperatures below 1000K "
             f"(e.g., T_rad = {t_radiative[np.argmin(t_radiative)]} in shell {np.argmin(t_radiative)} in your model) "
-            "are not accurately handled by Tardis."
+            "are not accurately handled by Tardis.",
         )
 
     if hasattr(csvy_model_data, "columns") and (

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -682,7 +682,7 @@ def parse_csvy_radiation_field_state(
         raise ValueError(
             "Radiative temperature is too low in some of the shells, temperatures below 1000K "
             f"(e.g., T_rad = {t_radiative[np.argmin(t_radiative)]} in shell {np.argmin(t_radiative)} in your model) "
-            "are not accurately handled by Tardis.",
+            "are not accurately handled by Tardis."
         )
 
     if hasattr(csvy_model_data, "columns") and (

--- a/tardis/plasma/properties/helium_nlte.py
+++ b/tardis/plasma/properties/helium_nlte.py
@@ -83,7 +83,6 @@ class HeliumNLTE(ProcessingPlasmaProperty):
             * (1 / g_electron)
             * (1 / (w**2.0))
             * np.exp(ionization_data.loc[2, 1] * beta_rad)
-            ) 
         )
 
     @staticmethod

--- a/tardis/plasma/properties/helium_nlte.py
+++ b/tardis/plasma/properties/helium_nlte.py
@@ -82,10 +82,8 @@ class HeliumNLTE(ProcessingPlasmaProperty):
             * (1.0 / (2 * float(g.loc[2, 1, 0])))
             * (1 / g_electron)
             * (1 / (w**2.0))
-            * np.minimum(
-                np.exp(ionization_data.loc[2, 1] * beta_rad),
-                np.finfo(np.float64).max,
-            )  # Prevents overflow
+            * np.exp(ionization_data.loc[2, 1] * beta_rad)
+            ) 
         )
 
     @staticmethod

--- a/tardis/plasma/properties/helium_nlte.py
+++ b/tardis/plasma/properties/helium_nlte.py
@@ -82,7 +82,10 @@ class HeliumNLTE(ProcessingPlasmaProperty):
             * (1.0 / (2 * float(g.loc[2, 1, 0])))
             * (1 / g_electron)
             * (1 / (w**2.0))
-            * np.exp(ionization_data.loc[2, 1] * beta_rad)
+            * np.minimum(
+                np.exp(ionization_data.loc[2, 1] * beta_rad),
+                np.finfo(np.float64).max,
+            )  # Prevents overflow
         )
 
     @staticmethod


### PR DESCRIPTION
### :pencil: Description

When the T_radiative in the shell is below 404 K, the highlighted part in the screenshot below will return Inf due to float overflow, which cause the nan values in the calculation of electron density. 

This PR initially aims to prevent the overflow by capping the value to be the max float value allowed in the program. However a better way to do this maybe raise an error when the input model T_radiative is below certain threshold (1000K is chosen in this PR), so the user can double check the input model. 

Fun fact, the low T_rad also cause kernel crash when using the macroatom setting. 

<img width="873" alt="image" src="https://github.com/tardis-sn/tardis/assets/48139543/186209bb-bc72-425b-8ea5-bf6e7245c521">


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
