### PR TITLE
Move setup environment steps to composite action

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -1,0 +1,32 @@
+name: "Setup environment"
+description: "Sets up environment for tardis and caches it"
+
+inputs:
+  os-label:
+    description: "os label for lock file, default linux"
+    required: true
+    default: "linux"
+
+runs:
+  using: "composite"
+  steps:
+      - name: Download Lock File
+        run:  wget -q https://raw.githubusercontent.com/tardis-sn/tardis/master/conda-${{ inputs.os-label }}.lock
+        if: matrix.pip == true
+        shell: bash
+      
+      - name: Generate Cache Key
+        run: | 
+          file_hash=$(cat conda-${{ inputs.os-label }}.lock | shasum -a 256 | cut -d' ' -f1)
+          echo "file_hash=$file_hash" >> "${GITHUB_OUTPUT}"
+        id: cache-environment-key
+        shell: bash
+        
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: conda-${{ inputs.os-label }}.lock
+          cache-environment-key: ${{ steps.cache-environment-key.outputs.file_hash }}
+          cache-downloads-key: ${{ steps.cache-environment-key.outputs.file_hash }}
+          environment-name: tardis
+          cache-environment: true
+          cache-downloads: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,25 +56,11 @@ jobs:
 
       - name: Setup LFS
         uses: ./.github/actions/setup_lfs
-
-      - name: Download Lock File
-        run:  wget -q https://raw.githubusercontent.com/tardis-sn/tardis/master/conda-${{ matrix.label }}.lock
-        if: matrix.pip == true
       
-      - name: Generate Cache Key
-        run: | 
-          file_hash=$(cat conda-${{ matrix.label }}.lock | shasum -a 256 | cut -d' ' -f1)
-          echo "file_hash=$file_hash" >> "${GITHUB_OUTPUT}"
-        id: cache-environment-key
-        
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: conda-${{ matrix.label }}.lock
-          cache-environment-key: ${{ steps.cache-environment-key.outputs.file_hash }}
-          cache-downloads-key: ${{ steps.cache-environment-key.outputs.file_hash }}
-          environment-name: tardis
-          cache-environment: true
-          cache-downloads: true
+      - name: Setup environment
+        uses: ./.github/actions/setup_env
+        with: 
+          os-label: ${{ matrix.label }}
 
       - name: Install package editable
         run: |


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The setup environment steps are redundant across all workflows and can be moved to a separate composite action file. This will make it easy to users to create new workflows and make them simpler.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
