### PR TITLE
Fix build docs workflow 

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -57,31 +57,30 @@ jobs:
         run: |
           # Initialize should-run as false
           echo "should-run=false" >> $GITHUB_OUTPUT
-          
+
           # Always run for push and workflow_dispatch
           if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "should-run=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
-          # For pull_request_target events
+
+           # For pull_request_target events
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             # Check if docs directory has changes
-            HAS_DOCS_CHANGES=false
-            if git diff origin/master..."$(git rev-parse --abbrev-ref HEAD)" --name-only | cat | grep '^docs/' | grep -q .; then
-              HAS_DOCS_CHANGES=true
+            if git diff origin/master..."$(git rev-parse --abbrev-ref HEAD)" --name-only | grep '^docs/' | grep -q .; then
               num_files=$(git diff --name-only origin/master...HEAD | grep '^docs/' | wc -l)
               echo "Changes found in documentation files: $num_files"
+              echo "should-run=true" >> $GITHUB_OUTPUT
+              exit 0
             else
-              echo "No changes found in documentation files - will stop running the pipeline."
+              echo "No changes found in documentation files."
             fi
-            
+
             # Check if PR has build-docs label
             HAS_BUILD_DOCS_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'build-docs') }}
-            
-            if [[ "$HAS_DOCS_CHANGES" == "true" && "$HAS_BUILD_DOCS_LABEL" == "false" ]] || \
-               [[ "$HAS_DOCS_CHANGES" == "false" && "$HAS_BUILD_DOCS_LABEL" == "true" ]]; then
+            if [[ "$HAS_BUILD_DOCS_LABEL" == "true" ]]; then
               echo "should-run=true" >> $GITHUB_OUTPUT
+              exit 0
             fi
           fi
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -73,7 +73,7 @@ jobs:
               echo "should-run=true" >> $GITHUB_OUTPUT
               exit 0
             else
-              echo "No changes found in documentation files."
+              echo "No changes found in documentation files - will stop running the pipeline."
             fi
 
             # Check if PR has build-docs label


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The build docs workflow is skipping when there are changes in docs and a label is applied.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
