### PR TITLE
Creating a new class RPacketLastInteractionTracker and initializing it

### DIFF
--- a/tardis/transport/montecarlo/montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/montecarlo_main_loop.py
@@ -5,7 +5,10 @@ from numba.typed import List
 
 from tardis.transport.montecarlo import njit_dict
 from tardis.transport.montecarlo.numba_interface import NumbaModel
-from tardis.transport.montecarlo.packet_trackers import RPacketTracker
+from tardis.transport.montecarlo.packet_trackers import (
+    RPacketTracker,
+    RPacketLastInteractionTracker,
+)
 from tardis.transport.montecarlo.packet_collections import (
     VPacketCollection,
     consolidate_vpacket_tracker,
@@ -68,6 +71,9 @@ def montecarlo_main_loop(
         no_of_packets
     )
 
+    # While in review this is a temporary name, will delete the original
+    # last_interaction_tracker class and will use that name
+    last_interaction_tracker_work = RPacketLastInteractionTracker(no_of_packets)
     v_packets_energy_hist = np.zeros_like(spectrum_frequency)
     delta_nu = spectrum_frequency[1] - spectrum_frequency[0]
 

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -115,18 +115,45 @@ class RPacketTracker(object):
 last_interaction_tracker_spec = [
     ("radius", float64[:]),
     ("shell_id", int64[:]),
-    ("interaction_type", int64[:]),
     ("energy", float64[:]),
+    ("nu", float64[:]),
+    ("interaction_type", int64[:]),
     ("in_id", int64[:]),
     ("in_nu", float64[:]),
     ("out_id", int64[:]),
     ("out_nu", float64[:]),
-    ("nu", float64[:]),
 ]
 
 
 @jitclass(last_interaction_tracker_spec)
 class RPacketLastInteractionTracker:
+    """
+    Numba JITCLASS for storing the last interaction information that an RPacket underwent.
+    Parameters
+    ----------
+        radius : float
+            Radius from the center where the interaction happened.
+        shell_id : int
+            The id of the shell in which the interaction happened.
+        energy : float
+            The energy of the RPacket
+        nu : float
+            The frequency of the RPacket after the interaction.
+        interaction_type: int
+            The id of the type of interaction that happened
+                - LINE = 2
+                - ESCATTERING = 4
+                - CONTINUUM_PROCESS = 8
+        in_id : int
+            In case of Line Interaction, the id of the absorption line interaction.
+        in_nu : float
+            The frequency corresponding to the absorption process
+        out_id : int
+            In case of Line Interaction, the id of the emission line interaction.
+        out_nu : float
+            The frequency corresponding to the emission process
+    """
+
     def __init__(self, no_of_packets):
         self.radius = -1 * np.ones(no_of_packets, dtype=np.float64)
         self.shell_id = -1 * np.ones(no_of_packets, dtype=np.int64)

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -110,3 +110,30 @@ class RPacketTracker(object):
         self.energy = self.energy[: self.num_interactions]
         self.shell_id = self.shell_id[: self.num_interactions]
         self.interaction_type = self.interaction_type[: self.num_interactions]
+
+
+last_interaction_tracker_spec = [
+    ("radius", float64[:]),
+    ("shell_id", int64[:]),
+    ("interaction_type", int64[:]),
+    ("energy", float64[:]),
+    ("in_id", int64[:]),
+    ("in_nu", float64[:]),
+    ("out_id", int64[:]),
+    ("out_nu", float64[:]),
+    ("nu", float64[:]),
+]
+
+
+@jitclass(last_interaction_tracker_spec)
+class RPacketLastInteractionTracker:
+    def __init__(self, no_of_packets):
+        self.radius = -1 * np.ones(no_of_packets, dtype=np.float64)
+        self.shell_id = -1 * np.ones(no_of_packets, dtype=np.int64)
+        self.nu = np.zeros(no_of_packets, dtype=np.float64)
+        self.energy = np.zeros(no_of_packets, dtype=np.float64)
+        self.interaction_type = -1 * np.ones(no_of_packets, dtype=np.int64)
+        self.in_id = -1 * np.ones(no_of_packets, dtype=np.in64)
+        self.in_nu = np.zeros(no_of_packets, dtype=np.float64)
+        self.out_id = -1 * np.ones(no_of_packets, dtype=np.int64)
+        self.out_nu = np.zeros(no_of_packets, dtype=np.float64)


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature`

This PR will create a new class, RPacketLastInteractionTracker, which will store the information of the last interaction an RPacket undergoes. 
The information it will store:
 - radius
 - shell_id
 - interaction_type
 - nu
 - energy
In case of Line Interaction It will also store,
 - in_id
 - in_nu
 - out_id
 - out_nu






### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
