### PR TITLE
Replace M_PI=np.arccos(-1) with M_PI=np.pi

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -286,3 +286,5 @@ Israel Roldan <israel.alberto.rv@gmail.com> AirvZxf <israel.alberto.rv@gmail.com
 Israel Roldan <israel.alberto.rv@gmail.com> airv_zxf <israel.alberto.rv@gmail.com>
 
 Michael Zingale <michael.zingale@stonybrook.edu>
+
+Akash Kaushik <akash265457k@gmail.com>

--- a/tardis/spectrum/formal_integral.py
+++ b/tardis/spectrum/formal_integral.py
@@ -24,7 +24,7 @@ from tardis.transport.montecarlo.numba_interface import (
 )
 
 C_INV = 3.33564e-11
-M_PI = np.arccos(-1)
+M_PI = np.pi
 KB_CGS = 1.3806488e-16
 H_CGS = 6.62606957e-27
 

--- a/tardis/spectrum/formal_integral.py
+++ b/tardis/spectrum/formal_integral.py
@@ -24,7 +24,7 @@ from tardis.transport.montecarlo.numba_interface import (
 )
 
 C_INV = 3.33564e-11
-M_PI = np.pi
+PI = np.pi
 KB_CGS = 1.3806488e-16
 H_CGS = 6.62606957e-27
 
@@ -197,7 +197,7 @@ def numba_formal_integral(
                 pJred_lu += direction
                 pJblue_lu += direction
             I_nu[p_idx] *= p
-        L[nu_idx] = 8 * M_PI * M_PI * trapezoid_integration(I_nu, R_max / N)
+        L[nu_idx] = 8 * PI * PI * trapezoid_integration(I_nu, R_max / N)
 
     return L, I_nu_p
 
@@ -640,7 +640,7 @@ class FormalIntegrator:
         I_nu = self.transport.I_nu_p * ps
         L_test = np.array(
             [
-                8 * M_PI * M_PI * trapezoid_integration((I_nu)[i, :], R_max / N)
+                8 * PI * PI * trapezoid_integration((I_nu)[i, :], R_max / N)
                 for i in range(nu.shape[0])
             ]
         )

--- a/tardis/spectrum/formal_integral_cuda.py
+++ b/tardis/spectrum/formal_integral_cuda.py
@@ -6,7 +6,7 @@ from numba import cuda
 from tardis.transport.montecarlo.configuration.constants import SIGMA_THOMSON
 
 C_INV = 3.33564e-11
-M_PI = np.pi
+PI = np.pi
 KB_CGS = 1.3806488e-16
 H_CGS = 6.62606957e-27
 
@@ -28,7 +28,7 @@ def cuda_vector_integrator(L, I_nu, N, R_max):
     """
     nu_idx = cuda.grid(1)
     L[nu_idx] = (
-        8 * M_PI * M_PI * trapezoid_integration_cuda(I_nu[nu_idx], R_max / N)
+        8 * PI * PI * trapezoid_integration_cuda(I_nu[nu_idx], R_max / N)
     )
 
 

--- a/tardis/spectrum/formal_integral_cuda.py
+++ b/tardis/spectrum/formal_integral_cuda.py
@@ -6,7 +6,7 @@ from numba import cuda
 from tardis.transport.montecarlo.configuration.constants import SIGMA_THOMSON
 
 C_INV = 3.33564e-11
-M_PI = np.arccos(-1)
+M_PI = np.pi
 KB_CGS = 1.3806488e-16
 H_CGS = 6.62606957e-27
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

This pull request addresses the inconsistent usage of the constant for π (pi) in the code. The previously assigned variable `M_PI` was defined as `np.arccos(-1)`. This has now been replaced with `M_PI=np.pi`, which is a more straightforward and standardized way to reference the value of π using NumPy's built-in constant.

This change improves code readability and consistency, ensuring that we use `np.pi` across the codebase instead of redefining π in different ways. 

This PR resolves issue #2863 regarding the inconsistent definition of π.

### :pushpin: Resources

- [NumPy Documentation: Constants](https://numpy.org/doc/stable/reference/constants.html#numpy.pi)

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)

I ran the testing pipeline, and all tests passed successfully, confirming that the change does not introduce any issues.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.

