### PR TITLE
Fix missing atom data error in benchmark action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -97,11 +97,7 @@ jobs:
             echo "Some benchmarks have failed!"
             exit 1
           fi
-
-      - name: ASV benchmarks
-        if: github.event_name != 'pull_request_target'
-        run: asv run --bench just-discover
-
+          
       - name: Generate Graphs and HTML
         if: github.event_name != 'pull_request_target'
         run: asv publish

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,6 +66,11 @@ jobs:
           path: benchmarks/data/kurucz_cd23_chianti_H_He.h5
           key: atom-data
 
+      - name: Copy atom data to refdata
+        run: |
+          mkdir -p tardis-refdata/atom_data
+          cp benchmarks/data/kurucz_cd23_chianti_H_He.h5 tardis-refdata/atom_data/
+
       - name: Setup Mamba
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -92,6 +97,10 @@ jobs:
             echo "Some benchmarks have failed!"
             exit 1
           fi
+
+      - name: ASV benchmarks
+        if: github.event_name != 'pull_request_target'
+        run: asv run --bench just-discover
 
       - name: Generate Graphs and HTML
         if: github.event_name != 'pull_request_target'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -97,7 +97,7 @@ jobs:
             echo "Some benchmarks have failed!"
             exit 1
           fi
-          
+
       - name: Generate Graphs and HTML
         if: github.event_name != 'pull_request_target'
         run: asv publish


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

The benchmarks workflow throws an error where it could find the atomic data. Copying atomic data to that specific directory will fix that issue

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
