### PR TITLE
Opacity state slice

### DIFF
--- a/tardis/opacities/opacity_state.py
+++ b/tardis/opacities/opacity_state.py
@@ -106,7 +106,7 @@ class OpacityState:
         self.photo_ion_activation_idx = photo_ion_activation_idx
         self.k_packet_idx = k_packet_idx
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: slice):
         """Get a shell or slice of shells of the attributes of the opacity state
 
         Args:

--- a/tardis/opacities/opacity_state.py
+++ b/tardis/opacities/opacity_state.py
@@ -110,7 +110,7 @@ class OpacityState:
         """Get a shell or slice of shells of the attributes of the opacity state
 
         Args:
-            i (int, slice): shell index or slice
+            i (slice): shell slice.  Will fail if slice is int since class only supports array types
 
         Returns:
             OpacityState : a shallow copy of the current instance

--- a/tardis/opacities/opacity_state.py
+++ b/tardis/opacities/opacity_state.py
@@ -106,6 +106,41 @@ class OpacityState:
         self.photo_ion_activation_idx = photo_ion_activation_idx
         self.k_packet_idx = k_packet_idx
 
+    def __getitem__(self, i):
+        """Get a shell or slice of shells of the attributes of the opacity state
+
+        Args:
+            i (int, slice): shell index or slice
+
+        Returns:
+            OpacityState : a shallow copy of the current instance
+        """
+        # NOTE: This currently will not work with continuum processes since it does not slice those arrays
+        return OpacityState(
+            self.electron_density[i],
+            self.t_electrons[i],
+            self.line_list_nu,
+            self.tau_sobolev[:, i],
+            self.transition_probabilities[:, i],
+            self.line2macro_level_upper,
+            self.macro_block_references,
+            self.transition_type,
+            self.destination_level_id,
+            self.transition_line_id,
+            self.bf_threshold_list_nu,
+            self.p_fb_deactivation,
+            self.photo_ion_nu_threshold_mins,
+            self.photo_ion_nu_threshold_maxs,
+            self.photo_ion_block_references,
+            self.chi_bf,
+            self.x_sect,
+            self.phot_nus,
+            self.ff_opacity_factor,
+            self.emissivities,
+            self.photo_ion_activation_idx,
+            self.k_packet_idx,
+        )
+
 
 def opacity_state_initialize(
     plasma,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -20,7 +20,7 @@ from tardis.transport.montecarlo.estimators.radfield_mc_estimators import (
 from tardis.transport.montecarlo.montecarlo_transport_state import (
     MonteCarloTransportState,
 )
-from tardis.transport.montecarlo.numba_interface import (
+from tardis.opacities.opacity_state import ( 
     opacity_state_initialize,
 )
 from tardis.transport.montecarlo.packet_trackers import (
@@ -110,10 +110,8 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.line_interaction_type,
             self.montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
-        opacity_state = opacity_state.slice(
-            simulation_state.geometry.v_inner_boundary_index,
-            simulation_state.geometry.v_outer_boundary_index,
-        )
+        opacity_state = opacity_state[simulation_state.geometry.v_inner_boundary_index: simulation_state.geometry.v_outer_boundary_index]
+        
         estimators = initialize_estimator_statistics(
             opacity_state.tau_sobolev.shape, gamma_shape
         )

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -112,7 +112,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
         )
         opacity_state = opacity_state.slice(
             simulation_state.geometry.v_inner_boundary_index,
-            simulation_state.geometry.v_outer_boundary_index
+            simulation_state.geometry.v_outer_boundary_index,
         )
         estimators = initialize_estimator_statistics(
             opacity_state.tau_sobolev.shape, gamma_shape

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -103,7 +103,6 @@ class MonteCarloTransportSolver(HDFWriterMixin):
         packet_collection = self.packet_source.create_packets(
             no_of_packets, seed_offset=iteration
         )
-        
 
         geometry_state = simulation_state.geometry.to_numba()
         opacity_state = opacity_state_initialize(
@@ -111,11 +110,13 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.line_interaction_type,
             self.montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
-        opacity_state = opacity_state[simulation_state.geometry.v_inner_boundary_index: simulation_state.geometry.v_outer_boundary_index]
+        opacity_state = opacity_state[
+            simulation_state.geometry.v_inner_boundary_index : simulation_state.geometry.v_outer_boundary_index
+        ]
         estimators = initialize_estimator_statistics(
             opacity_state.tau_sobolev.shape, gamma_shape
         )
-        
+
         transport_state = MonteCarloTransportState(
             packet_collection,
             estimators,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -110,9 +110,10 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.line_interaction_type,
             self.montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
-        opacity_state = opacity_state[
-            simulation_state.geometry.v_inner_boundary_index : simulation_state.geometry.v_outer_boundary_index
-        ]
+        opacity_state = opacity_state.slice(
+            simulation_state.geometry.v_inner_boundary_index,
+            simulation_state.geometry.v_outer_boundary_index
+        )
         estimators = initialize_estimator_statistics(
             opacity_state.tau_sobolev.shape, gamma_shape
         )

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -103,9 +103,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
         packet_collection = self.packet_source.create_packets(
             no_of_packets, seed_offset=iteration
         )
-        estimators = initialize_estimator_statistics(
-            plasma.tau_sobolevs.shape, gamma_shape
-        )
+        
 
         geometry_state = simulation_state.geometry.to_numba()
         opacity_state = opacity_state_initialize(
@@ -113,6 +111,11 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.line_interaction_type,
             self.montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
+        opacity_state = opacity_state.slice(self.simulation_state.geometry.v_inner_boundary_index, self.simulation_state.geometry.v_outer_boundary_index)
+        estimators = initialize_estimator_statistics(
+            opacity_state.tau_sobolevs.shape, gamma_shape
+        )
+        
         transport_state = MonteCarloTransportState(
             packet_collection,
             estimators,

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -111,9 +111,9 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             self.line_interaction_type,
             self.montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
-        opacity_state = opacity_state.slice(self.simulation_state.geometry.v_inner_boundary_index, self.simulation_state.geometry.v_outer_boundary_index)
+        opacity_state = opacity_state[simulation_state.geometry.v_inner_boundary_index: simulation_state.geometry.v_outer_boundary_index]
         estimators = initialize_estimator_statistics(
-            opacity_state.tau_sobolevs.shape, gamma_shape
+            opacity_state.tau_sobolev.shape, gamma_shape
         )
         
         transport_state = MonteCarloTransportState(

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -112,9 +112,34 @@ class OpacityState(object):
         self.photo_ion_activation_idx = photo_ion_activation_idx
         self.k_packet_idx = k_packet_idx
 
+    def __getitem__(self, i):
+        return OpacityState(
+            self.electron_density[i],
+            self.t_electrons[i],
+            self.line_list_nu,
+            self.tau_sobolev[:, i],
+            self.transition_probabilities[:, i],
+            self.line2macro_level_upper,
+            self.macro_block_references,
+            self.transition_type,
+            self.destination_level_id,
+            self.transition_line_id,
+            self.bf_threshold_list_nu,
+            self.p_fb_deactivation,
+            self.photo_ion_nu_threshold_mins,
+            self.photo_ion_nu_threshold_maxs,
+            self.photo_ion_block_references,
+            self.chi_bf,
+            self.x_sect,
+            self.phot_nus,
+            self.ff_opacity_factor,
+            self.emissivities,
+            self.photo_ion_activation_idx,
+            self.k_packet_idx,)
+
     def slice(self, i, j):
         return OpacityState(
-            self.electron_densities[i:j],
+            self.electron_density[i:j],
             self.t_electrons[i:j],
             self.line_list_nu,
             self.tau_sobolev[:, i:j],

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -146,32 +146,6 @@ class OpacityState(object):
             self.k_packet_idx,
         )
 
-    def slice(self, i, j):
-        return OpacityState(
-            self.electron_density[i:j],
-            self.t_electrons[i:j],
-            self.line_list_nu,
-            self.tau_sobolev[:, i:j],
-            self.transition_probabilities[:, i:j],
-            self.line2macro_level_upper,
-            self.macro_block_references,
-            self.transition_type,
-            self.destination_level_id,
-            self.transition_line_id,
-            self.bf_threshold_list_nu,
-            self.p_fb_deactivation,
-            self.photo_ion_nu_threshold_mins,
-            self.photo_ion_nu_threshold_maxs,
-            self.photo_ion_block_references,
-            self.chi_bf,
-            self.x_sect,
-            self.phot_nus,
-            self.ff_opacity_factor,
-            self.emissivities,
-            self.photo_ion_activation_idx,
-            self.k_packet_idx,
-        )
-
 
 def opacity_state_initialize(
     plasma,

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -121,7 +121,7 @@ class OpacityState(object):
         Returns:
             OpacityState : a shallow copy of the current instance
         """
-        #NOTE: This currently will not work with continuum processes since it does not slice those arrays
+        # NOTE: This currently will not work with continuum processes since it does not slice those arrays
         return OpacityState(
             self.electron_density[i],
             self.t_electrons[i],
@@ -156,7 +156,7 @@ class OpacityState(object):
         Returns:
             OpacityState : a shallow copy of the current instance
         """
-        #NOTE: This currently will not work with continuum processes since it does not slice those arrays
+        # NOTE: This currently will not work with continuum processes since it does not slice those arrays
         return OpacityState(
             self.electron_density[i:j],
             self.t_electrons[i:j],
@@ -181,6 +181,7 @@ class OpacityState(object):
             self.photo_ion_activation_idx,
             self.k_packet_idx,
         )
+
 
 def opacity_state_initialize(
     plasma,

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -119,8 +119,9 @@ class OpacityState(object):
             i (int, slice): shell index or slice
 
         Returns:
-            OpacityState a shallow copy of the current instance
+            OpacityState : a shallow copy of the current instance
         """
+        #NOTE: This currently will not work with continuum processes since it does not slice those arrays
         return OpacityState(
             self.electron_density[i],
             self.t_electrons[i],
@@ -146,6 +147,40 @@ class OpacityState(object):
             self.k_packet_idx,
         )
 
+    def slice(self, i):
+        """Get a shell or slice of shells of the attributes of the opacity state
+
+        Args:
+            i (int, slice): shell index or slice
+
+        Returns:
+            OpacityState : a shallow copy of the current instance
+        """
+        #NOTE: This currently will not work with continuum processes since it does not slice those arrays
+        return OpacityState(
+            self.electron_density[i],
+            self.t_electrons[i],
+            self.line_list_nu,
+            self.tau_sobolev[:, i],
+            self.transition_probabilities[:, i],
+            self.line2macro_level_upper,
+            self.macro_block_references,
+            self.transition_type,
+            self.destination_level_id,
+            self.transition_line_id,
+            self.bf_threshold_list_nu,
+            self.p_fb_deactivation,
+            self.photo_ion_nu_threshold_mins,
+            self.photo_ion_nu_threshold_maxs,
+            self.photo_ion_block_references,
+            self.chi_bf,
+            self.x_sect,
+            self.phot_nus,
+            self.ff_opacity_factor,
+            self.emissivities,
+            self.photo_ion_activation_idx,
+            self.k_packet_idx,
+        )
 
 def opacity_state_initialize(
     plasma,

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -113,6 +113,14 @@ class OpacityState(object):
         self.k_packet_idx = k_packet_idx
 
     def __getitem__(self, i):
+        """Get a shell or slice of shells of the attributes of the opacity state
+
+        Args:
+            i (int, slice): shell index or slice
+
+        Returns:
+            OpacityState a shallow copy of the current instance
+        """
         return OpacityState(
             self.electron_density[i],
             self.t_electrons[i],
@@ -135,7 +143,8 @@ class OpacityState(object):
             self.ff_opacity_factor,
             self.emissivities,
             self.photo_ion_activation_idx,
-            self.k_packet_idx,)
+            self.k_packet_idx,
+        )
 
     def slice(self, i, j):
         return OpacityState(
@@ -160,7 +169,8 @@ class OpacityState(object):
             self.ff_opacity_factor,
             self.emissivities,
             self.photo_ion_activation_idx,
-            self.k_packet_idx,)
+            self.k_packet_idx,
+        )
 
 
 def opacity_state_initialize(

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -112,11 +112,11 @@ class OpacityState(object):
         self.photo_ion_activation_idx = photo_ion_activation_idx
         self.k_packet_idx = k_packet_idx
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: slice):
         """Get a shell or slice of shells of the attributes of the opacity state
 
         Args:
-            i (int, slice): shell index or slice
+            i (slice): shell slice.  Will fail if slice is int since class only supports array types
 
         Returns:
             OpacityState : a shallow copy of the current instance

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -158,11 +158,11 @@ class OpacityState(object):
         """
         #NOTE: This currently will not work with continuum processes since it does not slice those arrays
         return OpacityState(
-            self.electron_density[i],
-            self.t_electrons[i],
+            self.electron_density[i:j],
+            self.t_electrons[i:j],
             self.line_list_nu,
-            self.tau_sobolev[:, i],
-            self.transition_probabilities[:, i],
+            self.tau_sobolev[:, i:j],
+            self.transition_probabilities[:, i:j],
             self.line2macro_level_upper,
             self.macro_block_references,
             self.transition_type,

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -147,7 +147,7 @@ class OpacityState(object):
             self.k_packet_idx,
         )
 
-    def slice(self, i):
+    def slice(self, i, j):
         """Get a shell or slice of shells of the attributes of the opacity state
 
         Args:

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -147,41 +147,6 @@ class OpacityState(object):
             self.k_packet_idx,
         )
 
-    def slice(self, i, j):
-        """Get a shell or slice of shells of the attributes of the opacity state
-
-        Args:
-            i (int, slice): shell index or slice
-
-        Returns:
-            OpacityState : a shallow copy of the current instance
-        """
-        # NOTE: This currently will not work with continuum processes since it does not slice those arrays
-        return OpacityState(
-            self.electron_density[i:j],
-            self.t_electrons[i:j],
-            self.line_list_nu,
-            self.tau_sobolev[:, i:j],
-            self.transition_probabilities[:, i:j],
-            self.line2macro_level_upper,
-            self.macro_block_references,
-            self.transition_type,
-            self.destination_level_id,
-            self.transition_line_id,
-            self.bf_threshold_list_nu,
-            self.p_fb_deactivation,
-            self.photo_ion_nu_threshold_mins,
-            self.photo_ion_nu_threshold_maxs,
-            self.photo_ion_block_references,
-            self.chi_bf,
-            self.x_sect,
-            self.phot_nus,
-            self.ff_opacity_factor,
-            self.emissivities,
-            self.photo_ion_activation_idx,
-            self.k_packet_idx,
-        )
-
 
 def opacity_state_initialize(
     plasma,

--- a/tardis/transport/montecarlo/numba_interface.py
+++ b/tardis/transport/montecarlo/numba_interface.py
@@ -112,6 +112,31 @@ class OpacityState(object):
         self.photo_ion_activation_idx = photo_ion_activation_idx
         self.k_packet_idx = k_packet_idx
 
+    def slice(self, i, j):
+        return OpacityState(
+            self.electron_densities[i:j],
+            self.t_electrons[i:j],
+            self.line_list_nu,
+            self.tau_sobolev[:, i:j],
+            self.transition_probabilities[:, i:j],
+            self.line2macro_level_upper,
+            self.macro_block_references,
+            self.transition_type,
+            self.destination_level_id,
+            self.transition_line_id,
+            self.bf_threshold_list_nu,
+            self.p_fb_deactivation,
+            self.photo_ion_nu_threshold_mins,
+            self.photo_ion_nu_threshold_maxs,
+            self.photo_ion_block_references,
+            self.chi_bf,
+            self.x_sect,
+            self.phot_nus,
+            self.ff_opacity_factor,
+            self.emissivities,
+            self.photo_ion_activation_idx,
+            self.k_packet_idx,)
+
 
 def opacity_state_initialize(
     plasma,

--- a/tardis/transport/montecarlo/tests/test_numba_interface.py
+++ b/tardis/transport/montecarlo/tests/test_numba_interface.py
@@ -17,7 +17,7 @@ def test_opacity_state_initialize(nb_simulation_verysimple, input_params, sliced
     print(dir(actual))
     if sliced:
         index = slice(2, 5)
-        actual = actual.slice(index)
+        actual = actual.slice(2, 5)
     else:
         index = ...
 

--- a/tardis/transport/montecarlo/tests/test_numba_interface.py
+++ b/tardis/transport/montecarlo/tests/test_numba_interface.py
@@ -35,7 +35,6 @@ def test_opacity_state_initialize(
         actual.electron_density, plasma.electron_densities.values[index]
     )
     npt.assert_allclose(actual.line_list_nu, plasma.atomic_data.lines.nu.values)
-    print(actual.tau_sobolev.shape, plasma.tau_sobolevs.values[:, index].shape)
     npt.assert_allclose(
         actual.tau_sobolev, plasma.tau_sobolevs.values[:, index]
     )

--- a/tardis/transport/montecarlo/tests/test_numba_interface.py
+++ b/tardis/transport/montecarlo/tests/test_numba_interface.py
@@ -4,8 +4,9 @@ import numpy.testing as npt
 import numpy as np
 
 
-@pytest.mark.parametrize("input_params", ["scatter", "macroatom", "downbranch"])
-def test_opacity_state_initialize(nb_simulation_verysimple, input_params):
+
+@pytest.mark.parametrize("input_params,sliced", [("scatter", False), ("macroatom", False), ("macroatom", True), ("downbranch", False), ("downbranch", True)])
+def test_opacity_state_initialize(nb_simulation_verysimple, input_params, sliced):
     line_interaction_type = input_params
     plasma = nb_simulation_verysimple.plasma
     actual = numba_interface.opacity_state_initialize(
@@ -13,12 +14,19 @@ def test_opacity_state_initialize(nb_simulation_verysimple, input_params):
         line_interaction_type,
         disable_line_scattering=False,
     )
+    print(dir(actual))
+    if sliced:
+        index = slice(2, 5)
+        actual = actual.slice(index)
+    else:
+        index = ...
 
     npt.assert_allclose(
-        actual.electron_density, plasma.electron_densities.values
+        actual.electron_density, plasma.electron_densities.values[index]
     )
     npt.assert_allclose(actual.line_list_nu, plasma.atomic_data.lines.nu.values)
-    npt.assert_allclose(actual.tau_sobolev, plasma.tau_sobolevs.values)
+    print(actual.tau_sobolev.shape,  plasma.tau_sobolevs.values[:, index].shape)
+    npt.assert_allclose(actual.tau_sobolev, plasma.tau_sobolevs.values[:, index])
     if line_interaction_type == "scatter":
         empty = np.zeros(1, dtype=np.int64)
         npt.assert_allclose(
@@ -32,7 +40,7 @@ def test_opacity_state_initialize(nb_simulation_verysimple, input_params):
     else:
         npt.assert_allclose(
             actual.transition_probabilities,
-            plasma.transition_probabilities.values,
+            plasma.transition_probabilities.values[:, index],
         )
         npt.assert_allclose(
             actual.line2macro_level_upper,

--- a/tardis/transport/montecarlo/tests/test_numba_interface.py
+++ b/tardis/transport/montecarlo/tests/test_numba_interface.py
@@ -27,7 +27,7 @@ def test_opacity_state_initialize(
     print(dir(actual))
     if sliced:
         index = slice(2, 5)
-        actual = actual.slice(2, 5)
+        actual = actual[index]
     else:
         index = ...
 

--- a/tardis/transport/montecarlo/tests/test_numba_interface.py
+++ b/tardis/transport/montecarlo/tests/test_numba_interface.py
@@ -24,7 +24,7 @@ def test_opacity_state_initialize(
         line_interaction_type,
         disable_line_scattering=False,
     )
-    print(dir(actual))
+
     if sliced:
         index = slice(2, 5)
         actual = actual[index]

--- a/tardis/transport/montecarlo/tests/test_numba_interface.py
+++ b/tardis/transport/montecarlo/tests/test_numba_interface.py
@@ -4,9 +4,19 @@ import numpy.testing as npt
 import numpy as np
 
 
-
-@pytest.mark.parametrize("input_params,sliced", [("scatter", False), ("macroatom", False), ("macroatom", True), ("downbranch", False), ("downbranch", True)])
-def test_opacity_state_initialize(nb_simulation_verysimple, input_params, sliced):
+@pytest.mark.parametrize(
+    "input_params,sliced",
+    [
+        ("scatter", False),
+        ("macroatom", False),
+        ("macroatom", True),
+        ("downbranch", False),
+        ("downbranch", True),
+    ],
+)
+def test_opacity_state_initialize(
+    nb_simulation_verysimple, input_params, sliced
+):
     line_interaction_type = input_params
     plasma = nb_simulation_verysimple.plasma
     actual = numba_interface.opacity_state_initialize(
@@ -25,8 +35,10 @@ def test_opacity_state_initialize(nb_simulation_verysimple, input_params, sliced
         actual.electron_density, plasma.electron_densities.values[index]
     )
     npt.assert_allclose(actual.line_list_nu, plasma.atomic_data.lines.nu.values)
-    print(actual.tau_sobolev.shape,  plasma.tau_sobolevs.values[:, index].shape)
-    npt.assert_allclose(actual.tau_sobolev, plasma.tau_sobolevs.values[:, index])
+    print(actual.tau_sobolev.shape, plasma.tau_sobolevs.values[:, index].shape)
+    npt.assert_allclose(
+        actual.tau_sobolev, plasma.tau_sobolevs.values[:, index]
+    )
     if line_interaction_type == "scatter":
         empty = np.zeros(1, dtype=np.int64)
         npt.assert_allclose(


### PR DESCRIPTION
### :pencil: Adds a __geitem__ operation to the opacity state class which allows slicing and indexing by shell


**Type:**  :rocket: `feature`
The opacity state should be able to be sliced in order to run the Montecarlo on sub-slices of the geometry.  Let me know if there are other features or considerations to think about.



### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
