### PR TITLE
Adds number_of_packets property to the packet collection

### DIFF
--- a/tardis/transport/montecarlo/packet_collections.py
+++ b/tardis/transport/montecarlo/packet_collections.py
@@ -232,24 +232,24 @@ class VPacketCollection:
             temp_energies[: self.length] = self.energies
             temp_initial_mus[: self.length] = self.initial_mus
             temp_initial_rs[: self.length] = self.initial_rs
-            temp_last_interaction_in_nu[: self.length] = (
-                self.last_interaction_in_nu
-            )
-            temp_last_interaction_in_r[: self.length] = (
-                self.last_interaction_in_r
-            )
-            temp_last_interaction_type[: self.length] = (
-                self.last_interaction_type
-            )
-            temp_last_interaction_in_id[: self.length] = (
-                self.last_interaction_in_id
-            )
-            temp_last_interaction_out_id[: self.length] = (
-                self.last_interaction_out_id
-            )
-            temp_last_interaction_shell_id[: self.length] = (
-                self.last_interaction_shell_id
-            )
+            temp_last_interaction_in_nu[
+                : self.length
+            ] = self.last_interaction_in_nu
+            temp_last_interaction_in_r[
+                : self.length
+            ] = self.last_interaction_in_r
+            temp_last_interaction_type[
+                : self.length
+            ] = self.last_interaction_type
+            temp_last_interaction_in_id[
+                : self.length
+            ] = self.last_interaction_in_id
+            temp_last_interaction_out_id[
+                : self.length
+            ] = self.last_interaction_out_id
+            temp_last_interaction_shell_id[
+                : self.length
+            ] = self.last_interaction_shell_id
 
             self.nus = temp_nus
             self.energies = temp_energies

--- a/tardis/transport/montecarlo/packet_collections.py
+++ b/tardis/transport/montecarlo/packet_collections.py
@@ -13,10 +13,9 @@ packet_collection_spec = [
     ("initial_energies", float64[:]),
     ("packet_seeds", int64[:]),
     ("time_of_simulation", float64),
-    ("radiation_field_luminosity", float64),  #
+    ("radiation_field_luminosity", float64),
     ("output_nus", float64[:]),
     ("output_energies", float64[:]),
-    ("number_of_packets", int64),
 ]
 
 
@@ -235,24 +234,24 @@ class VPacketCollection:
             temp_energies[: self.length] = self.energies
             temp_initial_mus[: self.length] = self.initial_mus
             temp_initial_rs[: self.length] = self.initial_rs
-            temp_last_interaction_in_nu[: self.length] = (
-                self.last_interaction_in_nu
-            )
-            temp_last_interaction_in_r[: self.length] = (
-                self.last_interaction_in_r
-            )
-            temp_last_interaction_type[: self.length] = (
-                self.last_interaction_type
-            )
-            temp_last_interaction_in_id[: self.length] = (
-                self.last_interaction_in_id
-            )
-            temp_last_interaction_out_id[: self.length] = (
-                self.last_interaction_out_id
-            )
-            temp_last_interaction_shell_id[: self.length] = (
-                self.last_interaction_shell_id
-            )
+            temp_last_interaction_in_nu[
+                : self.length
+            ] = self.last_interaction_in_nu
+            temp_last_interaction_in_r[
+                : self.length
+            ] = self.last_interaction_in_r
+            temp_last_interaction_type[
+                : self.length
+            ] = self.last_interaction_type
+            temp_last_interaction_in_id[
+                : self.length
+            ] = self.last_interaction_in_id
+            temp_last_interaction_out_id[
+                : self.length
+            ] = self.last_interaction_out_id
+            temp_last_interaction_shell_id[
+                : self.length
+            ] = self.last_interaction_shell_id
 
             self.nus = temp_nus
             self.energies = temp_energies

--- a/tardis/transport/montecarlo/packet_collections.py
+++ b/tardis/transport/montecarlo/packet_collections.py
@@ -16,6 +16,7 @@ packet_collection_spec = [
     ("radiation_field_luminosity", float64),  #
     ("output_nus", float64[:]),
     ("output_energies", float64[:]),
+    ("number_of_packets", int64),
 ]
 
 
