### PR TITLE
Add token to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           name: TARDIS v${{ env.NEW_TAG }}
           tag_name: release-${{ env.NEW_TAG }}
+          token: ${{ secrets.BOT_TOKEN }}
           body: "This release has been created automatically by the TARDIS continuous delivery pipeline."
           draft: false
       
@@ -127,6 +128,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: release-${{ env.NEW_TAG }}
+          token: ${{ secrets.BOT_TOKEN }}
           body: |
             This release has been created automatically by the TARDIS continuous delivery pipeline.
             ${{ env.doi_badge }}


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR aims at fixing the bug where post release workflow does not run after the release workflow is executed normally. Triggering another workflow requires a PAT and wont work with the default github token.


Sample RElease:
https://github.com/KasukabeDefenceForce/tardis/actions/runs/12010276847

Sample post release:
https://github.com/KasukabeDefenceForce/tardis/actions/runs/12010282772

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
