### PR TITLE
Switch from `logger.warn` to `logger.warning` and other corrections

### DIFF
--- a/tardis/visualization/tools/liv_plot.py
+++ b/tardis/visualization/tools/liv_plot.py
@@ -310,7 +310,7 @@ class LIVPlotter:
             if num_bins < 1:
                 raise ValueError("Number of bins must be positive")
             elif num_bins > len(bin_edges) - 1:
-                logger.warn(
+                logger.warning(
                     "Number of bins must be less than or equal to number of shells. Plotting with number of bins equals to number of shells."
                 )
                 new_bin_edges = bin_edges


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :vertical_traffic_light: `testing` ` | :roller_coaster: `infrastructure`

`logger.warn` is deprecated.
Closes https://github.com/tardis-sn/tardis/issues/2755

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
