### PR TITLE
Add Packet Wavelength filter to LIV Plot

### DIFF
--- a/docs/io/visualization/how_to_liv_plot.ipynb
+++ b/docs/io/visualization/how_to_liv_plot.ipynb
@@ -121,6 +121,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Plotting a specific wavelength range\n",
+    "You can also restrict the wavelength range of escaped packets that you want to plot by specifying `packet_wvl_range`. It should be a quantity in Angstroms, containing two values - lower lambda and upper lambda i.e. `[lower_lambda, upper_lambda] * u.AA`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter.generate_plot_mpl(packet_wvl_range=[3000, 9000] * u.AA)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Plotting only the top contributing elements"
    ]
   },
@@ -305,6 +331,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Plotting a specific wavelength range\n",
+    "You can also restrict the wavelength range of escaped packets that you want to plot by specifying `packet_wvl_range`. It should be a quantity in Angstroms, containing two values - lower lambda and upper lambda i.e. `[lower_lambda, upper_lambda] * u.AA`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy import units as u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plotter.generate_plot_ply(packet_wvl_range=[3000, 9000] * u.AA)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Plotting only the top contributing elements"
    ]
   },
@@ -372,7 +424,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plotter.generate_plot_ply(species_list = [\"Si I-III\", \"Ca\", \"S\"], num_bins=10)"
+    "plotter.generate_plot_ply(species_list = [\"Si I-III\", \"Ca\", \"S\"], num_bins=21)"
    ]
   },
   {

--- a/docs/io/visualization/how_to_liv_plot.ipynb
+++ b/docs/io/visualization/how_to_liv_plot.ipynb
@@ -205,7 +205,7 @@
    "metadata": {},
    "source": [
     "### Plotting a specific number of bins\n",
-    "You can regroup the bins with broader or narrower widths within the same velocity range using `num_bins`."
+    "You can regroup the bins with broader widths within the same velocity range using `num_bins`."
    ]
   },
   {
@@ -415,7 +415,7 @@
    "metadata": {},
    "source": [
     "### Plotting a specific number of bins\n",
-    "You can regroup the bins with broader and narrower widths within the same velocity range using `num_bins`."
+    "You can regroup the bins with broader widths within the same velocity range using `num_bins`."
    ]
   },
   {
@@ -424,7 +424,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plotter.generate_plot_ply(species_list = [\"Si I-III\", \"Ca\", \"S\"], num_bins=21)"
+    "plotter.generate_plot_ply(species_list = [\"Si I-III\", \"Ca\", \"S\"], num_bins=10)"
    ]
   },
   {

--- a/tardis/visualization/tools/liv_plot.py
+++ b/tardis/visualization/tools/liv_plot.py
@@ -216,6 +216,7 @@ class LIVPlotter:
 
         plot_colors = []
         plot_data = []
+        species_not_wvl_range = []
         species_counter = 0
 
         for specie_list in self._species_mapped.values():
@@ -223,13 +224,11 @@ class LIVPlotter:
             for specie in specie_list:
                 if specie in self.species:
                     if specie not in groups.groups:
-                        # atomic_number = specie // 100
-                        # ion_number = specie % 100
-                        # ion_numeral = int_to_roman(ion_number + 1)
-                        # label = f"{atomic_number2element_symbol(atomic_number)} {ion_numeral}"
-                        # logger.warning(
-                        #     f"Species {label} not found in the wavelength range."
-                        # )
+                        atomic_number = specie // 100
+                        ion_number = specie % 100
+                        ion_numeral = int_to_roman(ion_number + 1)
+                        label = f"{atomic_number2element_symbol(atomic_number)} {ion_numeral}"
+                        species_not_wvl_range.append(label)
                         continue
                     g_df = groups.get_group(specie)
                     r_last_interaction = (
@@ -243,7 +242,10 @@ class LIVPlotter:
                 plot_data.append(full_v_last)
                 plot_colors.append(self._color_list[species_counter])
                 species_counter += 1
-
+        if species_not_wvl_range:
+            logger.info(
+                f"{species_not_wvl_range} were not found in the provided wavelength range."
+            )
         return plot_data, plot_colors
 
     def _prepare_plot_data(


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

Added a Wavelength range filter to restrict the analysis of interacting packets in LIV Plot.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
