### PR TITLE
Fixes the codespell job failures

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -35,4 +35,4 @@ jobs:
       
       - name: Run codespell
         run: |
-          codespell docs/
+          codespell --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou' docs/


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Fixes the issue(#2903)


### :pushpin: Resources

[Stack Overflow](https://stackoverflow.com/questions/78867158/how-to-make-codespell-not-report-false-positives-in-base64-strings)

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
