### PR TITLE
Adds continuum marker to pytest and continuum tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
           echo "TARDIS_PIP_PATH=$directory_path" >> $GITHUB_ENV
 
       - name: Run tests
-        run: pytest tardis ${{ env.PYTEST_FLAGS }} -m not continuum
+        run: pytest tardis ${{ env.PYTEST_FLAGS }} -m "not continuum"
         working-directory: ${{ env.TARDIS_PIP_PATH }}
         if: always()
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ on:
 env:
   CACHE_NUMBER: 0  # increase to reset cache manually
   PYTEST_FLAGS: --tardis-refdata=${{ github.workspace }}/tardis-refdata --tardis-regression-data=${{ github.workspace }}/tardis-regression-data
-                --cov=tardis --cov-report=xml --cov-report=html 
+                --cov=tardis --cov-report=xml --cov-report=html
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 concurrency:
@@ -100,7 +100,12 @@ jobs:
           echo "TARDIS_PIP_PATH=$directory_path" >> $GITHUB_ENV
 
       - name: Run tests
-        run: pytest tardis ${{ env.PYTEST_FLAGS }}
+        run: pytest tardis ${{ env.PYTEST_FLAGS }} -m not continuum
+        working-directory: ${{ env.TARDIS_PIP_PATH }}
+        if: always()
+
+      - name: Run continuum tests
+        run: pytest tardis ${{ env.PYTEST_FLAGS }} -m continuum
         working-directory: ${{ env.TARDIS_PIP_PATH }}
         if: always()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,10 @@ tardis_visualization = ["tools/tests/data/*"]
 testpaths = ["tardis"]
 astropy_header = true
 text_file_format = "rst"
+markers = [
+    # continuum tests
+    "continuum",
+]
 
 [tool.tardis]
 edit_on_github = false

--- a/tardis/transport/montecarlo/estimators/tests/test_continuum_property_solver.py
+++ b/tardis/transport/montecarlo/estimators/tests/test_continuum_property_solver.py
@@ -11,6 +11,7 @@ from tardis.transport.montecarlo.estimators.continuum_radfield_properties import
 from tardis.simulation import Simulation
 
 
+@pytest.mark.continuum
 def test_continuum_estimators(
     continuum_config,
     nlte_atomic_dataset,

--- a/tardis/transport/montecarlo/tests/test_continuum.py
+++ b/tardis/transport/montecarlo/tests/test_continuum.py
@@ -6,6 +6,7 @@ import pytest
 from tardis.simulation import Simulation
 
 
+@pytest.mark.continuum
 def test_montecarlo_continuum(
     continuum_config,
     regression_data,


### PR DESCRIPTION
Also applies to tests action, splitting it by marker.

### :pencil: Description

**Type:** :vertical_traffic_light: `testing` 

We are moving back to global vars for our configuration so we need to isolate continuum tests. This achieve it with a custom pytest marker.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
