### PR TITLE
Typo in parse_structure_config documentation string

### DIFF
--- a/tardis/model/geometry/radial1d.py
+++ b/tardis/model/geometry/radial1d.py
@@ -11,10 +11,10 @@ class HomologousRadial1DGeometry:
 
     Parameters
     ----------
-    r_inner : astropy.units.quantity.Quantity
-    r_outer : astropy.units.quantity.Quantity
     v_inner : astropy.units.quantity.Quantity
     v_outer : astropy.units.quantity.Quantity
+    v_inner_boundary : astropy.units.quantity.Quantity
+    v_outer_boundary : astropy.units.quantity.Quantity
 
     Attributes
     ----------

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -181,8 +181,8 @@ def parse_csvy_geometry(
         velocity = velocity.to("cm/s")
 
     geometry = HomologousRadial1DGeometry(
-        velocity[:-1],  # r_inner
-        velocity[1:],  # r_outer
+        velocity[:-1],  # v_inner
+        velocity[1:],  # v_outer
         v_inner_boundary=v_boundary_inner,
         v_outer_boundary=v_boundary_outer,
         time_explosion=time_explosion,

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -66,42 +66,6 @@ def parse_structure_config(config, time_explosion, enable_homology=True):
     parsed from the configuration. If it is of type 'file', the velocity and density are
     read from a file. The parsed data is used to create a homologous radial 1D geometry object.
     """
-    """
-    Parse the structure configuration data.
-
-    Parameters
-    ----------
-    config : object
-        The configuration data.
-    time_explosion : float
-        The time of the explosion.
-    enable_homology : bool, optional
-        Whether to enable homology (default is True).
-
-    Returns
-    -------
-    electron_densities : object
-        The parsed electron densities.
-    temperature : object
-        The parsed temperature.
-    geometry : object
-        The parsed geometry.
-    density : object
-        The parsed density.
-
-    Raises
-    ------
-    NotImplementedError
-        If the structure configuration type is not supported.
-
-    Notes
-    -----
-    This function parses the structure configuration data and returns the parsed electron
-    densities, temperature, geometry, and density. The structure configuration can be of
-    type 'specific' or 'file'. If it is of type 'specific', the velocity and density are
-    parsed from the configuration. If it is of type 'file', the velocity and density are
-    read from a file. The parsed data is used to create a homologous radial 1D geometry object.
-    """
     electron_densities = None
     temperature = None
     structure_config = config.model.structure

--- a/tardis/model/parse_input.py
+++ b/tardis/model/parse_input.py
@@ -109,8 +109,8 @@ def parse_structure_config(config, time_explosion, enable_homology=True):
         )
         density = density[1:]
     geometry = HomologousRadial1DGeometry(
-        velocity[:-1],  # r_inner
-        velocity[1:],  # r_outer
+        velocity[:-1],  # v_inner
+        velocity[1:],  # v_outer
         v_inner_boundary=structure_config.get("v_inner_boundary", None),
         v_outer_boundary=structure_config.get("v_outer_boundary", None),
         time_explosion=time_explosion,


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

The documentation string of `parse_structure_config` was repeated twice, so I removed the extra one.
Also, there were some instances where `v_inner, v_outer` were labeled as `r_inner, r_outer`. So, I have changed them as well.



### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

@wkerzendorf Please apply the `build_docs` label.
> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
