### PR TITLE
[WIP] benchmark for energy input package

### DIFF
--- a/benchmarks/energy_input_energy_source.py
+++ b/benchmarks/energy_input_energy_source.py
@@ -1,0 +1,43 @@
+from asv_runner.benchmarks.mark import parameterize
+import numpy as np
+import pandas as pd
+import radioactivedecay as rd
+
+import tardis.energy_input.energy_source as energy_source
+from benchmarks.benchmark_base import BenchmarkBase
+
+from tardis.util.base import (
+    atomic_number2element_symbol,
+)
+from tardis.energy_input.util import (
+    convert_half_life_to_astropy_units,
+    ELECTRON_MASS_ENERGY_KEV,
+)
+
+
+class BenchmarkEnergyInputEnergySource(BenchmarkBase):
+    """
+    Class to benchmark the energy source
+    """
+
+    def time_positronium_continuum(self):
+        energy_source.positronium_continuum()
+
+    @parameterize(
+        {
+            "atomic number": [
+                1, 
+                24, 
+                13, 
+                18,
+            ], 
+            "atomic mass": [
+                1.008, 
+                51.9961,
+                26.9815385,
+                39.948,
+            ]
+        }
+    )
+    def time_get_isotope_string(atomic_number, atomic_mass):
+        energy_source.get_isotope_string(atomic_number, atomic_mass)


### PR DESCRIPTION
### :pencil: Description

Benchmark for energy input package within tardis

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
