### PR TITLE
Replace `setup_lfs` action with single file checkout

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -54,8 +54,13 @@ jobs:
         run: git fetch origin master:master
         if: github.event_name == 'pull_request_target'
 
-      - name: Setup LFS
-        uses: ./.github/actions/setup_lfs
+      - uses: actions/checkout@v4
+        with:
+          repository: tardis-sn/tardis-regression-data
+          path: tardis-regression-data
+          lfs: true
+          sparse-checkout: |
+            atom_data/kurucz_cd23_chianti_H_He.h5
 
       - name: Setup Mamba
         uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -90,8 +90,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
         if: github.event_name == 'pull_request_target'
 
-      - name: Setup LFS
-        uses: ./.github/actions/setup_lfs
+      - uses: actions/checkout@v4
+        with:
+          repository: tardis-sn/tardis-regression-data
+          path: tardis-regression-data
+          lfs: true
+          sparse-checkout: |
+            atom_data/kurucz_cd23_chianti_H_He.h5
 
       - name: Setup environment
         uses: ./.github/actions/setup_env


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The setup_lfs action uses the entire regression data repo, even though it is cached. Downloading the atom data file might consume fewer resources and prevent the LFS bandwidth from being used too much.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
