### PR TITLE
Fix the issue where the docs are built twice when there are no changes

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -40,8 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     outputs:
-      trigger-check-outcome: ${{ steps.trigger_check.outcome }}
-      docs-check-outcome: ${{ steps.docs_check.outcome }}
+      should-run: ${{ steps.check_conditions.outputs.should-run }}
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
@@ -53,32 +52,43 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
         if: github.event_name == 'pull_request_target'
 
-      - name: Check for trigger by push event, manual dispatch, build-docs label on a PR
-        id: trigger_check
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'build-docs')
+      - id: check_conditions
+        name: Check conditions for running workflow
         run: |
-          echo "Building docs as a test."
-          exit 0
-        continue-on-error: true
-
-      - name: Check for changes in documentation
-        run: |
-          if git diff origin/master..."$(git rev-parse --abbrev-ref HEAD)" --name-only | cat | grep '^docs/' | grep -q .; then
+          # Initialize should-run as false
+          echo "should-run=false" >> $GITHUB_OUTPUT
+          
+          # Always run for push and workflow_dispatch
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # For pull_request_target events
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            # Check if docs directory has changes
+            HAS_DOCS_CHANGES=false
+            if git diff origin/master..."$(git rev-parse --abbrev-ref HEAD)" --name-only | cat | grep '^docs/' | grep -q .; then
+              HAS_DOCS_CHANGES=true
               num_files=$(git diff --name-only origin/master...HEAD | grep '^docs/' | wc -l)
               echo "Changes found in documentation files: $num_files"
-              exit 0
-          else
+            else
               echo "No changes found in documentation files - will stop running the pipeline."
-              exit 1
+            fi
+            
+            # Check if PR has build-docs label
+            HAS_BUILD_DOCS_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'build-docs') }}
+            
+            if [[ "$HAS_DOCS_CHANGES" == "true" && "$HAS_BUILD_DOCS_LABEL" == "false" ]] || \
+               [[ "$HAS_DOCS_CHANGES" == "false" && "$HAS_BUILD_DOCS_LABEL" == "true" ]]; then
+              echo "should-run=true" >> $GITHUB_OUTPUT
+            fi
           fi
-        id: docs_check
-        if: steps.trigger_check.outcome != 'success'
-        continue-on-error: true
 
   build-docs:
     runs-on: ubuntu-latest
     needs: check-for-changes
-    if: needs.check-for-changes.outputs.trigger-check-outcome == 'success' || needs.check-for-changes.outputs.docs-check-outcome == 'success'
+    if: needs.check-for-changes.outputs.should-run == 'true'
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`
This PR aims to fix the issue where the docs would build again when the "build-docs" label was added even when there were no changes in the PR. 

Issue: https://github.com/tardis-sn/tardis/issues/2868

Here is a sample run:
https://github.com/KasukabeDefenceForce/tardis/pull/58
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
