### PR TITLE
Benchmark run_tardis with track_rpacket enabled

### DIFF
--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -70,7 +70,7 @@ class BenchmarkBase:
     @property
     def config_rpacket_tracking(self):
         config = Configuration.from_yaml(
-            "tardis/io/configuration/tests/data/tardis_configv1_verysimple.yml"
+            f"{self.example_configuration_dir}/tardis_configv1_verysimple.yml"
         )
         config.montecarlo.tracking.track_rpacket = True
         return config

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -1,3 +1,4 @@
+import functools
 from copy import deepcopy
 from os.path import dirname, join, realpath
 from pathlib import Path
@@ -67,7 +68,7 @@ class BenchmarkBase:
             YAMLLoader,
         )
 
-    @property
+    @functools.cached_property
     def config_rpacket_tracking(self):
         config = Configuration.from_yaml(
             f"{self.example_configuration_dir}/tardis_configv1_verysimple.yml"

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -68,6 +68,16 @@ class BenchmarkBase:
         )
 
     @property
+    def config_rpacket_tracking(self):
+        config = Configuration.from_yaml(
+            "tardis/io/configuration/tests/data/tardis_configv1_verysimple.yml"
+        )
+        config.montecarlo.tracking.track_rpacket = True
+        config.montecarlo.iterations = 1
+        config.montecarlo.no_of_packets = 4000
+        return config
+
+    @property
     def tardis_ref_path(self):
         # TODO: This route is fixed but needs to get from the arguments given in the command line.
         #       /app/tardis-refdata

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -1,4 +1,3 @@
-import functools
 from copy import deepcopy
 from os.path import dirname, join, realpath
 from pathlib import Path
@@ -68,7 +67,7 @@ class BenchmarkBase:
             YAMLLoader,
         )
 
-    @functools.cached_property
+    @property
     def config_rpacket_tracking(self):
         config = Configuration.from_yaml(
             f"{self.example_configuration_dir}/tardis_configv1_verysimple.yml"

--- a/benchmarks/benchmark_base.py
+++ b/benchmarks/benchmark_base.py
@@ -73,8 +73,6 @@ class BenchmarkBase:
             "tardis/io/configuration/tests/data/tardis_configv1_verysimple.yml"
         )
         config.montecarlo.tracking.track_rpacket = True
-        config.montecarlo.iterations = 1
-        config.montecarlo.no_of_packets = 4000
         return config
 
     @property

--- a/benchmarks/run_tardis.py
+++ b/benchmarks/run_tardis.py
@@ -5,6 +5,7 @@ Basic TARDIS Benchmark.
 from benchmarks.benchmark_base import BenchmarkBase
 from tardis import run_tardis
 
+
 class BenchmarkRunTardis(BenchmarkBase):
     """
     Class to benchmark the `run tardis` function.
@@ -13,6 +14,13 @@ class BenchmarkRunTardis(BenchmarkBase):
     def time_run_tardis(self):
         run_tardis(
             self.config_verysimple,
+            atom_data=self.atomic_dataset,
+            show_convergence_plots=False,
+        )
+
+    def time_run_tardis_rpacket_tracking(self):
+        run_tardis(
+            self.config_rpacket_tracking,
             atom_data=self.atomic_dataset,
             show_convergence_plots=False,
         )


### PR DESCRIPTION
### :pencil: Description

**Type:** roller_coaster: `infrastructure`
This PR benchmarks the run_tardis function with track_rpacket enabled.

