### PR TITLE
Refactor: Rename 'expected' to 'expected_fh' for clarity as file handler

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -290,3 +290,5 @@ Israel Roldan <israel.alberto.rv@gmail.com> airv_zxf <israel.alberto.rv@gmail.co
 Michael Zingale <michael.zingale@stonybrook.edu>
 
 Akash Kaushik <akash265457k@gmail.com>
+
+Rudraksh Nalbalwar <nalbalwarrudraksh@gmail.com>

--- a/tardis/io/tests/test_HDFWriter.py
+++ b/tardis/io/tests/test_HDFWriter.py
@@ -33,8 +33,8 @@ def test_simple_write(tmpdir, attr):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(attr)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected = pd.read_hdf(fname, key="/test/mock_hdf/scalars")["property"]
-    assert actual.property == expected
+    expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/scalars")["property"]
+    assert actual.property == expected_fh
 
 
 mock_df = pd.DataFrame(
@@ -55,7 +55,7 @@ def test_complex_obj_write(tmpdir, attr):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(attr)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected = pd.read_hdf(fname, key="/test/mock_hdf/property").values
+    expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/property").values
 
     assert_array_almost_equal(actual.property, expected)
 
@@ -73,10 +73,10 @@ def test_multi_index_write(tmpdir):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(mock_multiIndex)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected = pd.read_hdf(fname, key="/test/mock_hdf/property")
-    expected = pd.MultiIndex.from_tuples(expected.unstack().values)
+    expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/property")
+    expected_fh = pd.MultiIndex.from_tuples(expected.unstack().values)
     # These are multiindex objects, so we need to compare the values
-    assert np.all(expected.values == actual.property.values)
+    assert np.all(expected_fh.values == actual.property.values)
 
 
 # Test Quantity Objects
@@ -90,8 +90,8 @@ def test_quantity_objects_write(tmpdir, attr):
     attr_quantity = u.Quantity(attr, "g/cm**3")
     actual = MockHDF(attr_quantity)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected = pd.read_hdf(fname, key="/test/mock_hdf/property")
-    assert_array_almost_equal(actual.property.cgs.value, expected)
+    expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/property")
+    assert_array_almost_equal(actual.property.cgs.value, expected_fh)
 
 
 scalar_quantity_objects = [1.5, 4.2e7]
@@ -103,18 +103,18 @@ def test_scalar_quantity_objects_write(tmpdir, attr):
     attr_quantity = u.Quantity(attr, "g/cm**3")
     actual = MockHDF(attr_quantity)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected = pd.read_hdf(fname, key="/test/mock_hdf/scalars/")["property"]
-    assert_array_almost_equal(actual.property.cgs.value, expected)
+    expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/scalars/")["property"]
+    assert_array_almost_equal(actual.property.cgs.value, expected_fh)
 
 
 def test_none_write(tmpdir):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(None)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected = pd.read_hdf(fname, key="/test/mock_hdf/scalars/")["property"]
-    if expected == "none":
-        expected = None
-    assert actual.property == expected
+    expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/scalars/")["property"]
+    if expected_fh == "none":
+        expected_fh = None
+    assert actual.property == expected_fh
 
 
 # Test class_properties parameter (like homologous_density is a class
@@ -136,8 +136,8 @@ def test_objects_write(tmpdir, attr):
     attr_quantity = u.Quantity(attr, "g/cm**3")
     actual = MockClass(attr_quantity, nested_object)
     actual.to_hdf(fname, path="test", overwrite=True)
-    expected_property = pd.read_hdf(fname, key="/test/mock_class/property")
-    assert_array_almost_equal(actual.property.cgs.value, expected_property)
+    expected_fh_property = pd.read_hdf(fname, key="/test/mock_class/property")
+    assert_array_almost_equal(actual.property.cgs.value, expected_fh_property)
     nested_property = pd.read_hdf(
         fname, key="/test/mock_class/nested_object/property"
     )

--- a/tardis/io/tests/test_HDFWriter.py
+++ b/tardis/io/tests/test_HDFWriter.py
@@ -57,7 +57,7 @@ def test_complex_obj_write(tmpdir, attr):
     actual.to_hdf(fname, path="test", overwrite=True)
     expected_fh = pd.read_hdf(fname, key="/test/mock_hdf/property").values
 
-    assert_array_almost_equal(actual.property, expected)
+    assert_array_almost_equal(actual.property, expected_fh)
 
 
 arr = np.array(

--- a/tardis/model/tests/test_base.py
+++ b/tardis/model/tests/test_base.py
@@ -472,11 +472,11 @@ def test_hdf_simulation_state_scalars(
     hdf_file_path, simulation_verysimple, attr
 ):
     path = "simulation_state/scalars"
-    expected = pd.read_hdf(hdf_file_path, path)[attr]
+    expected_fh = pd.read_hdf(hdf_file_path, path)[attr]
     actual = getattr(simulation_verysimple.simulation_state, attr)
     if hasattr(actual, "cgs"):
         actual = actual.cgs.value
-    assert_almost_equal(actual, expected)
+    assert_almost_equal(actual, expected_fh)
 
 
 simulation_state_nparray_attrs = ["dilution_factor", "v_inner", "v_outer"]
@@ -487,8 +487,8 @@ def test_hdf_simulation_state_nparray(
     hdf_file_path, simulation_verysimple, attr
 ):
     path = f"simulation_state/{attr}"
-    expected = pd.read_hdf(hdf_file_path, path)
+    expected_fh = pd.read_hdf(hdf_file_path, path)
     actual = getattr(simulation_verysimple.simulation_state, attr)
     if hasattr(actual, "cgs"):
         actual = actual.cgs.value
-    assert_almost_equal(actual, expected.values)
+    assert_almost_equal(actual, expected_fh.values)

--- a/tardis/model/tests/test_density.py
+++ b/tardis/model/tests/test_density.py
@@ -17,8 +17,8 @@ def test_hdf_density_0(hdf_file_path, simulation_verysimple):
     if hasattr(actual, "cgs"):
         actual = actual.cgs.value
     path = "simulation_state/density"
-    expected = pd.read_hdf(hdf_file_path, path)
-    assert_almost_equal(actual, expected.values)
+    expected_fh = pd.read_hdf(hdf_file_path, path)
+    assert_almost_equal(actual, expected_fh.values)
 
 
 def test_hdf_time_0(hdf_file_path, simulation_verysimple):
@@ -26,5 +26,5 @@ def test_hdf_time_0(hdf_file_path, simulation_verysimple):
     if hasattr(actual, "cgs"):
         actual = actual.cgs.value
     path = "simulation_state/scalars"
-    expected = pd.read_hdf(hdf_file_path, path)["time_explosion"]
-    assert_almost_equal(actual, expected)
+    expected_fh = pd.read_hdf(hdf_file_path, path)["time_explosion"]
+    assert_almost_equal(actual, expected_fh)

--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -179,28 +179,28 @@ class TestPlasma:
     def test_plasma_properties(self, plasma, attr):
         key = f"plasma/{attr}"
         try:
-            expected = pd.read_hdf(self.regression_data.fpath, key)
+            expected_fh = pd.read_hdf(self.regression_data.fpath, key)
         except KeyError:
             pytest.skip(f"Key {key} not found in regression data")
 
         if hasattr(plasma, attr):
             actual = getattr(plasma, attr)
             if attr == "selected_atoms":
-                npt.assert_allclose(actual.values, expected.values)
+                npt.assert_allclose(actual.values, expected_fh.values)
             elif actual.ndim == 1:
                 actual = pd.Series(actual)
-                pdt.assert_series_equal(actual, expected)
+                pdt.assert_series_equal(actual, expected_fh)
             else:
                 actual = pd.DataFrame(actual)
-                pdt.assert_frame_equal(actual, expected)
+                pdt.assert_frame_equal(actual, expected_fh)
         else:
             warnings.warn(f'Property "{attr}" not found')
 
     def test_levels(self, plasma):
         actual = pd.DataFrame(plasma.levels)
         key = "plasma/levels"
-        expected = pd.read_hdf(self.regression_data.fpath, key)
-        pdt.assert_frame_equal(actual, expected)
+        expected_fh = pd.read_hdf(self.regression_data.fpath, key)
+        pdt.assert_frame_equal(actual, expected_fh)
 
     @pytest.mark.parametrize("attr", scalars_properties)
     def test_scalars_properties(self, plasma, attr):
@@ -208,20 +208,20 @@ class TestPlasma:
         if hasattr(actual, "cgs"):
             actual = actual.cgs.value
         key = "plasma/scalars"
-        expected = pd.read_hdf(self.regression_data.fpath, key)[attr]
-        npt.assert_equal(actual, expected)
+        expected_fh = pd.read_hdf(self.regression_data.fpath, key)[attr]
+        npt.assert_equal(actual, expected_fh)
 
     def test_helium_treatment(self, plasma):
         actual = plasma.helium_treatment
         key = "plasma/scalars"
-        expected = pd.read_hdf(self.regression_data.fpath, key)[
+        expected_fh = pd.read_hdf(self.regression_data.fpath, key)[
             "helium_treatment"
         ]
-        assert actual == expected
+        assert actual == expected_fh
 
     def test_zeta_data(self, plasma):
         if hasattr(plasma, "zeta_data"):
             actual = plasma.zeta_data
             key = "plasma/zeta_data"
-            expected = pd.read_hdf(self.regression_data.fpath, key)
-            npt.assert_allclose(actual, expected.values)
+            expected_fh = pd.read_hdf(self.regression_data.fpath, key)
+            npt.assert_allclose(actual, expected_fh.values)

--- a/tardis/spectrum/tests/test_spectrum.py
+++ b/tardis/spectrum/tests/test_spectrum.py
@@ -165,8 +165,8 @@ def test_hdf_spectrum(hdf_file_path, spectrum, attr):
         assert_almost_equal(actual, expected)
     else:
         path = os.path.join("spectrum", attr)
-        expected = pd.read_hdf(hdf_file_path, path)
-        assert_almost_equal(actual, expected.values)
+        expected_fh = pd.read_hdf(hdf_file_path, path)
+        assert_almost_equal(actual, expected_fh.values)
 
 
 ###

--- a/tardis/transport/montecarlo/tests/test_base.py
+++ b/tardis/transport/montecarlo/tests/test_base.py
@@ -29,8 +29,8 @@ def test_hdf_transport(
     if hasattr(actual, "cgs"):
         actual = actual.cgs.value
     path = f"transport/{attr}"
-    expected = pd.read_hdf(hdf_file_path, path)
-    assert_almost_equal(actual, expected.values)
+    expected_fh = pd.read_hdf(hdf_file_path, path)
+    assert_almost_equal(actual, expected_fh.values)
 
 
 transport_state_properties = [
@@ -70,5 +70,5 @@ def test_hdf_transport_state(
     if hasattr(actual, "cgs"):
         actual = actual.cgs.value
     path = f"transport_state/{attr}"
-    expected = pd.read_hdf(hdf_file_path, path)
-    assert_almost_equal(actual, expected.values)
+    expected_fh = pd.read_hdf(hdf_file_path, path)
+    assert_almost_equal(actual, expected_fh.values)

--- a/tardis/visualization/tools/tests/test_liv_plot.py
+++ b/tardis/visualization/tools/tests/test_liv_plot.py
@@ -307,9 +307,9 @@ class TestLIVPlotter:
         """
         fig, _ = plotter_generate_plot_mpl
         regression_data = RegressionData(request)
-        expected = regression_data.sync_hdf_store(generate_plot_mpl_hdf)
+        expected_fh = regression_data.sync_hdf_store(generate_plot_mpl_hdf)
         for item in ["_species_name", "_color_list", "step_x", "step_y"]:
-            expected_values = expected.get(
+            expected_values = expected_fh.get(
                 "plot_data_hdf/" + item
             ).values.flatten()
             actual_values = getattr(generate_plot_mpl_hdf, item)
@@ -324,7 +324,7 @@ class TestLIVPlotter:
             else:
                 assert np.array_equal(expected_values, actual_values)
 
-        labels = expected["plot_data_hdf/scalars"]
+        labels = expected_fh["plot_data_hdf/scalars"]
         for index1, data in enumerate(fig.get_children()):
             if isinstance(data.get_label(), str):
                 assert (
@@ -334,13 +334,13 @@ class TestLIVPlotter:
             if isinstance(data, Line2D):
                 np.testing.assert_allclose(
                     data.get_xydata(),
-                    expected.get("plot_data_hdf/" + "data" + str(index1)),
+                    expected_fh.get("plot_data_hdf/" + "data" + str(index1)),
                     rtol=0.3,
                     atol=3,
                 )
                 np.testing.assert_allclose(
                     data.get_path().vertices,
-                    expected.get("plot_data_hdf/" + "linepath" + str(index1)),
+                    expected_fh.get("plot_data_hdf/" + "linepath" + str(index1)),
                     rtol=1,
                     atol=3,
                 )
@@ -348,7 +348,7 @@ class TestLIVPlotter:
                 for index2, path in enumerate(data.get_paths()):
                     np.testing.assert_almost_equal(
                         path.vertices,
-                        expected.get(
+                        expected_fh.get(
                             "plot_data_hdf/"
                             + "polypath"
                             + "ind_"
@@ -357,7 +357,7 @@ class TestLIVPlotter:
                             + str(index2)
                         ),
                     )
-        expected.close()
+        expected_fh.close()
 
     def test_mpl_image(self, plotter_generate_plot_mpl, tmp_path, request):
         """
@@ -474,10 +474,10 @@ class TestLIVPlotter:
         """
         fig, _ = plotter_generate_plot_ply
         regression_data = RegressionData(request)
-        expected = regression_data.sync_hdf_store(generate_plot_plotly_hdf)
+        expected_fh = regression_data.sync_hdf_store(generate_plot_plotly_hdf)
 
         for item in ["_species_name", "_color_list", "step_x", "step_y"]:
-            expected_values = expected.get(
+            expected_values = expected_fh.get(
                 "plot_data_hdf/" + item
             ).values.flatten()
             actual_values = getattr(generate_plot_plotly_hdf, item)
@@ -497,7 +497,7 @@ class TestLIVPlotter:
                 assert (
                     data.stackgroup
                     == getattr(
-                        expected["/plot_data_hdf/scalars"],
+                        expected_fh["/plot_data_hdf/scalars"],
                         "_" + str(index) + "stackgroup",
                     ).decode()
                 )
@@ -505,20 +505,20 @@ class TestLIVPlotter:
                 assert (
                     data.name
                     == getattr(
-                        expected["/plot_data_hdf/scalars"],
+                        expected_fh["/plot_data_hdf/scalars"],
                         "_" + str(index) + "name",
                     ).decode()
                 )
             np.testing.assert_allclose(
                 data.x,
-                expected.get(group + "x").values.flatten(),
+                expected_fh.get(group + "x").values.flatten(),
                 rtol=0.3,
                 atol=3,
             )
             np.testing.assert_allclose(
                 data.y,
-                expected.get(group + "y").values.flatten(),
+                expected_fh.get(group + "y").values.flatten(),
                 rtol=0.3,
                 atol=3,
             )
-        expected.close()
+        expected_fh.close()

--- a/tardis/visualization/tools/tests/test_sdec_plot.py
+++ b/tardis/visualization/tools/tests/test_sdec_plot.py
@@ -215,7 +215,7 @@ class TestSDECPlotter:
         request,
     ):
         regression_data = RegressionData(request)
-        expected = regression_data.sync_hdf_store(calculate_plotting_data_hdf)
+        expected_fh = regression_data.sync_hdf_store(calculate_plotting_data_hdf)
         group = "plot_data_hdf/"
         for attribute_type, attribute_name in self.plotting_data_attributes:
             plot_object = getattr(
@@ -225,13 +225,13 @@ class TestSDECPlotter:
                 if isinstance(plot_object, astropy.units.quantity.Quantity):
                     plot_object = plot_object.cgs.value
                 np.testing.assert_allclose(
-                    plot_object, expected.get(group + attribute_name)
+                    plot_object, expected_fh.get(group + attribute_name)
                 )
             if attribute_type == "attributes_pd":
                 pd.testing.assert_frame_equal(
-                    plot_object, expected.get(group + attribute_name)
+                    plot_object, expected_fh.get(group + attribute_name)
                 )
-        expected.close()
+        expected_fh.close()
 
     @pytest.fixture(scope="class", params=combinations)
     def plotter_generate_plot_mpl(self, request, observed_spectrum, plotter):
@@ -295,13 +295,13 @@ class TestSDECPlotter:
     ):
         fig, _ = plotter_generate_plot_mpl
         regression_data = RegressionData(request)
-        expected = regression_data.sync_hdf_store(generate_plot_mpl_hdf)
+        expected_fh = regression_data.sync_hdf_store(generate_plot_mpl_hdf)
         for item in ["_species_name", "_color_list"]:
             np.testing.assert_array_equal(
-                expected.get("plot_data_hdf/" + item).values.flatten(),
+                expected_fh.get("plot_data_hdf/" + item).values.flatten(),
                 getattr(generate_plot_mpl_hdf, item),
             )
-        labels = expected["plot_data_hdf/scalars"]
+        labels = expected_fh["plot_data_hdf/scalars"]
         for index1, data in enumerate(fig.get_children()):
             if isinstance(data.get_label(), str):
                 assert (
@@ -312,18 +312,18 @@ class TestSDECPlotter:
             if isinstance(data, Line2D):
                 np.testing.assert_allclose(
                     data.get_xydata(),
-                    expected.get("plot_data_hdf/" + "data" + str(index1)),
+                    expected_fh.get("plot_data_hdf/" + "data" + str(index1)),
                 )
                 np.testing.assert_allclose(
                     data.get_path().vertices,
-                    expected.get("plot_data_hdf/" + "linepath" + str(index1)),
+                    expected_fh.get("plot_data_hdf/" + "linepath" + str(index1)),
                 )
             # save artists which correspond to element contributions
             if isinstance(data, PolyCollection):
                 for index2, path in enumerate(data.get_paths()):
                     np.testing.assert_almost_equal(
                         path.vertices,
-                        expected.get(
+                        expected_fh.get(
                             "plot_data_hdf/"
                             + "polypath"
                             + "ind_"
@@ -332,7 +332,7 @@ class TestSDECPlotter:
                             + str(index2)
                         ),
                     )
-        expected.close()
+        expected_fh.close()
 
     @pytest.fixture(scope="class", params=combinations)
     def plotter_generate_plot_ply(self, request, observed_spectrum, plotter):
@@ -385,11 +385,11 @@ class TestSDECPlotter:
     ):
         fig, _ = plotter_generate_plot_ply
         regression_data = RegressionData(request)
-        expected = regression_data.sync_hdf_store(generate_plot_plotly_hdf)
+        expected_fh = regression_data.sync_hdf_store(generate_plot_plotly_hdf)
 
         for item in ["_species_name", "_color_list"]:
             np.testing.assert_array_equal(
-                expected.get("plot_data_hdf/" + item).values.flatten(),
+                expected_fh.get("plot_data_hdf/" + item).values.flatten(),
                 getattr(generate_plot_plotly_hdf, item),
             )
 
@@ -399,7 +399,7 @@ class TestSDECPlotter:
                 assert (
                     data.stackgroup
                     == getattr(
-                        expected["/plot_data_hdf/scalars"],
+                        expected_fh["/plot_data_hdf/scalars"],
                         "_" + str(index) + "stackgroup",
                     ).decode()
                 )
@@ -407,18 +407,18 @@ class TestSDECPlotter:
                 assert (
                     data.name
                     == getattr(
-                        expected["/plot_data_hdf/scalars"],
+                        expected_fh["/plot_data_hdf/scalars"],
                         "_" + str(index) + "name",
                     ).decode()
                 )
             np.testing.assert_allclose(
-                data.x, expected.get(group + "x").values.flatten()
+                data.x, expected_fh.get(group + "x").values.flatten()
             )
             np.testing.assert_allclose(
-                data.y, expected.get(group + "y").values.flatten()
+                data.y, expected_fh.get(group + "y").values.flatten()
             )
 
-        expected.close()
+        expected_fh.close()
 
     def test_mpl_image(self, plotter_generate_plot_mpl, tmp_path, request):
         regression_data = RegressionData(request)


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation` 

In this pull request, I have refactored the code to improve clarity by renaming the variable expected to expected_fh wherever it was used as a file handler. This helps make the code more readable and better reflects the role of the variable.
This PR closes issue #2864 
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
