### PR TITLE
Fix benchmarks 2

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,7 +68,7 @@ jobs:
             asv=0.6.4
             mamba
             conda-build
-            conda
+            conda=24.9.0
 
       - name: Accept all asv questions
         run: asv machine --yes


### PR DESCRIPTION
### :pencil: Description

**Type:** infrastructure

Similar to https://github.com/tardis-sn/tardis/pull/2831.
Conda also had a a new release and for some reason the pipeline was not picking that up. Using this version of conda should fix the benchmarks workflow again.



Proof it works- https://github.com/tardis-sn/tardis/actions/runs/11215008048/job/31171292601

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
