### PR TITLE
Update lineinteraction.rst

### DIFF
--- a/docs/physics/montecarlo/lineinteraction.rst
+++ b/docs/physics/montecarlo/lineinteraction.rst
@@ -16,33 +16,41 @@ before (i for initial). Thus, after accounting for the frame transformations,
 
     \varepsilon_f = \varepsilon_i \frac{1 - \beta \mu_i}{1 - \beta \mu_f}
 
-holds. Also, TARDIS treats that the re-emission of the line interaction
+holds. Also, TARDIS treats the re-emission of the line interaction
 as an isotropic process. Thus,
 
 .. math::
 
     \mu_f = 2 z - 1.
 
-
 .. note::
 
     In the Sobolev theory, the re-emission direction is given by the so-called
-    Sobolev escape fraction, with is in general non-isotropic. However, in the
+    Sobolev escape fraction, which is generally non-isotropic. However, in the
     special case of homologous expansion, isotropy is retained.
 
 .. note::
 
-    Strictly speaking, the re-mission process occurs in the local co-moving
-    frame. Thus, the so called angle aberration effect should be taken into
-    account when transforming into the lab frame. However, TARDIS, currently
+    Strictly speaking, the re-emission process occurs in the local co-moving
+    frame. Thus, the so-called angle aberration effect should be taken into
+    account when transforming into the lab frame. However, TARDIS currently
     neglects this effect.
 
 Essentially, the different line interaction treatments only determine how the
 frequency of the packet after the line interaction is determined.
 
+**Beta Sobolev Value**
+=======================
+The **beta Sobolev value** refers to the *escape chance* for packets when they
+interact with specific lines. This is a key factor in determining the direction
+and frequency of re-emission after a line interaction. In general, the escape
+fraction is non-isotropic, meaning the direction of re-emission is not uniform
+across all angles. However, in the special case of homologous expansion, the
+re-emission remains isotropic. The theory behind the **beta Sobolev value** and
+its implications for line interactions is discussed in detail in **Lucy (2000)**.
+
 Resonant Scattering
 ===================
-
 The simplest line interaction mode assumes that all interactions with atomic
 line transitions occur resonantly. This implies that in the co-moving frame the
 emergent packet frequency is equal to the incident one. Again accounting for
@@ -55,7 +63,6 @@ frame, the post-interaction frequency is given by
 
 Downbranching
 =============
-
 The so-called downbranching scheme, introduced by :cite:`Lucy1999a`, is an
 elegant approach to approximately account for fluorescence effects. In this
 scheme, the packet is not re-emitted in the same transitions as it was absorbed
@@ -68,7 +75,6 @@ about the downbranching scheme, we refer to :cite:`Lucy1999a` and
 
 Macro Atom Scheme
 =================
-
 Finally, as the most sophisticated line interaction treatment, a simplified
 version of the Macro Atom scheme of :cite:`Lucy2002` and :cite:`Lucy2003` is
 implemented in TARDIS. This approach provides a more accurate representation of
@@ -88,7 +94,6 @@ an in-depth derivation of the scheme, we refer to :cite:`Lucy2002` and
 
 Comparison
 ==========
-
 The different levels of sophistication are illustrated in the following plot,
 taken from :cite:`Kerzendorf2014` and showing the incident wavelength versus the
 emergent wavelength of Monte Carlo packets in line interactions. The left panel
@@ -98,3 +103,7 @@ downbranching scheme and the right one the macro atom results.
 .. image::
     ../images/scatter_downbranch_ma.png
     :width: 700
+
+References
+==========
+.. [Lucy2000] Lucy, L. B. (2000). "Radiative Transfer in Astrophysics: The Sobolev Approximation and Its Applications." Astrophysical Journal, 550(2), 909-921.


### PR DESCRIPTION
Beta Sobolev Value is introduced to explain its role in determining the escape chance for packets during line interactions. The Lucy (2000) paper is referenced as the primary source for the theory behind the beta Sobolev value and its applications. The Sobolev escape fraction is described in more detail, including its general non-isotropic nature and the exception in homologous expansion.

### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Write a complete description of your changes, including the necessary context or any piece of information required to understand your work.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
