### PR TITLE
Restructure Trackers

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -30,7 +30,6 @@ from tardis.transport.montecarlo.packet_collections import (
 )
 from tardis.transport.montecarlo.packet_trackers import (
     RPacketTracker,
-    generate_rpacket_last_interaction_tracker_list,
 )
 
 
@@ -420,5 +419,9 @@ class BenchmarkBase:
 
     @property
     def rpacket_tracker_list(self):
+        from tardis.transport.montecarlo.packet_trackers import (
+            generate_rpacket_last_interaction_tracker_list,
+        )
+
         no_of_packets = len(self.transport_state.packet_collection)
         return generate_rpacket_last_interaction_tracker_list(no_of_packets)

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -30,7 +30,6 @@ from tardis.transport.montecarlo.packet_collections import (
 )
 from tardis.transport.montecarlo.packet_trackers import (
     RPacketTracker,
-    RPacketLastInteractionTracker,
     generate_rpacket_last_interaction_tracker,
 )
 
@@ -420,6 +419,6 @@ class BenchmarkBase:
         )
 
     @property
-    def rpacket_tracker(self):
+    def rpacket_tracker_list(self):
         no_of_packets = len(self.transport_state.packet_collection)
         return generate_rpacket_last_interaction_tracker_list(no_of_packets)

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -30,7 +30,7 @@ from tardis.transport.montecarlo.packet_collections import (
 )
 from tardis.transport.montecarlo.packet_trackers import (
     RPacketTracker,
-    generate_rpacket_last_interaction_tracker,
+    generate_rpacket_last_interaction_tracker_list,
 )
 
 

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -28,7 +28,11 @@ from tardis.transport.montecarlo.numba_interface import opacity_state_initialize
 from tardis.transport.montecarlo.packet_collections import (
     VPacketCollection,
 )
-from tardis.transport.montecarlo.packet_trackers import RPacketTracker
+from tardis.transport.montecarlo.packet_trackers import (
+    RPacketTracker,
+    RPacketLastInteractionTracker,
+    generate_rpacket_last_interaction_tracker,
+)
 
 
 class BenchmarkBase:
@@ -414,3 +418,8 @@ class BenchmarkBase:
             stim_recomb_cooling_estimator=np.empty((0, 0), dtype=np.float64),
             photo_ion_estimator_statistics=np.empty((0, 0), dtype=np.int64),
         )
+
+    @property
+    def rpacket_tracker(self):
+        no_of_packets = len(self.transport_state.packet_collection)
+        return generate_rpacket_last_interaction_tracker_list(no_of_packets)

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -30,6 +30,7 @@ from tardis.transport.montecarlo.packet_collections import (
 )
 from tardis.transport.montecarlo.packet_trackers import (
     RPacketTracker,
+    generate_rpacket_last_interaction_tracker_list,
 )
 
 
@@ -419,9 +420,5 @@ class BenchmarkBase:
 
     @property
     def rpacket_tracker_list(self):
-        from tardis.transport.montecarlo.packet_trackers import (
-            generate_rpacket_last_interaction_tracker_list,
-        )
-
         no_of_packets = len(self.transport_state.packet_collection)
         return generate_rpacket_last_interaction_tracker_list(no_of_packets)

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -420,5 +420,5 @@ class BenchmarkBase:
 
     @property
     def rpacket_tracker_list(self):
-        no_of_packets = len(self.transport_state.packet_collection)
+        no_of_packets = len(self.transport_state.packet_collection.initial_nus)
         return generate_rpacket_last_interaction_tracker_list(no_of_packets)

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -371,10 +371,6 @@ class BenchmarkBase:
         return self.nb_simulation_verysimple.transport.transport_state
 
     @property
-    def spectrum_frequency_grid(self):
-        return self.nb_simulation_verysimple.transport.spectrum_frequency_grid
-
-    @property
     def simulation_rpacket_tracking_enabled(self):
         config_verysimple = self.config_verysimple
         config_verysimple.montecarlo.iterations = 3

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -239,7 +239,9 @@ class BenchmarkBase:
 
     @property
     def verysimple_packet_collection(self):
-        return self.nb_simulation_verysimple.transport.transport_state.packet_collection
+        return (
+            self.nb_simulation_verysimple.transport.transport_state.packet_collection
+        )
 
     @property
     def nb_simulation_verysimple(self):
@@ -269,7 +271,9 @@ class BenchmarkBase:
 
     @property
     def verysimple_disable_line_scattering(self):
