### PR TITLE
Fix units for virtual packet properties in MonteCarloTransportState

### DIFF
--- a/tardis/montecarlo/montecarlo_transport_state.py
+++ b/tardis/montecarlo/montecarlo_transport_state.py
@@ -365,9 +365,7 @@ class MonteCarloTransportState(HDFWriterMixin):
     @property
     def virt_packet_last_interaction_in_nu(self):
         try:
-            return u.Quantity(
-                self.vpacket_tracker.last_interaction_in_nu, u.Hz
-            )
+            return u.Quantity(self.vpacket_tracker.last_interaction_in_nu, u.Hz)
         except AttributeError:
             warnings.warn(
                 "MontecarloTransport.virt_packet_last_interaction_in_nu:"

--- a/tardis/montecarlo/montecarlo_transport_state.py
+++ b/tardis/montecarlo/montecarlo_transport_state.py
@@ -366,7 +366,7 @@ class MonteCarloTransportState(HDFWriterMixin):
     def virt_packet_last_interaction_in_nu(self):
         try:
             return u.Quantity(
-                self.vpacket_tracker.last_interaction_in_nu, u.erg
+                self.vpacket_tracker.last_interaction_in_nu, u.Hz
             )
         except AttributeError:
             warnings.warn(
@@ -381,7 +381,7 @@ class MonteCarloTransportState(HDFWriterMixin):
     @property
     def virt_packet_last_interaction_type(self):
         try:
-            return u.Quantity(self.vpacket_tracker.last_interaction_type, u.erg)
+            return self.vpacket_tracker.last_interaction_type
         except AttributeError:
             warnings.warn(
                 "MontecarloTransport.virt_packet_last_interaction_type:"
@@ -395,9 +395,7 @@ class MonteCarloTransportState(HDFWriterMixin):
     @property
     def virt_packet_last_line_interaction_in_id(self):
         try:
-            return u.Quantity(
-                self.vpacket_tracker.last_interaction_in_id, u.erg
-            )
+            return self.vpacket_tracker.last_interaction_in_id
         except AttributeError:
             warnings.warn(
                 "MontecarloTransport.virt_packet_last_line_interaction_in_id:"
@@ -411,9 +409,7 @@ class MonteCarloTransportState(HDFWriterMixin):
     @property
     def virt_packet_last_line_interaction_out_id(self):
         try:
-            return u.Quantity(
-                self.vpacket_tracker.last_interaction_out_id, u.erg
-            )
+            return self.vpacket_tracker.last_interaction_out_id
         except AttributeError:
             warnings.warn(
                 "MontecarloTransport.virt_packet_last_line_interaction_out_id:"
@@ -427,9 +423,7 @@ class MonteCarloTransportState(HDFWriterMixin):
     @property
     def virt_packet_last_line_interaction_shell_id(self):
         try:
-            return u.Quantity(
-                self.vpacket_tracker.last_interaction_shell_id, u.erg
-            )
+            return self.vpacket_tracker.last_interaction_shell_id
         except AttributeError:
             warnings.warn(
                 "MontecarloTransport.virt_packet_last_line_interaction_shell_id:"


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixed the units in properties for virtual packets in MonteCarloTransportState.

Resolves https://github.com/tardis-sn/tardis/issues/2540

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
