### PR TITLE
Fixes the codespell job failure

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -35,4 +35,4 @@ jobs:
       
       - name: Run codespell
         run: |
-          codespell --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou' docs/
+          codespell docs/ --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -35,4 +35,4 @@ jobs:
       
       - name: Run codespell
         run: |
-          codespell docs/ --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou'
+          codespell --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou' docs/

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          clean: true
           ref: ${{ github.event.pull_request.head.sha }}
         if: github.event_name == 'pull_request_target'
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -33,13 +33,6 @@ jobs:
         with:
           os-label: linux-64
 
-      # - name: Clear cache
-        # run: |
-          # echo "Clearing cache..."
-          # rm -rf ~/.cache
-      
       - name: Run codespell
         run: |
-          echo "Clearing cache..."
-          rm -rf ~/.cache
           codespell docs/ --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -32,6 +32,11 @@ jobs:
         uses: ./.github/actions/setup_env
         with:
           os-label: linux-64
+
+      - name: Clear cache
+        run: |
+          echo "Clearing cache..."
+          rm -rf ~/.cache
       
       - name: Run codespell
         run: |

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -35,4 +35,4 @@ jobs:
       
       - name: Run codespell
         run: |
-          codespell docs/
+          codespell docs/ --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -33,11 +33,13 @@ jobs:
         with:
           os-label: linux-64
 
-      - name: Clear cache
-        run: |
-          echo "Clearing cache..."
-          rm -rf ~/.cache
+      # - name: Clear cache
+        # run: |
+          # echo "Clearing cache..."
+          # rm -rf ~/.cache
       
       - name: Run codespell
         run: |
+          echo "Clearing cache..."
+          rm -rf ~/.cache
           codespell docs/ --ignore-regex='[A-Za-z0-9+/]{100,}' --ignore-words-list 'Parrent,Layou'

--- a/.mailmap
+++ b/.mailmap
@@ -215,6 +215,8 @@ Stuart Sim <s.sim@qub.ac.uk> ssim <ssim@users.noreply.github.com>
 Stuart Sim <s.sim@qub.ac.uk> Stuart Sim <ssim@mso.anu.edu.au>
 Stuart Sim <s.sim@qub.ac.uk> Stuart Sim <stuartsim@bashir.pst.qub.ac.uk>
 
+Swayam Shah <swayamshah66@gmail.com> Sonu0305 <swayamshah66@gmail.com>
+
 TARDIS Bot <tardis.sn.bot@gmail.com>
 TARDIS Bot <tardis.sn.bot@gmail.com> tardis-bot <tardis.sn.bot@gmail.com>
 TARDIS Bot <tardis.sn.bot@gmail.com> TARDIS Bot <wkerzendorf+tardis@gmail.com>


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Fixes the issue(#2903) by finding a generalised solution to skip the base64 encoded long image urls which cause codespell to detect false positives and cause test failure.


### :pushpin: Resources

[Stack Overflow](https://stackoverflow.com/questions/78867158/how-to-make-codespell-not-report-false-positives-in-base64-strings)

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
