### PR TITLE
Add google analytics key to tardis docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -103,9 +103,8 @@ jobs:
       - name: Install package
         run: pip install -e .
 
-      - name: Install Sphinx and extensions
+      - name: Install Sphinx extensions
         run: |
-          pip install sphinx
           pip install sphinxcontrib-googleanalytics
 
       - name: Build documentation

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -103,6 +103,11 @@ jobs:
       - name: Install package
         run: pip install -e .
 
+      - name: Install Sphinx and extensions
+        run: |
+          pip install sphinx
+          pip install sphinxcontrib-googleanalytics
+
       - name: Build documentation
         run: cd docs/ && make html NCORES=auto
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -261,6 +261,13 @@ htmlhelp_basename = project + "doc"
 modindex_common_prefix = ["tardis."]
 
 
+
+# -- Google Analytics Using Extension -------------------------------------------------
+
+if os.getenv("GITHUB_ACTIONS"):
+  extensions.append("sphinxcontrib.googleanalytics")
+  googleanalytics_id = "G-53HJHD1BWS"
+
 # -- Options for LaTeX output -------------------------------------------------
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Add google analytics to tardis docs


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
