### PR TITLE
Fixes IntegrationError causing refdata generation failure

### DIFF
--- a/tardis/montecarlo/montecarlo_transport_state.py
+++ b/tardis/montecarlo/montecarlo_transport_state.py
@@ -236,13 +236,15 @@ class MonteCarloTransportState(HDFWriterMixin):
                 # if integration is impossible or fails, return an empty spectrum
                 warnings.warn(
                     "The FormalIntegrator is not yet implemented for the full "
-                    "relativity mode oir continuum processes. "
+                    "relativity mode or continuum processes. "
                     "Please run with config option enable_full_relativity: "
-                    "False and continuum_processes_enabled: False",
+                    "False and continuum_processes_enabled: False "
+                    "This RETURNS AN EMPTY SPECTRUM!",
                     UserWarning,
                 )
                 return TARDISSpectrum(
-                    np.array([0, 1]) * u.Hz, np.array([0]) * u.erg / u.s
+                    np.array([np.nan, np.nan]) * u.Hz,
+                    np.array([np.nan]) * u.erg / u.s,
                 )
         return self._spectrum_integrated
 

--- a/tardis/montecarlo/montecarlo_transport_state.py
+++ b/tardis/montecarlo/montecarlo_transport_state.py
@@ -4,10 +4,11 @@ import numpy as np
 from astropy import units as u
 
 from tardis.io.util import HDFWriterMixin
-from tardis.montecarlo.spectrum import TARDISSpectrum
 from tardis.montecarlo.estimators.dilute_blackbody_properties import (
     MCDiluteBlackBodyRadFieldSolver,
 )
+from tardis.montecarlo.montecarlo_numba.formal_integral import IntegrationError
+from tardis.montecarlo.spectrum import TARDISSpectrum
 
 
 class MonteCarloTransportState(HDFWriterMixin):
@@ -74,6 +75,7 @@ class MonteCarloTransportState(HDFWriterMixin):
         self.integrator_settings = None
         self._spectrum_integrated = None
         self.enable_full_relativity = False
+        self.enable_continuum_processes = False
         self.geometry_state = geometry_state
         self.opacity_state = opacity_state
         self.rpacket_tracker = rpacket_tracker
@@ -224,11 +226,24 @@ class MonteCarloTransportState(HDFWriterMixin):
         if self._spectrum_integrated is None:
             # This was changed from unpacking to specific attributes as compute
             # is not used in calculate_spectrum
-            self._spectrum_integrated = self.integrator.calculate_spectrum(
-                self.spectrum_frequency[:-1],
-                points=self.integrator_settings.points,
-                interpolate_shells=self.integrator_settings.interpolate_shells,
-            )
+            try:
+                self._spectrum_integrated = self.integrator.calculate_spectrum(
+                    self.spectrum_frequency[:-1],
+                    points=self.integrator_settings.points,
+                    interpolate_shells=self.integrator_settings.interpolate_shells,
+                )
+            except IntegrationError:
+                # if integration is impossible or fails, return an empty spectrum
+                warnings.warn(
+                    "The FormalIntegrator is not yet implemented for the full "
+                    "relativity mode oir continuum processes. "
+                    "Please run with config option enable_full_relativity: "
+                    "False and continuum_processes_enabled: False"
+                    UserWarning,
+                )
+                return TARDISSpectrum(
+                    np.array([0, 1]) * u.Hz, np.array([0]) * u.erg / u.s
+                )
         return self._spectrum_integrated
 
     @property

--- a/tardis/montecarlo/montecarlo_transport_state.py
+++ b/tardis/montecarlo/montecarlo_transport_state.py
@@ -238,7 +238,7 @@ class MonteCarloTransportState(HDFWriterMixin):
                     "The FormalIntegrator is not yet implemented for the full "
                     "relativity mode oir continuum processes. "
                     "Please run with config option enable_full_relativity: "
-                    "False and continuum_processes_enabled: False"
+                    "False and continuum_processes_enabled: False",
                     UserWarning,
                 )
                 return TARDISSpectrum(


### PR DESCRIPTION
Now returns an empty spectrum instead of a crash and gives a warning.

### :pencil: Description

**Type:** :beetle: `bugfix` 

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
