### PR TITLE
updated converged status to self.converged throughout workflow

### DIFF
--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -445,7 +445,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
 
     def run(self):
         """Run the TARDIS simulation until convergence is reached"""
-        converged = False
+        self.converged = False
         while self.completed_iterations < self.total_iterations - 1:
             logger.info(
                 f"\n\tStarting iteration {(self.completed_iterations + 1):d} of {self.total_iterations:d}"
@@ -466,13 +466,13 @@ class SimpleTARDISWorkflow(WorkflowLogging):
 
             self.solve_plasma(estimated_radfield_properties)
 
-            converged = self.check_convergence(estimated_values)
+            self.converged = self.check_convergence(estimated_values)
             self.completed_iterations += 1
 
-            if converged and self.convergence_strategy.stop_if_converged:
+            if self.converged and self.convergence_strategy.stop_if_converged:
                 break
 
-        if converged:
+        if self.converged:
             logger.info("\n\tStarting final iteration")
         else:
             logger.error(

--- a/tardis/workflows/standard_tardis_workflow.py
+++ b/tardis/workflows/standard_tardis_workflow.py
@@ -206,7 +206,7 @@ class StandardTARDISWorkflow(
 
     def run(self):
         """Run the TARDIS simulation until convergence is reached"""
-        converged = False
+        self.converged = False
         while self.completed_iterations < self.total_iterations - 1:
             logger.info(
                 f"\n\tStarting iteration {(self.completed_iterations + 1):d} of {self.total_iterations:d}"
@@ -237,13 +237,13 @@ class StandardTARDISWorkflow(
 
             self.solve_plasma(estimated_radfield_properties)
 
-            converged = self.check_convergence(estimated_values)
+            self.converged = self.check_convergence(estimated_values)
             self.completed_iterations += 1
 
-            if converged and self.convergence_strategy.stop_if_converged:
+            if self.converged and self.convergence_strategy.stop_if_converged:
                 break
 
-        if converged:
+        if self.converged:
             logger.info("\n\tStarting final iteration")
         else:
             logger.error(

--- a/tardis/workflows/v_inner_solver.py
+++ b/tardis/workflows/v_inner_solver.py
@@ -309,7 +309,7 @@ class InnerVelocitySolverWorkflow(SimpleTARDISWorkflow):
 
     def run(self):
         """Run the TARDIS simulation until convergence is reached"""
-        converged = False
+        self.converged = False
         while self.completed_iterations < self.total_iterations - 1:
             logger.info(
                 f"\n\tStarting iteration {(self.completed_iterations + 1):d} of {self.total_iterations:d}"
@@ -334,14 +334,14 @@ class InnerVelocitySolverWorkflow(SimpleTARDISWorkflow):
                 estimated_values["mask"],
             )
 
-            converged = self.check_convergence(estimated_values)
+            self.converged = self.check_convergence(estimated_values)
 
             self.completed_iterations += 1
 
-            if converged and self.convergence_strategy.stop_if_converged:
+            if self.converged and self.convergence_strategy.stop_if_converged:
                 break
 
-        if converged:
+        if self.converged:
             logger.info("\n\tStarting final iteration")
         else:
             logger.error(


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Throughout the workflow notebooks, the converged variable was a temporary variable, so it could not update properly. I went through simple_tardis_workflow.py, standard_tardis_workflow.py, and v_inner_solver.py and changed every 'converged' variable to 'self.converged'.

@DeerWhale 
