### PR TITLE
Commit hash of PR HEAD not found fix

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,11 +41,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Checkout pull/${{ github.event.number }}
+      - name: Checkout PR and master branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+        if: github.event_name == 'pull_request_target'
+
+      - name: fetch master branch
+        run: git fetch origin master:master
         if: github.event_name == 'pull_request_target'
 
       - name: Setup LFS
@@ -101,9 +105,8 @@ jobs:
       - name: Run benchmarks for base and head commits of PR
         if: github.event_name == 'pull_request_target'
         run: |
-          echo ${{ github.event.pull_request.base.sha }} > commit_hashes.txt
-          echo ${{ github.event.pull_request.head.sha }} >> commit_hashes.txt
-
+          echo $(git rev-parse HEAD) > commit_hashes.txt
+          echo $(git rev-parse master) >> commit_hashes.txt
           asv run -a repeat=2 -a rounds=1 HASHFILE:commit_hashes.txt | tee asv-output-PR.log  
             if grep -q failed asv-output-PR.log; then 
               echo "Some benchmarks have failed!"
@@ -111,10 +114,10 @@ jobs:
             fi
 
       - name: Compare Master and PR head
-        run: asv compare ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} --config asv.conf.json | tee asv-compare-output.log
+        run: asv compare origin/master HEAD --config asv.conf.json | tee asv-compare-output.log
 
       - name: Compare Master and PR head but only show changed results
-        run: asv compare ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} --only-changed --config asv.conf.json | tee asv-compare-changed-output.log
+        run: asv compare origin/master HEAD --only-changed --config asv.conf.json | tee asv-compare-changed-output.log
 
       - name: Benchmarks compare output
         id: asv_pr_vs_master

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
         if: github.event_name == 'pull_request_target'
 
-      - name: fetch master branch
+      - name: Fetch master branch
         run: git fetch origin master:master
         if: github.event_name == 'pull_request_target'
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

In the earlier changes that I made was running fine on my fork action runs but I only checked that by creating pull request from my own account (which did not involved creating a fork). The latest action in tardis fails to read the commits of the PR which i am suspecting to be the reason of a PR created from a fork. So, I tried to make the same environment by creating a fork of my tardis repo from a different account and then making a [pull request](https://github.com/officialasishkumar/tardis/pull/68) from that account. The action ran on that PR which can be found at https://github.com/officialasishkumar/tardis/actions/runs/10113490866/job/27969978963. The commit hash are now getting detected by asv as you can see at "Run benchmarks for base and head commits of PR". I hope this fixes the issue. 


Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
