### PR TITLE
Removing checkout to the tardis repo step from setup lfs workflow

### DIFF
--- a/.github/actions/setup_lfs/action.yml
+++ b/.github/actions/setup_lfs/action.yml
@@ -1,97 +1,96 @@
-name: 'Setup LFS'
-description: 'Pull LFS repositories and caches them'
+name: "Setup LFS"
+description: "Pull LFS repositories and caches them"
 
 inputs:
   refdata-repo:
     description: "tardis refdata repository"
     required: false
-    default: 'tardis-sn/tardis-refdata'
-  regression-data-repo: 
+    default: "tardis-sn/tardis-refdata"
+  regression-data-repo:
     description: "tardis regression data repository"
     required: false
-    default: 'tardis-sn/tardis-regression-data'
+    default: "tardis-sn/tardis-regression-data"
 
 runs:
-    using: "composite"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Clone Refdata Repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.refdata-repo }}
-          path: tardis-refdata
-          lfs: false
+  using: "composite"
+  steps:
+    - name: Clone Refdata Repo
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.refdata-repo }}
+        path: tardis-refdata
+        lfs: false
 
-      - name: Create LFS file list
-        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-        working-directory: tardis-refdata
-        shell: bash
+    - name: Create LFS file list
+      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      working-directory: tardis-refdata
+      shell: bash
 
-      - name: Restore LFS cache
-        uses: actions/cache/restore@v3
-        id: lfs-cache-refdata
-        with:
-          path: tardis-refdata/.git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-refdata/.lfs-assets-id') }}-v1
+    - name: Restore LFS cache
+      uses: actions/cache/restore@v3
+      id: lfs-cache-refdata
+      with:
+        path: tardis-refdata/.git/lfs
+        key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-refdata/.lfs-assets-id') }}-v1
 
-      - name: Git LFS Pull
-        run: git lfs pull
-        working-directory: tardis-refdata
-        if: steps.lfs-cache-refdata.outputs.cache-hit != 'true'
-        shell: bash
-      
-      - name: Git LFS Checkout
-        run: git lfs checkout
-        working-directory: tardis-refdata
-        if: steps.lfs-cache-refdata.outputs.cache-hit == 'true'
-        shell: bash
-      
-      - name: Save LFS cache if not found
-        # uses fake ternary 
-        # for reference: https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
-        if: ${{ steps.lfs-cache-refdata.outputs.cache-hit != 'true'  && always() || false }}
-        uses: actions/cache/save@v3
-        id: lfs-cache-refdata-save
-        with:
-          path: tardis-refdata/.git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-refdata/.lfs-assets-id') }}-v1
-      
-      - name: Clone tardis-sn/tardis-regression-data
-        uses: actions/checkout@v4
-        with:
-          repository:  ${{ inputs.regression-data-repo }}
-          path: tardis-regression-data
-      
-      - name: Create LFS file list
-        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-        working-directory: tardis-regression-data
-        shell: bash
+    - name: Git LFS Pull
+      run: git lfs pull
+      working-directory: tardis-refdata
+      if: steps.lfs-cache-refdata.outputs.cache-hit != 'true'
+      shell: bash
 
-      - name: Restore LFS cache
-        uses: actions/cache/restore@v3
-        id: lfs-cache-regression-data
-        with:
-          path: tardis-regression-data/.git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-regression-data/.lfs-assets-id') }}-v1
-  
-      - name: Git LFS Pull
-        run: git lfs pull
-        working-directory: tardis-regression-data
-        if: steps.lfs-cache-regression-data.outputs.cache-hit != 'true'
-        shell: bash
-      
-      - name: Git LFS Checkout
-        run: git lfs checkout
-        working-directory: tardis-regression-data
-        if: steps.lfs-cache-regression-data.outputs.cache-hit == 'true'
-        shell: bash
-      
-      - name: Save LFS cache if not found
-        # uses fake ternary 
-        # for reference: https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
-        if: ${{ steps.lfs-cache-regression-data.outputs.cache-hit != 'true'  && always() || false }}
-        uses: actions/cache/save@v3
-        id: lfs-cache-regression-data-save
-        with:
-          path: tardis-regression-data/.git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-regression-data/.lfs-assets-id') }}-v1
+    - name: Git LFS Checkout
+      run: git lfs checkout
+      working-directory: tardis-refdata
+      if: steps.lfs-cache-refdata.outputs.cache-hit == 'true'
+      shell: bash
+
+    - name: Save LFS cache if not found
+      # uses fake ternary
+      # for reference: https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
+      if: ${{ steps.lfs-cache-refdata.outputs.cache-hit != 'true'  && always() || false }}
+      uses: actions/cache/save@v3
+      id: lfs-cache-refdata-save
+      with:
+        path: tardis-refdata/.git/lfs
+        key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-refdata/.lfs-assets-id') }}-v1
+
+    - name: Clone tardis-sn/tardis-regression-data
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.regression-data-repo }}
+        path: tardis-regression-data
+
+    - name: Create LFS file list
+      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      working-directory: tardis-regression-data
+      shell: bash
+
+    - name: Restore LFS cache
+      uses: actions/cache/restore@v3
+      id: lfs-cache-regression-data
+      with:
+        path: tardis-regression-data/.git/lfs
+        key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-regression-data/.lfs-assets-id') }}-v1
+
+    - name: Git LFS Pull
+      run: git lfs pull
+      working-directory: tardis-regression-data
+      if: steps.lfs-cache-regression-data.outputs.cache-hit != 'true'
+      shell: bash
+
+    - name: Git LFS Checkout
+      run: git lfs checkout
+      working-directory: tardis-regression-data
+      if: steps.lfs-cache-regression-data.outputs.cache-hit == 'true'
+      shell: bash
+
+    - name: Save LFS cache if not found
+      # uses fake ternary
+      # for reference: https://github.com/orgs/community/discussions/26738#discussioncomment-3253176
+      if: ${{ steps.lfs-cache-regression-data.outputs.cache-hit != 'true'  && always() || false }}
+      uses: actions/cache/save@v3
+      id: lfs-cache-regression-data-save
+      with:
+        path: tardis-regression-data/.git/lfs
+        key: ${{ runner.os }}-lfs-${{ hashFiles('tardis-regression-data/.lfs-assets-id') }}-v1


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This step is not needed as the tardis code is not used anywhere in the workflow.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
