### PR TITLE
Consistent units in packet source

### DIFF
--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -123,7 +123,7 @@ class BasePacketSource(abc.ABC):
         return (
             4
             * np.pi
-            * const.sigma_sb.cgs
+            * const.sigma_sb
             * self.radius**2
             * self.temperature**4
         ).to("erg/s")
@@ -179,7 +179,7 @@ class BlackBodySimpleSource(BasePacketSource):
         Radii for packets
             numpy.ndarray
         """
-        return np.ones(no_of_packets) * self.radius
+        return np.ones(no_of_packets) * self.radius.cgs
 
     def create_packet_nus(self, no_of_packets, l_samples=1000):
         """
@@ -222,7 +222,7 @@ class BlackBodySimpleSource(BasePacketSource):
         xis_prod = np.prod(xis[1:], 0)
         x = ne.evaluate("-log(xis_prod)/l")
 
-        return x * (const.k_B.cgs * self.temperature) / const.h.cgs
+        return (x * (const.k_B * self.temperature) / const.h).cgs
 
     def create_packet_mus(self, no_of_packets):
         """
@@ -286,11 +286,11 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
 
     Parameters
     ----------
-    time_explosion : float 64
+    time_explosion : astropy.units.Quantity
         Time elapsed since explosion
-    radius : float64
+    radius : astropy.units.Quantity
         Initial packet radius
-    temperature : float
+    temperature : astropy.units.Quantity
         Absolute Temperature.
     base_seed : int
         Base Seed for random number generator

--- a/tardis/montecarlo/packet_source.py
+++ b/tardis/montecarlo/packet_source.py
@@ -88,17 +88,17 @@ class BasePacketSource(abc.ABC):
             self.MAX_SEED_VAL, no_of_packets, replace=True
         )
 
-        radii = self.create_packet_radii(no_of_packets, *args, **kwargs)
-        nus = self.create_packet_nus(no_of_packets, *args, **kwargs)
+        radii = self.create_packet_radii(no_of_packets, *args, **kwargs).value
+        nus = self.create_packet_nus(no_of_packets, *args, **kwargs).value
         mus = self.create_packet_mus(no_of_packets, *args, **kwargs)
-        energies = self.create_packet_energies(no_of_packets, *args, **kwargs)
+        energies = self.create_packet_energies(
+            no_of_packets, *args, **kwargs
+        ).value
         # Check if all arrays have the same length
         assert (
             len(radii) == len(nus) == len(mus) == len(energies) == no_of_packets
         )
-        radiation_field_luminosity = (
-            self.calculate_radfield_luminosity().to(u.erg / u.s).value
-        )
+        radiation_field_luminosity = self.calculate_radfield_luminosity().value
         return PacketCollection(
             radii,
             nus,
@@ -136,9 +136,9 @@ class BlackBodySimpleSource(BasePacketSource):
 
     Parameters
     ----------
-    radius : float64
+    radius : astropy.units.Quantity
         Initial packet radius
-    temperature : float
+    temperature : astropy.units.Quantity
         Absolute Temperature.
     base_seed : int
         Base Seed for random number generator
@@ -150,7 +150,7 @@ class BlackBodySimpleSource(BasePacketSource):
     def from_simulation_state(cls, simulation_state, *args, **kwargs):
         return cls(
             simulation_state.r_inner[0],
-            simulation_state.t_inner.value,
+            simulation_state.t_inner,
             *args,
             **kwargs,
         )
@@ -222,12 +222,7 @@ class BlackBodySimpleSource(BasePacketSource):
         xis_prod = np.prod(xis[1:], 0)
         x = ne.evaluate("-log(xis_prod)/l")
 
-        if isinstance(self.temperature, u.Quantity):
-            temperature = self.temperature.value
-        else:
-            temperature = self.temperature
-
-        return x * (const.k_B.cgs.value * temperature) / const.h.cgs.value
+        return x * (const.k_B.cgs * self.temperature) / const.h.cgs
 
     def create_packet_mus(self, no_of_packets):
         """
@@ -266,7 +261,7 @@ class BlackBodySimpleSource(BasePacketSource):
         energies for packets
             numpy.ndarray
         """
-        return np.ones(no_of_packets) / no_of_packets
+        return np.ones(no_of_packets) / no_of_packets * u.erg
 
     def set_temperature_from_luminosity(self, luminosity: u.Quantity):
         """
@@ -308,7 +303,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
         return cls(
             simulation_state.time_explosion,
             simulation_state.r_inner[0],
-            simulation_state.t_inner.value,
+            simulation_state.t_inner,
             *args,
             **kwargs,
         )
@@ -338,7 +333,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
         """
         if self.radius is None or self.time_explosion is None:
             raise ValueError("Black body Radius or Time of Explosion isn't set")
-        self.beta = ((self.radius / self.time_explosion) / const.c).to("")
+        self.beta = (self.radius / self.time_explosion) / const.c
         return super().create_packets(no_of_packets)
 
     def create_packet_mus(self, no_of_packets):
@@ -387,4 +382,4 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource):
         # are calculated as ratios of packet energies and the time of simulation.
         # Thus, we can absorb the factor gamma in the packet energies, which is
         # more convenient.
-        return energies * static_inner_boundary2cmf_factor / gamma
+        return energies * static_inner_boundary2cmf_factor / gamma * u.erg

--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -1,5 +1,6 @@
 import os
 
+from astropy import units as u
 import numpy as np
 import pandas as pd
 import pytest
@@ -28,9 +29,7 @@ class TestPacketSource:
         -------
         os.path
         """
