### PR TITLE
Only Run Benchmarks Workflow When Owner is `tardis-sn`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,11 +26,11 @@ defaults:
 
 jobs:
   build:
-    if: github.repository_owner == 'tardis-sn' ||
-        github.event_name == 'push' ||
+    if: github.repository_owner == 'tardis-sn' &&
+        (github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' || 
         (github.event_name == 'pull_request_target' &&
-        contains(github.event.pull_request.labels.*.name, 'benchmarks'))
+        contains(github.event.pull_request.labels.*.name, 'benchmarks')))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,8 @@ defaults:
 
 jobs:
   build:
-    if: github.event_name == 'push' ||
+    if: github.repository_owner == 'tardis-sn' ||
+        github.event_name == 'push' ||
         github.event_name == 'workflow_dispatch' || 
         (github.event_name == 'pull_request_target' &&
         contains(github.event.pull_request.labels.*.name, 'benchmarks'))


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

People with write access to the benchmarks repo can accidentally push to the repository if they push to the master tardis branch. 

This pull request changes the workflow so it only runs if the repo owner is tardis-sn. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [X] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