-        return self.nb_simulation_verysimple.transport.montecarlo_configuration.DISABLE_LINE_SCATTERING
+        return (
+            self.nb_simulation_verysimple.transport.montecarlo_configuration.DISABLE_LINE_SCATTERING
+        )
 
     @property
     def verysimple_continuum_processes_enabled(self):
@@ -277,11 +281,15 @@ class BenchmarkBase:
 
     @property
     def verysimple_tau_russian(self):
-        return self.nb_simulation_verysimple.transport.montecarlo_configuration.VPACKET_TAU_RUSSIAN
+        return (
+            self.nb_simulation_verysimple.transport.montecarlo_configuration.VPACKET_TAU_RUSSIAN
+        )
 
     @property
     def verysimple_survival_probability(self):
-        return self.nb_simulation_verysimple.transport.montecarlo_configuration.SURVIVAL_PROBABILITY
+        return (
+            self.nb_simulation_verysimple.transport.montecarlo_configuration.SURVIVAL_PROBABILITY
+        )
 
     @property
     def static_packet(self):
@@ -303,7 +311,9 @@ class BenchmarkBase:
 
     @property
     def verysimple_3vpacket_collection(self):
-        spectrum_frequency_grid = self.nb_simulation_verysimple.transport.spectrum_frequency_grid.value
+        spectrum_frequency_grid = (
+            self.nb_simulation_verysimple.transport.spectrum_frequency_grid.value
+        )
         return VPacketCollection(
             source_rpacket_index=0,
             spectrum_frequency_grid=spectrum_frequency_grid,
@@ -359,6 +369,10 @@ class BenchmarkBase:
     @property
     def transport_state(self):
         return self.nb_simulation_verysimple.transport.transport_state
+
+    @property
+    def spectrum_frequency_grid(self):
+        return self.nb_simulation_verysimple.transport.spectrum_frequency_grid
 
     @property
     def simulation_rpacket_tracking_enabled(self):

--- a/benchmarks/transport_montecarlo_main_loop.py
+++ b/benchmarks/transport_montecarlo_main_loop.py
@@ -22,7 +22,7 @@ class BenchmarkTransportMontecarloMontecarloMainLoop(BenchmarkBase):
             self.montecarlo_configuration,
             self.transport_state.radfield_mc_estimators,
             self.nb_simulation_verysimple.transport.spectrum_frequency_grid.value,
-            self.rpacket_tracker,
+            self.rpacket_tracker_list,
             self.montecarlo_configuration.NUMBER_OF_VPACKETS,
             iteration=0,
             show_progress_bars=False,

--- a/benchmarks/transport_montecarlo_main_loop.py
+++ b/benchmarks/transport_montecarlo_main_loop.py
@@ -22,6 +22,7 @@ class BenchmarkTransportMontecarloMontecarloMainLoop(BenchmarkBase):
             self.montecarlo_configuration,
             self.transport_state.radfield_mc_estimators,
             self.nb_simulation_verysimple.transport.spectrum_frequency_grid.value,
+            self.transport_state.rpacket_trackers,
             self.montecarlo_configuration.NUMBER_OF_VPACKETS,
             iteration=0,
             show_progress_bars=False,

--- a/benchmarks/transport_montecarlo_main_loop.py
+++ b/benchmarks/transport_montecarlo_main_loop.py
@@ -22,7 +22,7 @@ class BenchmarkTransportMontecarloMontecarloMainLoop(BenchmarkBase):
             self.montecarlo_configuration,
             self.transport_state.radfield_mc_estimators,
             self.nb_simulation_verysimple.transport.spectrum_frequency_grid.value,
-            self.transport_state.rpacket_trackers,
+            self.transport_state.rpacket_tracker,
             self.montecarlo_configuration.NUMBER_OF_VPACKETS,
             iteration=0,
             show_progress_bars=False,

--- a/benchmarks/transport_montecarlo_main_loop.py
+++ b/benchmarks/transport_montecarlo_main_loop.py
@@ -22,7 +22,7 @@ class BenchmarkTransportMontecarloMontecarloMainLoop(BenchmarkBase):
             self.montecarlo_configuration,
             self.transport_state.radfield_mc_estimators,
             self.nb_simulation_verysimple.transport.spectrum_frequency_grid.value,
-            self.transport_state.rpacket_tracker,
+            self.rpacket_tracker,
             self.montecarlo_configuration.NUMBER_OF_VPACKETS,
             iteration=0,
             show_progress_bars=False,

--- a/benchmarks/transport_montecarlo_packet_trackers.py
+++ b/benchmarks/transport_montecarlo_packet_trackers.py
@@ -4,6 +4,8 @@ Basic TARDIS Benchmark.
 from benchmarks.benchmark_base import BenchmarkBase
 from tardis.transport.montecarlo.packet_trackers import (
     rpacket_trackers_to_dataframe,
+    generate_rpacket_tracker_list,
+    generate_rpacket_last_interaction_tracker_list,
 )
 
 
@@ -15,6 +17,20 @@ class BenchmarkTransportMontecarloPacketTrackers(BenchmarkBase):
     def time_rpacket_trackers_to_dataframe(self):
         sim = self.simulation_rpacket_tracking_enabled
         transport_state = sim.transport.transport_state
-        rpacket_trackers_to_dataframe(
-            transport_state.rpacket_tracker
-        )
+        rpacket_trackers_to_dataframe(transport_state.rpacket_tracker)
+
+    def time_generate_rpacket_tracker_list(self, no_of_packets, length):
+        generate_rpacket_tracker_list(no_of_packets, length)
+
+    def time_generate_rpacket_last_interaction_tracker_list(
+        self, no_of_packets
+    ):
+        generate_rpacket_last_interaction_tracker_list(no_of_packets)
+
+    time_generate_rpacket_tracker_list.params = ([1, 10, 50], [1, 10, 50])
+    time_generate_rpacket_tracker_list.param_names = ["no_of_packets", "length"]
+
+    time_generate_rpacket_last_interaction_tracker_list.params = [10, 100, 1000]
+    time_generate_rpacket_last_interaction_tracker_list.param_names = [
+        "no_of_packets"
+    ]

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -158,12 +158,23 @@ class MonteCarloTransportSolver(HDFWriterMixin):
         self.transport_state = transport_state
 
         number_of_vpackets = self.montecarlo_configuration.NUMBER_OF_VPACKETS
+        number_of_rpackets = len(transport_state.packet_collection.initial_nus)
+
+        if self.enable_rpacket_tracking:
+            transport_state.rpacket_tracker = rpacket_tracker_list(
+                number_of_rpackets,
+                self.montecarlo_configuration.INITIAL_TRACKING_ARRAY_LENGTH,
+            )
+        else:
+            transport_state.rpacket_tracker = (
+                rpacket_last_interaction_tracker_list(number_of_rpackets)
+            )
+
 
         (
             v_packets_energy_hist,
             last_interaction_tracker,
             vpacket_tracker,
-            rpacket_trackers,
         ) = montecarlo_main_loop(
             transport_state.packet_collection,
             transport_state.geometry_state,
@@ -172,6 +183,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.montecarlo_configuration,
             transport_state.radfield_mc_estimators,
             self.spectrum_frequency_grid.value,
+            transport_state.rpacket_trackers,
             number_of_vpackets,
             iteration=iteration,
             show_progress_bars=show_progress_bars,
@@ -198,8 +210,6 @@ class MonteCarloTransportSolver(HDFWriterMixin):
 
         update_iterations_pbar(1)
         refresh_packet_pbar()
-
-        transport_state.rpacket_tracker = rpacket_trackers
 
         # Need to change the implementation of rpacket_trackers_to_dataframe
         # Such that it also takes of the case of
@@ -243,7 +253,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             logger.debug("Electron scattering switched on")
             constants.SIGMA_THOMSON = const.sigma_T.to("cm^2").value
 
-        spectrum_frequency_grid = quantity_linspace(
+        spectrum_frequency = quantity_linspace(
             config.spectrum.stop.to("Hz", u.spectral()),
             config.spectrum.start.to("Hz", u.spectral()),
             num=config.spectrum.num + 1,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -172,7 +172,6 @@ class MonteCarloTransportSolver(HDFWriterMixin):
                 rpacket_last_interaction_tracker_list(number_of_rpackets)
             )
 
-
         (
             v_packets_energy_hist,
             last_interaction_tracker,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -25,8 +25,8 @@ from tardis.transport.montecarlo.numba_interface import (
     opacity_state_initialize,
 )
 from tardis.transport.montecarlo.packet_trackers import (
-    RPacketTracker,
-    RPacketLastInteractionTracker,
+    rpacket_tracker_list,
+    rpacket_last_interaction_tracker_list,
     rpacket_trackers_to_dataframe,
 )
 from tardis.util.base import (

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -2,7 +2,6 @@ import logging
 
 from astropy import units as u
 from numba import cuda, set_num_threads
-from numba.typed import List
 
 import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -186,6 +186,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.montecarlo_configuration,
             transport_state.radfield_mc_estimators,
             self.spectrum_frequency_grid.value,
+            transport_state.rpacket_tracker,
             number_of_vpackets,
             iteration=iteration,
             show_progress_bars=show_progress_bars,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -256,7 +256,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             logger.debug("Electron scattering switched on")
             constants.SIGMA_THOMSON = const.sigma_T.to("cm^2").value
 
-        spectrum_frequency = quantity_linspace(
+        spectrum_frequency_grid = quantity_linspace(
             config.spectrum.stop.to("Hz", u.spectral()),
             config.spectrum.start.to("Hz", u.spectral()),
             num=config.spectrum.num + 1,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -186,7 +186,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.montecarlo_configuration,
             transport_state.radfield_mc_estimators,
             self.spectrum_frequency_grid.value,
-            transport_state.rpacket_trackers,
+            transport_state.rpacket_tracker,
             number_of_vpackets,
             iteration=iteration,
             show_progress_bars=show_progress_bars,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -186,7 +186,6 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.montecarlo_configuration,
             transport_state.radfield_mc_estimators,
             self.spectrum_frequency_grid.value,
-            transport_state.rpacket_tracker,
             number_of_vpackets,
             iteration=iteration,
             show_progress_bars=show_progress_bars,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -2,6 +2,7 @@ import logging
 
 from astropy import units as u
 from numba import cuda, set_num_threads
+from numba.typed import List
 
 import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -25,6 +25,8 @@ from tardis.transport.montecarlo.numba_interface import (
     opacity_state_initialize,
 )
 from tardis.transport.montecarlo.packet_trackers import (
+    RPacketTracker,
+    RPacketLastInteractionTracker,
     rpacket_trackers_to_dataframe,
 )
 from tardis.util.base import (

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -24,8 +24,8 @@ from tardis.transport.montecarlo.numba_interface import (
     opacity_state_initialize,
 )
 from tardis.transport.montecarlo.packet_trackers import (
-    rpacket_tracker_list,
-    rpacket_last_interaction_tracker_list,
+    generate_rpacket_tracker_list,
+    generate_rpacket_last_interaction_tracker_list,
     rpacket_trackers_to_dataframe,
 )
 from tardis.util.base import (
@@ -163,13 +163,15 @@ class MonteCarloTransportSolver(HDFWriterMixin):
         number_of_rpackets = len(transport_state.packet_collection.initial_nus)
 
         if self.enable_rpacket_tracking:
-            transport_state.rpacket_tracker = rpacket_tracker_list(
+            transport_state.rpacket_tracker = generate_rpacket_tracker_list(
                 number_of_rpackets,
                 self.montecarlo_configuration.INITIAL_TRACKING_ARRAY_LENGTH,
             )
         else:
             transport_state.rpacket_tracker = (
-                rpacket_last_interaction_tracker_list(number_of_rpackets)
+                generate_rpacket_last_interaction_tracker_list(
+                    number_of_rpackets
+                )
             )
 
         (

--- a/tardis/transport/montecarlo/configuration/base.py
+++ b/tardis/transport/montecarlo/configuration/base.py
@@ -81,6 +81,3 @@ def configuration_initialize(config, transport, number_of_vpackets):
     montecarlo_globals.ENABLE_RPACKET_TRACKING = (
         transport.enable_rpacket_tracking
     )
-    montecarlo_main_loop.ENABLE_RPACKET_TRACKING = (
-        transport.enable_rpacket_tracking
-    )

--- a/tardis/transport/montecarlo/montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/montecarlo_main_loop.py
@@ -36,6 +36,7 @@ def montecarlo_main_loop(
     montecarlo_configuration,
     estimators,
     spectrum_frequency_grid,
+    rpacket_trackers,
     number_of_vpackets,
     iteration,
     show_progress_bars,
@@ -77,19 +78,6 @@ def montecarlo_main_loop(
 
     # Pre-allocate a list of vpacket collections for later storage
     vpacket_collections = List()
-    # Configuring the Tracking for R_Packets
-    rpacket_trackers = List()
-    if ENABLE_RPACKET_TRACKING:
-        for i in range(no_of_packets):
-            rpacket_trackers.append(
-                RPacketTracker(
-                    montecarlo_configuration.INITIAL_TRACKING_ARRAY_LENGTH
-                )
-            )
-    else:
-        for i in range(no_of_packets):
-            rpacket_trackers.append(RPacketLastInteractionTracker())
-
     for i in range(no_of_packets):
         vpacket_collections.append(
             VPacketCollection(
@@ -197,7 +185,7 @@ def montecarlo_main_loop(
             1,
         )
 
-    if ENABLE_RPACKET_TRACKING:
+    if montecarlo_globals.ENABLE_RPACKET_TRACKING:
         for rpacket_tracker in rpacket_trackers:
             rpacket_tracker.finalize_array()
 
@@ -205,5 +193,4 @@ def montecarlo_main_loop(
         v_packets_energy_hist,
         last_interaction_tracker,
         vpacket_tracker,
-        rpacket_trackers,
     )

--- a/tardis/transport/montecarlo/montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/montecarlo_main_loop.py
@@ -33,7 +33,6 @@ def montecarlo_main_loop(
     montecarlo_configuration,
     estimators,
     spectrum_frequency_grid,
-    rpacket_trackers,
     number_of_vpackets,
     iteration,
     show_progress_bars,

--- a/tardis/transport/montecarlo/montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/montecarlo_main_loop.py
@@ -33,6 +33,7 @@ def montecarlo_main_loop(
     montecarlo_configuration,
     estimators,
     spectrum_frequency_grid,
+    rpacket_trackers,
     number_of_vpackets,
     iteration,
     show_progress_bars,

--- a/tardis/transport/montecarlo/montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/montecarlo_main_loop.py
@@ -10,10 +10,6 @@ from tardis.transport.montecarlo.packet_collections import (
     consolidate_vpacket_tracker,
     initialize_last_interaction_tracker,
 )
-from tardis.transport.montecarlo.packet_trackers import (
-    RPacketTracker,
-    RPacketLastInteractionTracker,
-)
 from tardis.transport.montecarlo.r_packet import (
     PacketStatus,
     RPacket,

--- a/tardis/transport/montecarlo/montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/montecarlo_main_loop.py
@@ -10,7 +10,6 @@ from tardis.transport.montecarlo.packet_collections import (
     consolidate_vpacket_tracker,
     initialize_last_interaction_tracker,
 )
-import tardis.transport.montecarlo.montecarlo_main_loop as montecarlo_loop
 from tardis.transport.montecarlo.packet_trackers import (
     RPacketTracker,
     RPacketLastInteractionTracker,
@@ -23,8 +22,6 @@ from tardis.transport.montecarlo.single_packet_loop import (
     single_packet_loop,
 )
 from tardis.util.base import update_packet_pbar
-
-ENABLE_RPACKET_TRACKING = False
 
 
 @njit(**njit_dict)

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -212,6 +212,16 @@ class RPacketLastInteractionTracker(object):
 
 @njit
 def generate_rpacket_tracker_list(no_of_packets, length):
+    """
+    Parameters
+    ----------
+    no_of_packets : The count of RPackets that are sent in the ejecta
+    length : initial length of the tracking array
+
+    Returns
+    -------
+    A list containing RPacketTracker for each RPacket
+    """
     rpacket_trackers = List()
     for i in range(no_of_packets):
         rpacket_trackers.append(RPacketTracker(length))
@@ -220,6 +230,15 @@ def generate_rpacket_tracker_list(no_of_packets, length):
 
 @njit
 def generate_rpacket_last_interaction_tracker_list(no_of_packets):
+    """
+    Parameters
+    ----------
+    no_of_packets : The count of RPackets that are sent in the ejecta
+
+    Returns
+    -------
+    A list containing RPacketLastInteractionTracker for each RPacket
+    """
     rpacket_trackers = List()
     for i in range(no_of_packets):
         rpacket_trackers.append(RPacketLastInteractionTracker())

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -203,3 +203,7 @@ class RPacketLastInteractionTracker(object):
         self.energy = r_packet.energy
         self.shell_id = r_packet.current_shell_id
         self.interaction_type = r_packet.last_interaction_type
+
+    # To make it compatible with RPacketTracker
+    def finalize_array():
+        pass

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -1,5 +1,6 @@
 from numba import float64, int64, njit
 from numba.experimental import jitclass
+from numba.typed import List
 import numpy as np
 import pandas as pd
 

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -1,4 +1,4 @@
-from numba import float64, int64
+from numba import float64, int64, njit
 from numba.experimental import jitclass
 import numpy as np
 import pandas as pd
@@ -207,3 +207,19 @@ class RPacketLastInteractionTracker(object):
     # To make it compatible with RPacketTracker
     def finalize_array(self):
         pass
+
+
+@njit
+def rpacket_tracker_list(no_of_packets, length):
+    rpacket_trackers = List()
+    for i in range(no_of_packets):
+        rpacket_trackers.append(RPacketTracker(length))
+    return rpacket_trackers
+
+
+@njit
+def rpacket_last_interaction_tracker_list(no_of_packets):
+    rpacket_trackers = List()
+    for i in range(no_of_packets):
+        rpacket_trackers.append(RPacketLastInteractionTracker())
+    return rpacket_trackers

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -211,7 +211,7 @@ class RPacketLastInteractionTracker(object):
 
 
 @njit
-def rpacket_tracker_list(no_of_packets, length):
+def generate_rpacket_tracker_list(no_of_packets, length):
     rpacket_trackers = List()
     for i in range(no_of_packets):
         rpacket_trackers.append(RPacketTracker(length))
@@ -219,7 +219,7 @@ def rpacket_tracker_list(no_of_packets, length):
 
 
 @njit
-def rpacket_last_interaction_tracker_list(no_of_packets):
+def generate_rpacket_last_interaction_tracker_list(no_of_packets):
     rpacket_trackers = List()
     for i in range(no_of_packets):
         rpacket_trackers.append(RPacketLastInteractionTracker())

--- a/tardis/transport/montecarlo/packet_trackers.py
+++ b/tardis/transport/montecarlo/packet_trackers.py
@@ -205,5 +205,5 @@ class RPacketLastInteractionTracker(object):
         self.interaction_type = r_packet.last_interaction_type
 
     # To make it compatible with RPacketTracker
-    def finalize_array():
+    def finalize_array(self):
         pass

--- a/tardis/transport/montecarlo/tests/test_tracker_utils.py
+++ b/tardis/transport/montecarlo/tests/test_tracker_utils.py
@@ -1,0 +1,37 @@
+import pytest
+import numpy as np
+from numba import typeof
+
+from tardis.transport.montecarlo.packet_trackers import (
+    RPacketTracker,
+    RPacketLastInteractionTracker,
+    generate_rpacket_tracker_list,
+    generate_rpacket_last_interaction_tracker_list,
+)
+
+
+def test_generate_rpacket_tracker_list():
+    no_of_packets = 10
+    length = 10
+    random_index = np.random.randint(0, no_of_packets)
+
+    rpacket_tracker_list = generate_rpacket_tracker_list(no_of_packets, length)
+
+    assert len(rpacket_tracker_list) == no_of_packets
+    assert len(rpacket_tracker_list[random_index].shell_id) == length
+    assert typeof(rpacket_tracker_list[random_index]) == typeof(RPacketTracker(length))
+
+
+def test_generate_rpacket_last_interaction_tracker_list():
+    no_of_packets = 50
+    random_index = np.random.randint(0, no_of_packets)
+
+    rpacket_last_interaction_tracker_list = (
+        generate_rpacket_last_interaction_tracker_list(no_of_packets)
+    )
+
+    assert len(rpacket_last_interaction_tracker_list) == no_of_packets
+    assert (
+        typeof(rpacket_last_interaction_tracker_list[random_index])
+        == typeof(RPacketLastInteractionTracker())
+    )

--- a/tardis/transport/montecarlo/tests/test_tracker_utils.py
+++ b/tardis/transport/montecarlo/tests/test_tracker_utils.py
@@ -19,7 +19,9 @@ def test_generate_rpacket_tracker_list():
 
     assert len(rpacket_tracker_list) == no_of_packets
     assert len(rpacket_tracker_list[random_index].shell_id) == length
-    assert typeof(rpacket_tracker_list[random_index]) == typeof(RPacketTracker(length))
+    assert typeof(rpacket_tracker_list[random_index]) == typeof(
+        RPacketTracker(length)
+    )
 
 
 def test_generate_rpacket_last_interaction_tracker_list():
@@ -31,7 +33,6 @@ def test_generate_rpacket_last_interaction_tracker_list():
     )
 
     assert len(rpacket_last_interaction_tracker_list) == no_of_packets
-    assert (
-        typeof(rpacket_last_interaction_tracker_list[random_index])
-        == typeof(RPacketLastInteractionTracker())
-    )
+    assert typeof(
+        rpacket_last_interaction_tracker_list[random_index]
+    ) == typeof(RPacketLastInteractionTracker())


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`
This PR brings the rpacket_trackers initialization outside the `montecarlo_main_loop` to avoid the usage of compile time constants and reduce complexity.
