### PR TITLE
Donot run docs, benchmarks and stardis tests on draft PRs.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,6 +32,7 @@ jobs:
   build:
     if: github.repository_owner == 'tardis-sn' &&
       (github.event_name == 'push' ||
+      (!github.event.pull_request.draft) ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
       contains(github.event.pull_request.labels.*.name, 'benchmarks')))

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,6 +14,7 @@ on:
       - reopened
       - synchronize
       - labeled # benchmarks label required
+      - ready_for_review
   workflow_dispatch:
 
 env: 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -38,6 +38,7 @@ defaults:
 jobs:
   check-for-changes:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     outputs:
       trigger-check-outcome: ${{ steps.trigger_check.outcome }}
       docs-check-outcome: ${{ steps.docs_check.outcome }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,6 +18,7 @@ on:
       - reopened
       - synchronize
       - labeled # requires the `build-docs` label
+      - ready_for_review
 
   workflow_dispatch: # manual trigger
 

--- a/.github/workflows/stardis-tests.yml
+++ b/.github/workflows/stardis-tests.yml
@@ -3,7 +3,7 @@ name: stardis-tests
 on:
   push:
     branches:
-    - '*'
+    - 'master'
 
   pull_request:
     branches:

--- a/.github/workflows/stardis-tests.yml
+++ b/.github/workflows/stardis-tests.yml
@@ -3,7 +3,7 @@ name: stardis-tests
 on:
   push:
     branches:
-    - 'master'
+    - master
 
   pull_request:
     branches:
@@ -27,15 +27,11 @@ jobs:
   build:
     strategy:
       matrix:
-        label: [osx-64, linux-64]
+        label: [linux-64]
         include:
           - os: ubuntu-latest
             label: linux-64
             prefix: /usr/share/miniconda3/envs/stardis
-
-          - os: macos-latest
-            label: osx-64
-            prefix: /Users/runner/miniconda3/envs/stardis
 
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/stardis-tests.yml
+++ b/.github/workflows/stardis-tests.yml
@@ -39,6 +39,7 @@ jobs:
 
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
+    if: ${{ !github.event.pull_request.draft }}
     steps:     
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/stardis-tests.yml
+++ b/.github/workflows/stardis-tests.yml
@@ -9,6 +9,11 @@ on:
     branches:
     - '*'
 
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR makes sure that the build docs, benchmarks and stardis tests are run on a PR which is ready for review.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
