### PR TITLE
Abundance widget bug fix

### DIFF
--- a/docs/io/visualization/how_to_abundance_widget.ipynb
+++ b/docs/io/visualization/how_to_abundance_widget.ipynb
@@ -97,7 +97,7 @@
    "outputs": [],
    "source": [
     "# sim = run_tardis(\"tardis_example.yml\")\n",
-    "# widget = CustomAbundanceWidget.from_sim(sim)"
+    "# widget = CustomAbundanceWidget.from_simulation(sim)"
    ]
   },
   {

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -282,7 +282,9 @@ class CustomAbundanceWidgetData:
         CustomAbundanceWidgetData
         """
         abundance = sim.simulation_state.abundance.copy()
-        isotope_abundance = sim.simulation_state.composition.raw_isotope_abundance.copy()
+        isotope_abundance = (
+            sim.simulation_state.composition.raw_isotope_abundance.copy()
+        )
 
         # integrate element and isotope to one DataFrame
         abundance["mass_number"] = ""

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -281,8 +281,8 @@ class CustomAbundanceWidgetData:
         -------
         CustomAbundanceWidgetData
         """
-        abundance = sim.simulation_state.raw_abundance.copy()
-        isotope_abundance = sim.simulation_state.raw_isotope_abundance.copy()
+        abundance = sim.simulation_state.abundance.copy()
+        isotope_abundance = sim.simulation_state.composition.raw_isotope_abundance.copy()
 
         # integrate element and isotope to one DataFrame
         abundance["mass_number"] = ""


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`
The wrong usage of the parameters of the simulation_state class caused the bug. 

fixes #2571 

### :pushpin: Resources

Output after the fix

![Screenshot from 2024-04-09 14-47-47](https://github.com/tardis-sn/tardis/assets/53135486/b8b6dd77-8e0c-47b9-93db-87fcd220620d)
![Screenshot from 2024-04-09 14-48-05](https://github.com/tardis-sn/tardis/assets/53135486/c31f2de1-5be2-4dee-b55b-4aeafb85830c)



### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
@andrewfullard please review.