### PR TITLE
Remove parameters and speed up benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run benchmarks for last 5 commits if not PR
         if: github.event_name != 'pull_request_target'
         run: |
-          git log -n 5  --pretty=format:"%H" >> tag_commits.txt
+          git log -n 4  --pretty=format:"%H" >> tag_commits.txt
           asv run -a repeat=1 -a rounds=1 HASHFILE:tag_commits.txt | tee asv-output.log  
           if grep -q failed asv-output.log; then 
             echo "Some benchmarks have failed!"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,7 +72,7 @@ jobs:
         if: github.event_name != 'pull_request_target'
         run: |
           git log -n 5  --pretty=format:"%H" >> tag_commits.txt
-          asv run HASHFILE:tag_commits.txt | tee asv-output.log  
+          asv run -a repeat=1 -a rounds=1 HASHFILE:tag_commits.txt | tee asv-output.log  
           if grep -q failed asv-output.log; then 
             echo "Some benchmarks have failed!"
             exit 1
@@ -126,7 +126,7 @@ jobs:
           echo $(git rev-parse HEAD) > commit_hashes.txt
           echo $(git merge-base HEAD upstream/master) >> commit_hashes.txt
 
-          asv run HASHFILE:commit_hashes.txt | tee asv-output-PR.log  
+          asv run -a repeat=1 -a rounds=1 HASHFILE:commit_hashes.txt | tee asv-output-PR.log  
             if grep -q failed asv-output-PR.log; then 
               echo "Some benchmarks have failed!"
               exit 1

--- a/benchmarks/transport_montecarlo_interaction.py
+++ b/benchmarks/transport_montecarlo_interaction.py
@@ -31,7 +31,6 @@ class BenchmarkMontecarloMontecarloNumbaInteraction(BenchmarkBase):
         {
             "Line interaction type": [
                 LineInteractionType.SCATTER,
-                LineInteractionType.DOWNBRANCH,
                 LineInteractionType.MACROATOM,
             ],
         }
@@ -60,17 +59,7 @@ class BenchmarkMontecarloMontecarloNumbaInteraction(BenchmarkBase):
                     "mu": 0.8599443103322428,
                     "emission_line_id": 1000,
                     "energy": 0.9114437898710559,
-                },
-                {
-                    "mu": -0.6975116557422458,
-                    "emission_line_id": 2000,
-                    "energy": 0.8803098648913266,
-                },
-                {
-                    "mu": -0.7115661419975774,
-                    "emission_line_id": 0,
-                    "energy": 0.8800385929341252,
-                },
+                }
             ]
         }
     )

