### PR TITLE
Fixes qgridnext import error in tests

### DIFF
--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -47,9 +47,10 @@ def create_table_widget(
     except ModuleNotFoundError as e:
         logger.exception(
             "qgridnext must be installed via pip for widgets to work.\n \
-                         Run 'pip install qgridnext' inside your tardis environment"
+            Run 'pip install qgridnext' inside your tardis environment.\n \
+            Falling back to qgrid"
         )
-        raise e
+        import qgrid as qgridnext
 
     # Setting the options to be used for creating table widgets
     grid_options = {


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

The previous qgridnext import check #2819 caused tests to fail. This version falls back to regular qgrid, which will still raise an exception logging error but prevents test failures.

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
