### PR TITLE
Triggering tests in stardis after every push to master branch

### DIFF
--- a/.github/workflows/stardis-dispatch.yml
+++ b/.github/workflows/stardis-dispatch.yml
@@ -19,5 +19,5 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
-            -d '{ "event_type": "trigger-workflow", "client_payload": {"commit_sha": "${{ steps.get_sha.outputs.COMMIT_SHA }}"}}' \
+            -d '{ "event_type": "Tardis-Dispatch", "client_payload": {"commit_sha": "${{ steps.get_sha.outputs.COMMIT_SHA }}"}}' \
             https://api.github.com/repos/${{github.repository_owner}}/stardis/dispatches

--- a/.github/workflows/stardis-dispatch.yml
+++ b/.github/workflows/stardis-dispatch.yml
@@ -10,14 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Get commit SHA
-        id: get_sha
-        run: echo "::set-output name=COMMIT_SHA::$(git rev-parse HEAD)"
       - name: Dispatch to Stardis
         run: |
           curl -X POST \
             -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
-            -d '{ "event_type": "Tardis-Dispatch", "client_payload": {"commit_sha": "${{ steps.get_sha.outputs.COMMIT_SHA }}"}}' \
-            https://api.github.com/repos/${{github.repository_owner}}/stardis/dispatches
+            -d '{ "event_type": "tardis-dispatch"}}' \
+            https://api.github.com/repos/tardis-sn/stardis/dispatches

--- a/.github/workflows/stardis-dispatch.yml
+++ b/.github/workflows/stardis-dispatch.yml
@@ -19,5 +19,5 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
-            -d '{ "event_type": "repo-push", "client_payload": {"commit_sha": "${{ steps.get_sha.outputs.COMMIT_SHA }}"}}' \
-            https://api.github.com/repos/tardis-sn/stardis/dispatches
+            -d '{ "event_type": "trigger-workflow", "client_payload": {"commit_sha": "${{ steps.get_sha.outputs.COMMIT_SHA }}"}}' \
+            https://api.github.com/repos/${{github.repository_owner}}/stardis/dispatches

--- a/.github/workflows/stardis-dispatch.yml
+++ b/.github/workflows/stardis-dispatch.yml
@@ -1,0 +1,23 @@
+name: Stardis Dispatch
+on:
+    push:
+      branches:
+        - master
+    workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get commit SHA
+        id: get_sha
+        run: echo "::set-output name=COMMIT_SHA::$(git rev-parse HEAD)"
+      - name: Dispatch to Stardis
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -d '{ "event_type": "repo-push", "client_payload": {"commit_sha": "${{ steps.get_sha.outputs.COMMIT_SHA }}"}}' \
+            https://api.github.com/repos/tardis-sn/stardis/dispatches


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Triggering tests workflow in stardis after every push to the tardis master branch. This is related to [#201](https://github.com/tardis-sn/stardis/pull/201) in stardis.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