-        return os.path.abspath(
-            os.path.join(tardis_ref_path, "packet_unittest.h5")
-        )
+        return os.path.abspath(os.path.join(tardis_ref_path, "packet_unittest.h5"))
 
     @pytest.fixture(scope="class")
     def blackbodysimplesource(self, request):
@@ -64,11 +63,7 @@ class TestPacketSource:
         montecarlo_configuration.LEGACY_MODE_ENABLED = False
 
     def test_bb_packet_sampling(
-        self,
-        request,
-        tardis_ref_data,
-        packet_unit_test_fpath,
-        blackbodysimplesource,
+        self, request, tardis_ref_data, packet_unit_test_fpath, blackbodysimplesource
     ):
         """
         Parameters
@@ -76,20 +71,17 @@ class TestPacketSource:
         request : _pytest.fixtures.SubRequest
         tardis_ref_data: pd.HDFStore
         packet_unit_test_fpath: os.path
-        blackbodysimplesource: tardis.montecarlo.packet_source.BlackBodySimpleSource
         """
         if request.config.getoption("--generate-reference"):
             ref_bb = pd.read_hdf(packet_unit_test_fpath, key="/blackbody")
-            ref_bb.to_hdf(
-                tardis_ref_data, key="/packet_unittest/blackbody", mode="a"
-            )
+            ref_bb.to_hdf(tardis_ref_data, key="/packet_unittest/blackbody", mode="a")
             pytest.skip("Reference data was generated during this run.")
 
         ref_df = tardis_ref_data["/packet_unittest/blackbody"]
-        self.bb.temperature = 10000
-        nus = self.bb.create_packet_nus(100)
+        self.bb.temperature = 10000 * u.K
+        nus = self.bb.create_packet_nus(100).value
         mus = self.bb.create_packet_mus(100)
-        unif_energies = self.bb.create_packet_energies(100)
+        unif_energies = self.bb.create_packet_energies(100).value
         assert np.all(np.isclose(nus, ref_df["nus"]))
         assert np.all(np.isclose(mus, ref_df["mus"]))
         assert np.all(np.isclose(unif_energies, ref_df["energies"]))
@@ -105,13 +97,13 @@ class TestPacketSource:
         tardis_ref_data : pd.HDFStore
         blackbody_simplesource_relativistic : tardis.montecarlo.packet_source.BlackBodySimpleSourceRelativistic
         """
-        blackbody_simplesource_relativistic.temperature = 10000
+        blackbody_simplesource_relativistic.temperature = 10000 * u.K
         blackbody_simplesource_relativistic.beta = 0.25
 
-        nus = blackbody_simplesource_relativistic.create_packet_nus(100)
-        unif_energies = (
-            blackbody_simplesource_relativistic.create_packet_energies(100)
-        )
+        nus = blackbody_simplesource_relativistic.create_packet_nus(100).value
+        unif_energies = blackbody_simplesource_relativistic.create_packet_energies(
+            100
+        ).value
         blackbody_simplesource_relativistic._reseed(2508)
         mus = blackbody_simplesource_relativistic.create_packet_mus(10)
 

--- a/tardis/montecarlo/tests/test_packet_source.py
+++ b/tardis/montecarlo/tests/test_packet_source.py
@@ -29,7 +29,9 @@ class TestPacketSource:
         -------
         os.path
         """
-        return os.path.abspath(os.path.join(tardis_ref_path, "packet_unittest.h5"))
+        return os.path.abspath(
+            os.path.join(tardis_ref_path, "packet_unittest.h5")
+        )
 
     @pytest.fixture(scope="class")
     def blackbodysimplesource(self, request):
@@ -63,7 +65,11 @@ class TestPacketSource:
         montecarlo_configuration.LEGACY_MODE_ENABLED = False
 
     def test_bb_packet_sampling(
-        self, request, tardis_ref_data, packet_unit_test_fpath, blackbodysimplesource
+        self,
+        request,
+        tardis_ref_data,
+        packet_unit_test_fpath,
+        blackbodysimplesource,
     ):
         """
         Parameters
@@ -74,7 +80,9 @@ class TestPacketSource:
         """
         if request.config.getoption("--generate-reference"):
             ref_bb = pd.read_hdf(packet_unit_test_fpath, key="/blackbody")
-            ref_bb.to_hdf(tardis_ref_data, key="/packet_unittest/blackbody", mode="a")
+            ref_bb.to_hdf(
+                tardis_ref_data, key="/packet_unittest/blackbody", mode="a"
+            )
             pytest.skip("Reference data was generated during this run.")
 
         ref_df = tardis_ref_data["/packet_unittest/blackbody"]
@@ -101,9 +109,11 @@ class TestPacketSource:
         blackbody_simplesource_relativistic.beta = 0.25
 
         nus = blackbody_simplesource_relativistic.create_packet_nus(100).value
-        unif_energies = blackbody_simplesource_relativistic.create_packet_energies(
-            100
-        ).value
+        unif_energies = (
+            blackbody_simplesource_relativistic.create_packet_energies(
+                100
+            ).value
+        )
         blackbody_simplesource_relativistic._reseed(2508)
         mus = blackbody_simplesource_relativistic.create_packet_mus(10)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Changes functions in PacketSource to produce quantities, and the packetcollection creator function converts those to raw numpy arrays. Not sure if we want to test the functions explicitly with quantities.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
