### PR TITLE
Fixed the broken import modules in main gamma ray loop.

### DIFF
--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -9,12 +9,14 @@ from tardis.energy_input.energy_source import (
 )
 
 from tardis.energy_input.gamma_packet_loop import gamma_packet_loop
+from tardis.energy_input.gamma_ray_channel import (
+    create_isotope_dicts,
+    create_inventories_dict,
+    calculate_total_decays
+)
 from tardis.energy_input.gamma_ray_transport import (
     initialize_packets,
     calculate_ejecta_velocity_volume,
-    create_isotope_dicts,
-    create_inventories_dict,
-    calculate_total_decays,
     calculate_average_energies,
     decay_chain_energies,
     calculate_energy_per_mass,


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`.

Bug fix: Broken modules imported for Gamma Ray. #2590.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 

- #2590: `fix` and `close`.

### :pushpin: Resources

Examples, notebooks, and links to useful references.

N/A

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)
  - There is no unit test for `run_gamma_ray_loop`.
  - This function is used in `docs/working_gamma_ray_test.ipynb`.


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