--- a/benchmarks/transport_montecarlo_numba_interface.py
+++ b/benchmarks/transport_montecarlo_numba_interface.py
@@ -14,7 +14,7 @@ class BenchmarkMontecarloMontecarloNumbaNumbaInterface(BenchmarkBase):
     Class to benchmark the numba interface function.
     """
 
-    @parameterize({"Input params": ["scatter", "macroatom", "downbranch"]})
+    @parameterize({"Input params": ["scatter", "macroatom"]})
     def time_opacity_state_initialize(self, input_params):
         line_interaction_type = input_params
         plasma = self.nb_simulation_verysimple.plasma

--- a/benchmarks/transport_montecarlo_opacities.py
+++ b/benchmarks/transport_montecarlo_opacities.py
@@ -34,58 +34,76 @@ class BenchmarkMontecarloMontecarloNumbaOpacities(BenchmarkBase):
 
     @parameterize(
         {
-            "Ejecta density": [
-                1.0,
-                1e-2,
-                1e-2,
-                1e5,
-            ],
-            "Energy": [
-                511.0,
-                255.5,
-                255.5,
-                511.0e7,
-            ],
-            "Iron group fraction": [
-                0.0,
-                0.5,
-                0.25,
-                1.0,
-            ],
+            "Parameters": [
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 511.0,
+                    "Iron_group_fraction": 0.5,
+                },
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 5110000000.0,
+                    "Iron_group_fraction": 0.0,
+                },
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 255.5,
+                    "Iron_group_fraction": 0.0,
+                },
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 255.5,
+                    "Iron_group_fraction": 0.5,
+                },
+                {
+                    "Ejecta_density": 100000.0,
+                    "Energy": 255.5,
+                    "Iron_group_fraction": 1.0,
+                }
+            ]
         }
     )
-    def time_photoabsorption_opacity_calculation(
-        self, ejecta_density, energy, iron_group_fraction
-    ):
+    def time_photoabsorption_opacity_calculation(self, parameters):
         calculate_opacity.photoabsorption_opacity_calculation(
-            energy, ejecta_density, iron_group_fraction
+            parameters["Energy"],
+            parameters["Ejecta_density"],
+            parameters["Iron_group_fraction"],
         )
 
     @parameterize(
         {
-            "Ejecta density": [
-                1.0,
-                1e-2,
-                1e-2,
-                1e5,
-            ],
-            "Energy": [
-                511.0,
-                1500,
-                1200,
-                511.0e7,
-            ],
-            "Iron group fraction": [
-                0.0,
-                0.5,
-                0.25,
-                1.0,
-            ],
+            "Parameters": [
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 511.0,
+                    "Iron_group_fraction": 0.5,
+                },
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 5110000000.0,
+                    "Iron_group_fraction": 0.0,
+                },
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 255.5,
+                    "Iron_group_fraction": 0.0,
+                },
+                {
+                    "Ejecta_density": 0.01,
+                    "Energy": 255.5,
+                    "Iron_group_fraction": 0.5,
+                },
+                {
+                    "Ejecta_density": 100000.0,
+                    "Energy": 255.5,
+                    "Iron_group_fraction": 1.0,
+                }
+            ]
         }
     )
-    def time_pair_creation_opacity_calculation(
-        self, ejecta_density, energy, iron_group_fraction
-    ):
+    def time_pair_creation_opacity_calculation(self, parameters):
         calculate_opacity.pair_creation_opacity_calculation(
-            energy, ejecta_density, iron_group_fraction
+            parameters["Energy"],
+            parameters["Ejecta_density"],
+            parameters["Iron_group_fraction"],
         )

--- a/benchmarks/transport_montecarlo_packet.py
+++ b/benchmarks/transport_montecarlo_packet.py
@@ -117,11 +117,6 @@ class BenchmarkMontecarloMontecarloNumbaPacket(BenchmarkBase):
                 },
                 {
                     "current_shell_id": 132,
-                    "delta_shell": 1,
-                    "no_of_shells": 133,
-                },
-                {
-                    "current_shell_id": 132,
                     "delta_shell": 2,
                     "no_of_shells": 133,
                 },
@@ -145,11 +140,6 @@ class BenchmarkMontecarloMontecarloNumbaPacket(BenchmarkBase):
                     "current_shell_id": 132,
                     "delta_shell": 132,
                     "no_of_shells": 132,
-                },
-                {
-                    "current_shell_id": -133,
-                    "delta_shell": -133,
-                    "no_of_shells": -1e9,
                 },
                 {
                     "current_shell_id": 132,
@@ -181,11 +171,6 @@ class BenchmarkMontecarloMontecarloNumbaPacket(BenchmarkBase):
                     "current_shell_id": 132,
                     "delta_shell": 0,
                     "no_of_shells": 132,
-                },
-                {
-                    "current_shell_id": 132,
-                    "delta_shell": 20,
-                    "no_of_shells": 154,
                 },
             ]
         }

--- a/benchmarks/transport_montecarlo_vpacket.py
+++ b/benchmarks/transport_montecarlo_vpacket.py
@@ -161,6 +161,5 @@ class BenchmarkMontecarloMontecarloNumbaVpacket(BenchmarkBase):
             self.verysimple_opacity_state,
             False,
             parameters["tau_russian"],
-            parameters["survival_possibility"],
-            False,
+            parameters["survival_possibility"]
         )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

- Fixed the failing benchmarks.
- Speed up benchmarks by only running every benchmark once. 
- Removed parameters with close results in terms of time.

https://github.com/officialasishkumar/tardis/actions/runs/9987846474/job/27603058268#logs (earlier it used to take 1hr 22mins)

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
