### PR TITLE
Fix init bug for: line_interaction_type=scatter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -291,3 +291,5 @@ Israel Roldan <israel.alberto.rv@gmail.com> airv_zxf <israel.alberto.rv@gmail.co
 Michael Zingale <michael.zingale@stonybrook.edu>
 
 Akash Kaushik <akash265457k@gmail.com>
+
+Roee Yaron <roee.yaron.40@gmail.com>

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -444,6 +444,10 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         logger.info(
             f"\n\tStarting iteration {(self.iterations_executed + 1):d} of {self.iterations:d}"
         )
+    
+        if self.macro_atom is None:
+            self.plasma.beta_sobolev = None
+            macro_atom_state = None
 
         opacity_state = self.opacity.legacy_solve(self.plasma)
         if self.macro_atom is not None:


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

This commit fixes an initialization bug affecting runs with "line_interaction_type"=scatter. The issue was caused by two variables (macro_atom_state and plasma.beta_sobolev) that were not properly initialized. They are now set to None.
These variables are not needed for scatter physics, they were only intended to prevent the run from collapsing. 

### :pushpin: Resources
This is what happend in every run with: "line_interaction_type"=scatter
<img width="881" alt="image" src="https://github.com/user-attachments/assets/e97278c6-b72c-4fac-bd1b-5f475c4733c6" />

### :vertical_traffic_light: Testing

How did you test these changes?

	•	All tests have been run and passed.
	•	I manually verified that my scatter, downbranch, and macroatom simulations now work as expected.

### :ballot_box_with_check: Checklist

Although I did not have reviewers for this pull request and it is my first contribution, this is a straightforward simple bug fix.

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

**Note:** Im not allowed to perform any action, please help :)
@wkerzendorf @ftsamis @ssim 