### PR TITLE
Fail LFS pull if label not present

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,6 +34,7 @@ jobs:
     with:
       atom-data-sparse: false
       regression-data-repo: tardis-sn/tardis-regression-data
+      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   build:
     if: github.repository_owner == 'tardis-sn' &&

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -41,6 +41,7 @@ jobs:
     with:
       atom-data-sparse: true
       regression-data-repo: tardis-sn/tardis-regression-data
+      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   check-for-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -52,7 +52,6 @@ jobs:
           fi
         working-directory: tardis-regression-data
 
-      
       - name: Test cache availability
         uses: actions/cache/restore@v4
         id: test-lfs-cache-regression-data
@@ -60,6 +59,13 @@ jobs:
           path: tardis-regression-data/.git/lfs
           key: tardis-regression-${{ inputs.atom-data-sparse == true && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
           lookup-only: true
+    
+      - name: label test
+        if: |
+          inputs.allow_lfs_pull != true
+        run: |
+          echo "Error: LFS pull is required but not allowed (allow_lfs_pull is false)"
+          exit 1
       
       - name: Fail if LFS pull is needed but not allowed
         if: |

--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: "tardis-sn/tardis-regression-data"
         type: string
+      allow_lfs_pull:
+        description: "If true, allows LFS pull operations"
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -56,14 +61,28 @@ jobs:
           key: tardis-regression-${{ inputs.atom-data-sparse == 'true' && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
           lookup-only: true
       
+      - name: Fail if LFS pull is needed but not allowed
+        if: |
+          steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && 
+          inputs.allow_lfs_pull != true
+        run: |
+          echo "Error: LFS pull is required but not allowed (allow_lfs_pull is false)"
+          exit 1
+      
       - name: Git LFS Pull Atom Data
+        if: |
+          inputs.atom-data-sparse == true && 
+          steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && 
+          inputs.allow_lfs_pull == true
         run: git lfs pull --include=atom_data/kurucz_cd23_chianti_H_He.h5
-        if: ${{ inputs.atom-data-sparse == true && steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' }}
         working-directory: tardis-regression-data
       
       - name: Git LFS Pull Full Data
+        if: |
+          inputs.atom-data-sparse == false && 
+          steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && 
+          inputs.allow_lfs_pull == true
         run: git lfs pull
-        if: ${{ inputs.atom-data-sparse == false && steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' }}
         working-directory: tardis-regression-data
       
       - name: Git LFS Checkout

--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -59,14 +59,7 @@ jobs:
           path: tardis-regression-data/.git/lfs
           key: tardis-regression-${{ inputs.atom-data-sparse == true && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
           lookup-only: true
-    
-      - name: label test
-        if: |
-          inputs.allow_lfs_pull != true
-        run: |
-          echo "Error: LFS pull is required but not allowed (allow_lfs_pull is false)"
-          exit 1
-      
+  
       - name: Fail if LFS pull is needed but not allowed
         if: |
           steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && 

--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: ${{ inputs.regression-data-repo }}
           path: tardis-regression-data
-          sparse-checkout: ${{ inputs.atom-data-sparse == 'true' && 'atom_data/kurucz_cd23_chianti_H_He.h5' || '' }}
+          sparse-checkout: ${{ inputs.atom-data-sparse == true && 'atom_data/kurucz_cd23_chianti_H_He.h5' || '' }}
     
       - name: Create LFS file list
         run: |
@@ -58,7 +58,7 @@ jobs:
         id: test-lfs-cache-regression-data
         with:
           path: tardis-regression-data/.git/lfs
-          key: tardis-regression-${{ inputs.atom-data-sparse == 'true' && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
+          key: tardis-regression-${{ inputs.atom-data-sparse == true && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
           lookup-only: true
       
       - name: Fail if LFS pull is needed but not allowed
@@ -86,12 +86,12 @@ jobs:
         working-directory: tardis-regression-data
       
       - name: Git LFS Checkout
-        if: ${{ inputs.atom-data-sparse == 'true' }}
+        if: ${{ inputs.atom-data-sparse == true }}
         run: git lfs checkout atom_data/kurucz_cd23_chianti_H_He.h5
         working-directory: tardis-regression-data
 
       - name: Git LFS Checkout Full
-        if: ${{ inputs.atom-data-sparse == 'false' }}
+        if: ${{ inputs.atom-data-sparse == false }}
         run: git lfs checkout
         working-directory: tardis-regression-data
   

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
     with:
       atom-data-sparse: false
       regression-data-repo: tardis-sn/tardis-regression-data
+      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   tests:
     name: ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ inputs.pip_git && 'pip tests enabled' || '' }}


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Adds a check that fails LFS pulls if label not present in pull requests.
Proof that label check works
https://github.com/tardis-sn/tardis/actions/runs/13371304706/job/37340450315

LFS pulls are allowed in master.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
