### PR TITLE
Add zenodo badge in the release summary notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,4 +90,5 @@ jobs:
             conda-linux-64.lock
             conda-osx-64.lock
             conda-lock.yml
+          fail_on_unmatched_files: false
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           draft: false
       
       - name: Wait for Zenodo to update the latest release
-        run: sleep 30
+        run: sleep 120
       
       - name: Fetch Latest DOI from Zenodo
         id: fetch-doi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,36 @@ jobs:
           python .ci-helpers/get_next_version.py
           echo "NEW_TAG=$(python .ci-helpers/get_next_version.py)" >> $GITHUB_ENV
 
+      - name: Initialize release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: TARDIS v${{ env.NEW_TAG }}
+          tag_name: release-${{ env.NEW_TAG }}
+          body: "This release has been created automatically by the TARDIS continuous delivery pipeline."
+          draft: true
+      
+      - name: Fetch Latest DOI from Zenodo
+        id: fetch-doi
+        run: |
+            CONCEPT_DOI="592480"
+            # Make the API request for BibTeX format, following redirects
+            response=$(curl -s -L -H "Accept: application/x-bibtex" "https://zenodo.org/api/records/${CONCEPT_DOI}")
+        
+            # Extract the full DOI value correctly
+            doi=$(echo "$response" | grep -oP 'doi\s*=\s*{([^}]+)}' | grep -oP '\{([^}]+)\}' | sed 's/[{}]//g')
+        
+            # Extract the DOI URL directly from the response
+            url=$(echo "$response" | grep -oP 'url\s*=\s*{([^}]+)}' | grep -oP '\{([^}]+)\}' | sed 's/[{}]//g')
+        
+            echo "Extracted DOI: ${doi}"
+            echo "Extracted URL: ${url}"
+            # Create DOI badge using the full DOI value
+            doi_badge="[![DOI Badge](https://img.shields.io/badge/DOI-${doi}-blue)](${doi_url})"
+        
+            # Store results in GitHub environment variables
+            echo "doi_badge=${doi_badge}" >> $GITHUB_ENV
+            echo "doi_url=${url}" >> $GITHUB_ENV
+        
       - name: Generate and process changelog
         run: |
           CHANGELOG=$(git cliff --config pyproject.toml --unreleased | sed -n '/^## Changelog/,$p' | grep -vE '^(ERROR|WARN)')
@@ -45,16 +75,13 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Create new release
+      - name: Update release with changelog and DOI
         uses: softprops/action-gh-release@v1
         with:
-          token: ${{ secrets.BOT_TOKEN }}
-          name: TARDIS v${{ env.NEW_TAG}}
           tag_name: release-${{ env.NEW_TAG }}
-          prerelease: false
           body: |
             This release has been created automatically by the TARDIS continuous delivery pipeline.
-            
+            ${{ env.doi_badge }}
             ${{ env.CHANGELOG }}
             
             A complete list of changes for this release is available at [CHANGELOG.md](https://github.com/tardis-sn/tardis/blob/master/CHANGELOG.md).
@@ -63,4 +90,4 @@ jobs:
             conda-linux-64.lock
             conda-osx-64.lock
             conda-lock.yml
-          fail_on_unmatched_files: false
+          draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
             echo "Extracted DOI: ${doi}"
             echo "Extracted URL: ${url}"
             # Create DOI badge using the full DOI value
-            doi_badge="[![DOI Badge](https://img.shields.io/badge/DOI-${doi}-blue)](${doi_url})"
+            doi_badge="[![DOI Badge](https://img.shields.io/badge/DOI-${doi}-blue)](${url})"
         
             # Store results in GitHub environment variables
             echo "doi_badge=${doi_badge}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
           name: TARDIS v${{ env.NEW_TAG }}
           tag_name: release-${{ env.NEW_TAG }}
           body: "This release has been created automatically by the TARDIS continuous delivery pipeline."
-          draft: true
+          draft: false
+      
+      - name: Wait for Zenodo to update the latest release
+        run: sleep 30
       
       - name: Fetch Latest DOI from Zenodo
         id: fetch-doi


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR aims at adding a zenodo badge in the release summary github notes alongwith the changelog.

Sample Run:
https://github.com/KasukabeDefenceForce/tardis/releases/tag/release-0024.10.07.1

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
