### PR TITLE
Fix broken URL in generating_widgets.ipynb

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -257,5 +257,9 @@ Ansh Kumar <1928013@kiit.ac.in>
 Ansh Kumar <1928013@kiit.ac.in> xansh <1928013@kiit.ac.in>
 Ansh Kumar <1928013@kiit.ac.in> Ansh Kumar <1928013@kiit.ac.in>
 
+Sarthak Srivastava <sarthaksri592@gmail.com>
+Sarthak Srivastava <sarthaksri592@gmail.com> sarthak-dv <sarthaksri592@gmail.com>
+Sarthak Srivastava <sarthaksri592@gmail.com> Sarthak Srivastava <sarthaksri592@gmail.com>
+
 Kim Lingemann <kim@tg-lingemann.de> kimsina <kim@tg-lingemann.de>
 Kim Lingemann <kim@tg-lingemann.de> kim <kim@tg-lingemann.de>

--- a/docs/io/visualization/generating_widgets.ipynb
+++ b/docs/io/visualization/generating_widgets.ipynb
@@ -7,7 +7,7 @@
     "# Generating Data Exploration Widgets\n",
     "A demonstration of how to generate TARDIS widgets that allows you to **explore simulation data within Jupyter Notebook with ease**!\n",
     "\n",
-    "This notebook is a quickstart tutorial, but more details on each widget (and its features) is given in the [Using TARDIS Widgets](https://tardis-sn.github.io/tardis/using/visualization/using_widgets.html) section of the documentation."
+    "This notebook is a quickstart tutorial, but more details on each widget (and its features) is given in the [Using TARDIS Widgets](https://tardis-sn.github.io/tardis/io/visualization/using_widgets.html) section of the documentation."
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

Fixed broken URL as pointed by the linked issue.

**Type:** :beetle: `bugfix`


Resolves https://github.com/tardis-sn/tardis/issues/2532


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method: Tested the URL
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
