### PR TITLE
Documentation typo

### DIFF
--- a/docs/physics/montecarlo/basicprinciples.rst
+++ b/docs/physics/montecarlo/basicprinciples.rst
@@ -102,7 +102,7 @@ This leads to the sampling rule
 
 .. math::
 
-    \mu = 2 z - 1.
+    \mu = 2 z + 1.
 
 Next Interaction Location
 -------------------------

--- a/docs/physics/montecarlo/basicprinciples.rst
+++ b/docs/physics/montecarlo/basicprinciples.rst
@@ -95,8 +95,8 @@ Here, all scattering angles are equally likely. Thus, the corresponding
 
 .. math::
 
-    \rho_{\mu}(\mu) &= \frac{1}{2}\\
-    f_{\mu}(\mu) &= \frac{1}{2} (\mu + 1).
+    \rho(\mu) &= \frac{1}{2}\\
+    f(\mu) &= \frac{1}{2} (\mu + 1).
 
 This leads to the sampling rule
 
@@ -112,8 +112,8 @@ The probability of a photon interacting after covering an optical depth
 
 .. math::
 
-    \rho_{\tau}(\tau) &= \exp(-\tau)\\
-    f_{\tau}(\tau) &= 1 - \exp(-\tau).
+    \rho(\tau) &= \exp(-\tau)\\
+    f(\tau) &= 1 - \exp(-\tau).
 
 
 With the inverse transformation method, the optical depth to the next interaction location may then be sampled by 

--- a/docs/physics/montecarlo/basicprinciples.rst
+++ b/docs/physics/montecarlo/basicprinciples.rst
@@ -96,13 +96,13 @@ Here, all scattering angles are equally likely. Thus, the corresponding
 .. math::
 
     \rho_{\mu}(\mu) &= \frac{1}{2}\\
-    f_{\mu}(\mu) &= \frac{1}{2} (\mu - 1).
+    f_{\mu}(\mu) &= \frac{1}{2} (\mu + 1).
 
 This leads to the sampling rule
 
 .. math::
 
-    \mu = 2 z + 1.
+    \mu = 2 z - 1.
 
 Next Interaction Location
 -------------------------

--- a/docs/physics/montecarlo/propagation.rst
+++ b/docs/physics/montecarlo/propagation.rst
@@ -186,9 +186,9 @@ Thomson scattering is calculated by the formula
     \Delta \tau = \sigma_{\mathrm{T}} n_e l.
 
 The Thomson cross section :math:`\sigma_{\mathrm{T}}`, which is a constant,
-appears here. This corresponds to the fact that a packet has a probability of :math:`1-e^{\sigma_{\mathrm{T}} n_e l}`
+appears here. This corresponds to the fact that a packet has a probability of :math:`1-e^{-\sigma_{\mathrm{T}} n_e l}`
 of going through a Thomson scattering prior to traveling a distance :math:`l` (in other words, the probability of the
-packet making it across a distance :math:`l` without scattering is :math:`e^{\sigma_{\mathrm{T}} n_e l}`).
+packet making it across a distance :math:`l` without scattering is :math:`e^{-\sigma_{\mathrm{T}} n_e l}`).
 
 The situation is complicated by the inclusion of frequency-dependent
 bound-bound interactions, i.e. interactions with atomic line transitions.


### PR DESCRIPTION
### :pencil: Description

**Type:** : :memo: `documentation`

A mathematical typo

$$\rho_{\mu}(\mu) = \frac{1}{2}\qquad \text{for } -1\le \mu \le 1$$

For: $-1\le \mu \le 1$
$$f_{\mu}(\mu) = \int_{-\infty}^{\mu} \rho_{\mu} d{\mu}$$

$$f_{\mu}(\mu) = \int_{-1}^{\mu} \frac{1}{2} d{\mu}$$

$$f_{\mu}(\mu) = \frac{1}{2}(\mu + 1)$$



### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
@wkerzendorf @andrewfullard Please review.