### PR TITLE
Close regression data files 

### DIFF
--- a/tardis/spectrum/tests/test_spectrum_solver.py
+++ b/tardis/spectrum/tests/test_spectrum_solver.py
@@ -32,10 +32,10 @@ class TestSpectrumSolver:
         simulation.run_final()
 
         request.cls.regression_data = RegressionData(request)
-        request.cls.regression_data.sync_hdf_store(simulation)
+        data = request.cls.regression_data.sync_hdf_store(simulation)
 
         yield simulation
-        request.cls.regression_data.close()
+        data.close()
 
     def get_expected_data(self, key: str):
         return pd.read_hdf(self.regression_data.fpath, key)

--- a/tardis/spectrum/tests/test_spectrum_solver.py
+++ b/tardis/spectrum/tests/test_spectrum_solver.py
@@ -34,7 +34,8 @@ class TestSpectrumSolver:
         request.cls.regression_data = RegressionData(request)
         request.cls.regression_data.sync_hdf_store(simulation)
 
-        return simulation
+        yield simulation
+        request.cls.regression_data.close()
 
     def get_expected_data(self, key: str):
         return pd.read_hdf(self.regression_data.fpath, key)

--- a/tardis/tests/fixtures/regression_data.py
+++ b/tardis/tests/fixtures/regression_data.py
@@ -171,5 +171,5 @@ class RegressionData:
 def regression_data(request):
     regression_data_instance = RegressionData(request)
     yield regression_data_instance
-    if regression_data_instance.hdf_store_object:
+    if regression_data_instance.hdf_store_object.is_open:
         regression_data_instance.hdf_store_object.close()

--- a/tardis/tests/fixtures/regression_data.py
+++ b/tardis/tests/fixtures/regression_data.py
@@ -171,5 +171,5 @@ class RegressionData:
 def regression_data(request):
     regression_data_instance = RegressionData(request)
     yield regression_data_instance
-    if regression_data_instance.hdf_store_object.is_open:
+    if regression_data_instance.hdf_store_object is not None and regression_data_instance.hdf_store_object.is_open:
         regression_data_instance.hdf_store_object.close()

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -55,10 +55,10 @@ class TestTransportSimple:
         simulation.run_final()
 
         request.cls.regression_data = RegressionData(request)
-        request.cls.regression_data.sync_hdf_store(simulation)
+        data = request.cls.regression_data.sync_hdf_store(simulation)
 
         yield simulation
-        request.cls.regression_data.close()
+        data.close()
 
     def get_expected_data(self, key: str):
         return pd.read_hdf(self.regression_data.fpath, key)

--- a/tardis/tests/test_tardis_full.py
+++ b/tardis/tests/test_tardis_full.py
@@ -57,7 +57,8 @@ class TestTransportSimple:
         request.cls.regression_data = RegressionData(request)
         request.cls.regression_data.sync_hdf_store(simulation)
 
-        return simulation
+        yield simulation
+        request.cls.regression_data.close()
 
     def get_expected_data(self, key: str):
         return pd.read_hdf(self.regression_data.fpath, key)

--- a/tardis/tests/test_tardis_full_formal_integral.py
+++ b/tardis/tests/test_tardis_full_formal_integral.py
@@ -73,8 +73,8 @@ class TestTransportSimpleFormalIntegral:
     def test_simulation(self, simulation, request):
         regression_data = RegressionData(request)
         container = SimulationContainer(simulation)
-        regression_data.sync_hdf_store(container)
-        regression_data.close()
+        data = regression_data.sync_hdf_store(container)
+        data.close()
 
     def test_j_blue_estimators(self, simulation, request):
         regression_data = RegressionData(request)

--- a/tardis/tests/test_tardis_full_formal_integral.py
+++ b/tardis/tests/test_tardis_full_formal_integral.py
@@ -74,6 +74,7 @@ class TestTransportSimpleFormalIntegral:
         regression_data = RegressionData(request)
         container = SimulationContainer(simulation)
         regression_data.sync_hdf_store(container)
+        regression_data.close()
 
     def test_j_blue_estimators(self, simulation, request):
         regression_data = RegressionData(request)

--- a/tardis/visualization/tools/tests/test_liv_plot.py
+++ b/tardis/visualization/tools/tests/test_liv_plot.py
@@ -357,6 +357,7 @@ class TestLIVPlotter:
                             + str(index2)
                         ),
                     )
+        expected.close()
 
     def test_mpl_image(self, plotter_generate_plot_mpl, tmp_path, request):
         """
@@ -520,3 +521,4 @@ class TestLIVPlotter:
                 rtol=0.3,
                 atol=3,
             )
+        expected.close()

--- a/tardis/visualization/tools/tests/test_sdec_plot.py
+++ b/tardis/visualization/tools/tests/test_sdec_plot.py
@@ -231,6 +231,7 @@ class TestSDECPlotter:
                 pd.testing.assert_frame_equal(
                     plot_object, expected.get(group + attribute_name)
                 )
+        expected.close()
 
     @pytest.fixture(scope="class", params=combinations)
     def plotter_generate_plot_mpl(self, request, observed_spectrum, plotter):
@@ -331,6 +332,7 @@ class TestSDECPlotter:
                             + str(index2)
                         ),
                     )
+        expected.close()
 
     @pytest.fixture(scope="class", params=combinations)
     def plotter_generate_plot_ply(self, request, observed_spectrum, plotter):
@@ -415,6 +417,8 @@ class TestSDECPlotter:
             np.testing.assert_allclose(
                 data.y, expected.get(group + "y").values.flatten()
             )
+
+        expected.close()
 
     def test_mpl_image(self, plotter_generate_plot_mpl, tmp_path, request):
         regression_data = RegressionData(request)


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :vertical_traffic_light: `testing` 

Closes regression data files after tests have run and suppresses warnings.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
