### PR TITLE
Updated helium nlte page in docs with in-text citation

### DIFF
--- a/docs/physics/setup/plasma/helium_nlte.rst
+++ b/docs/physics/setup/plasma/helium_nlte.rst
@@ -3,7 +3,7 @@ Helium NLTE
 
 The `helium_treatment` setting in the TARDIS config. file will accept one of three options:
  * `none`: The default setting. Populate helium in the same way as the other elements.
- * `recomb-nlte`: Treats helium in NLTE using the analytical approximation outlined in an upcoming paper. 
+ * `recomb-nlte`: Treats helium in NLTE using the analytical approximation outlined in :cite:`Boyle2017`. 
  * `numerical-nlte`: To be implemented. Will allow the use of a separate module (not distributed with TARDIS) to perform helium NLTE calculations numerically.
 
 Recombination He NLTE

--- a/docs/tardis.bib
+++ b/docs/tardis.bib
@@ -331,3 +331,20 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/1949PhRv...75.1696O},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
+@ARTICLE{Boyle2017,
+       author = {{Boyle}, Aoife and {Sim}, Stuart A. and {Hachinger}, Stephan and {Kerzendorf}, Wolfgang},
+        title = "{Helium in double-detonation models of type Ia supernovae}",
+      journal = {\aap},
+     keywords = {supernovae: general, white dwarfs, radiative transfer, Astrophysics - High Energy Astrophysical Phenomena, Astrophysics - Solar and Stellar Astrophysics},
+         year = 2017,
+        month = mar,
+       volume = {599},
+          eid = {A46},
+          doi = {10.1051/0004-6361/201629712},
+archivePrefix = {arXiv},
+       eprint = {1611.05938},
+ primaryClass = {astro-ph.HE},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2017A&A...599A..46B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation` 

The Helium NLTE docs page had a line referring to information "in an upcoming paper," but that [paper](https://ui.adsabs.harvard.edu/abs/2017A%26A...599A..46B/abstract) came out in 2017. I added the paper to the list of references and replaced "in an upcoming paper" with an in-text citation.

### :pushpin: Resources

<img width="918" alt="Screenshot 2024-04-04 at 5 25 47 PM" src="https://github.com/tardis-sn/tardis/assets/144159238/b1669e62-123e-4b1c-8749-0adec185e46a">

<img width="1043" alt="Screenshot 2024-04-04 at 5 26 25 PM" src="https://github.com/tardis-sn/tardis/assets/144159238/727bd047-248e-4ff4-9889-9e1e0022c249">

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