@@ -43,6 +44,7 @@ class PacketCollection:
         self.output_energies = (
             np.ones_like(initial_radii, dtype=np.float64) * -99.0
         )
+        self.number_of_packets = len(self.initial_radii)
 
 
 @njit(**njit_dict_no_parallel)
@@ -230,24 +232,24 @@ class VPacketCollection:
             temp_energies[: self.length] = self.energies
             temp_initial_mus[: self.length] = self.initial_mus
             temp_initial_rs[: self.length] = self.initial_rs
-            temp_last_interaction_in_nu[
-                : self.length
-            ] = self.last_interaction_in_nu
-            temp_last_interaction_in_r[
-                : self.length
-            ] = self.last_interaction_in_r
-            temp_last_interaction_type[
-                : self.length
-            ] = self.last_interaction_type
-            temp_last_interaction_in_id[
-                : self.length
-            ] = self.last_interaction_in_id
-            temp_last_interaction_out_id[
-                : self.length
-            ] = self.last_interaction_out_id
-            temp_last_interaction_shell_id[
-                : self.length
-            ] = self.last_interaction_shell_id
+            temp_last_interaction_in_nu[: self.length] = (
+                self.last_interaction_in_nu
+            )
+            temp_last_interaction_in_r[: self.length] = (
+                self.last_interaction_in_r
+            )
+            temp_last_interaction_type[: self.length] = (
+                self.last_interaction_type
+            )
+            temp_last_interaction_in_id[: self.length] = (
+                self.last_interaction_in_id
+            )
+            temp_last_interaction_out_id[: self.length] = (
+                self.last_interaction_out_id
+            )
+            temp_last_interaction_shell_id[: self.length] = (
+                self.last_interaction_shell_id
+            )
 
             self.nus = temp_nus
             self.energies = temp_energies

--- a/tardis/transport/montecarlo/packet_collections.py
+++ b/tardis/transport/montecarlo/packet_collections.py
@@ -44,7 +44,10 @@ class PacketCollection:
         self.output_energies = (
             np.ones_like(initial_radii, dtype=np.float64) * -99.0
         )
-        self.number_of_packets = len(self.initial_radii)
+
+    @property
+    def number_of_packets(self):
+        return len(self.initial_radii)
 
 
 @njit(**njit_dict_no_parallel)
@@ -232,24 +235,24 @@ class VPacketCollection:
             temp_energies[: self.length] = self.energies
             temp_initial_mus[: self.length] = self.initial_mus
             temp_initial_rs[: self.length] = self.initial_rs
-            temp_last_interaction_in_nu[
-                : self.length
-            ] = self.last_interaction_in_nu
-            temp_last_interaction_in_r[
-                : self.length
-            ] = self.last_interaction_in_r
-            temp_last_interaction_type[
-                : self.length
-            ] = self.last_interaction_type
-            temp_last_interaction_in_id[
-                : self.length
-            ] = self.last_interaction_in_id
-            temp_last_interaction_out_id[
-                : self.length
-            ] = self.last_interaction_out_id
-            temp_last_interaction_shell_id[
-                : self.length
-            ] = self.last_interaction_shell_id
+            temp_last_interaction_in_nu[: self.length] = (
+                self.last_interaction_in_nu
+            )
+            temp_last_interaction_in_r[: self.length] = (
+                self.last_interaction_in_r
+            )
+            temp_last_interaction_type[: self.length] = (
+                self.last_interaction_type
+            )
+            temp_last_interaction_in_id[: self.length] = (
+                self.last_interaction_in_id
+            )
+            temp_last_interaction_out_id[: self.length] = (
+                self.last_interaction_out_id
+            )
+            temp_last_interaction_shell_id[: self.length] = (
+                self.last_interaction_shell_id
+            )
 
             self.nus = temp_nus
             self.energies = temp_energies


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

Fixes #2738 by adding the number to the packet collection. Better option than in the transport state.

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
