### PR TITLE
LFS submodule error fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "astropy_shelpers"]
+	path = astropy_helpers
+	url = https://github.com/astropy/astropy-helpers.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "astropy_shelpers"]
-	path = astropy_helpers
-	url = https://github.com/astropy/astropy-helpers.git


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` :vertical_traffic_light: `testing` 

There is a submodule error which arises when setting up LFS.
https://github.com/tardis-sn/tardis/actions/runs/8972388017/job/24644151597#step:3:49
This PR aims to fix that.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
