### PR TITLE
Update docstrings of Tracker tests

### DIFF
--- a/tardis/transport/montecarlo/tests/test_rpacket_last_interaction_tracker.py
+++ b/tardis/transport/montecarlo/tests/test_rpacket_last_interaction_tracker.py
@@ -12,7 +12,7 @@ from tardis.transport.montecarlo.packet_trackers import (
 def interaction_type_in_use(
     nb_simulation_verysimple,
 ):
-    """Last interaction types of rpacket from LastInteractionTracker"""
+    """Last interaction types of rpacket from LastInteractionTracker class"""
     transport_state = nb_simulation_verysimple.transport.transport_state
     interaction_type = transport_state.last_interaction_type
     return interaction_type
@@ -23,7 +23,9 @@ def shell_id_in_use(
     nb_simulation_verysimple,
     interaction_type_in_use,
 ):
-    """Last interaction types of rpacket from LastInteractionTracker"""
+    """
+    shell_id when last interaction is line from LastInteractionTracker class
+    """
     transport_state = nb_simulation_verysimple.transport.transport_state
     shell_id = transport_state.last_line_interaction_shell_id
     mask = interaction_type_in_use == InteractionType.LINE
@@ -34,7 +36,9 @@ def shell_id_in_use(
 def interaction_type_to_check(
     nb_simulation_verysimple,
 ):
-    """Last interaction types of rpacket from RPacketLastInteractionTracker"""
+    """
+    Last interaction types of rpacket from RPacketLastInteractionTracker class
+    """
     transport_state = nb_simulation_verysimple.transport.transport_state
     interaction_type = np.empty(
         len(transport_state.rpacket_tracker), dtype=np.int64
@@ -52,7 +56,9 @@ def shell_id_to_check(
     nb_simulation_verysimple,
     interaction_type_to_check,
 ):
-    """Last interaction types of rpacket from RPacketLastInteractionTracker"""
+    """
+    shell_id when last interaction is line from RPacketLastInteractionTracker class
+    """
     transport_state = nb_simulation_verysimple.transport.transport_state
     shell_id = np.empty(len(transport_state.rpacket_tracker), dtype=np.int64)
     for i, last_interaction_tracker in enumerate(
@@ -78,7 +84,9 @@ def nu_packet_collection(
 def nu_to_check(
     nb_simulation_verysimple,
 ):
-    """Last interaction output nus of rpacket from RPacketLastInteractionTracker"""
+    """
+    Last interaction output nus of rpacket from RPacketLastInteractionTracker class
+    """
     transport_state = nb_simulation_verysimple.transport.transport_state
     nu = np.empty(len(transport_state.rpacket_tracker), dtype=np.float64)
     for i, last_interaction_tracker in enumerate(

--- a/tardis/transport/montecarlo/tests/test_rpacket_tracker.py
+++ b/tardis/transport/montecarlo/tests/test_rpacket_tracker.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.rpacket_tracking
 def interaction_type_last_interaction_class(
     simulation_rpacket_tracking,
 ):
-    """Last interaction types of rpacket from LastInteractionTracker"""
+    """Last interaction types of rpacket from LastInteractionTracker class"""
     interaction_type = (
         simulation_rpacket_tracking.transport.transport_state.last_interaction_type
     )
@@ -27,7 +27,9 @@ def interaction_type_last_interaction_class(
 def shell_id_last_interaction_class(
     simulation_rpacket_tracking,
 ):
-    """Last Line Interaction Shell Id of rpacket from LastInteractionTracker"""
+    """
+    shell_id when last interaction is line from LastInteractionTracker class
+    """
     interaction_type = (
         simulation_rpacket_tracking.transport.transport_state.last_interaction_type
     )
@@ -62,7 +64,7 @@ def rpacket_tracker(simulation_rpacket_tracking):
 
 @pytest.fixture(scope="module")
 def last_interaction_type_rpacket_tracker(rpacket_tracker):
-    """Last interaction types of rpacket from RPacketTracker"""
+    """Last interaction types of rpacket from RPacketTracker class"""
     no_of_packets = len(rpacket_tracker)
     interaction_type = np.empty(no_of_packets, dtype=np.int64)
 
@@ -78,7 +80,9 @@ def last_interaction_type_rpacket_tracker(rpacket_tracker):
 def shell_id_rpacket_tracker(
     rpacket_tracker, last_interaction_type_rpacket_tracker
 ):
-    """Last line interaction shell id of rpacket from RPacketTracker"""
+    """
+    shell_id when last interaction is line from RPacketTracker class
+    """
     no_of_packets = len(rpacket_tracker)
     shell_id = np.empty(no_of_packets, dtype=np.int64)
 
@@ -93,7 +97,7 @@ def shell_id_rpacket_tracker(
 
 @pytest.fixture()
 def nu_rpacket_tracker(rpacket_tracker):
-    """Output nu of rpacket from RPacketTracker"""
+    """Output nu of rpacket from RPacketTracker class"""
     no_of_packets = len(rpacket_tracker)
     nu = np.empty(no_of_packets, dtype=np.float64)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `documentation`

Earlier the docstring meant that the `shell_id` is of the last line interaction. 
For eg, if interaction_type is [Line, Escatter, Escatter, Line, Escatter] and the shell_id is [0, 1, 2, 2, 3, 4]. So the docstring sounded like it should return 3 since the last line interaction happened in the 3rd shell, but that was not the case.

The fixtures return the shell_id when the last interaction is strictly line
For eg, if interaction_type is [Line, Escatter, Escatter, Line, Escatter] and the shell_id is [0, 1, 2, 2, 3, 4]. In this case, since the last interaction is Escatter, it should not return anything.


