### PR TITLE
Fixing label issue in convergence plots (see Issue #2446)

### DIFF
--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -13,6 +13,17 @@ from traitlets import TraitError
 from astropy import units as u
 
 
+# Added the below as a (temporary) workaround to the latex
+# labels on the convergence plots not rendering correctly.
+import plotly
+from IPython.display import display, HTML
+
+plotly.offline.init_notebook_mode()
+display(HTML(
+    '<script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG"></script>'
+))
+
+
 def transition_colors(length, name="jet"):
     """
     Create colorscale for convergence plots, returns a list of colors.


### PR DESCRIPTION
See issue #2446

### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
