### PR TITLE
Remove plasma object going into the macroatom

### DIFF
--- a/tardis/opacities/macro_atom/macroatom_solver.py
+++ b/tardis/opacities/macro_atom/macroatom_solver.py
@@ -147,13 +147,14 @@ class MacroAtomSolver:
             State of the macro atom ready to be placed into the OpacityState
         """
         if legacy_mode:
-            transition_probabilities = (
-                self.solve_legacy_transition_probabilities(
-                    atomic_data,
-                    j_blues,
-                    tau_sobolev,
-                    stimulated_emission_factor,
-                )
+            transition_probabilities = self.solve_legacy_transition_probabilities(
+                atomic_data,
+                j_blues,  # This currently should fail, missing beta_sobolevs
+                tau_sobolev,
+                stimulated_emission_factor,
+            )
+            raise NotImplementedError(
+                "This method is not yet implemented for legacy_mode"
             )
         else:
             transition_probabilities = self.solve_transition_probabilities(

--- a/tardis/opacities/macro_atom/macroatom_solver.py
+++ b/tardis/opacities/macro_atom/macroatom_solver.py
@@ -122,7 +122,7 @@ class MacroAtomSolver:
 
     def solve(
         self,
-        legacy_plasma,
+        j_blues,
         atomic_data,
         tau_sobolev,
         stimulated_emission_factor,
@@ -150,7 +150,7 @@ class MacroAtomSolver:
             transition_probabilities = (
                 self.solve_legacy_transition_probabilities(
                     atomic_data,
-                    legacy_plasma,
+                    j_blues,
                     tau_sobolev,
                     stimulated_emission_factor,
                 )
@@ -158,7 +158,7 @@ class MacroAtomSolver:
         else:
             transition_probabilities = self.solve_transition_probabilities(
                 atomic_data,
-                legacy_plasma.j_blues,
+                j_blues,
                 tau_sobolev,
                 beta_sobolev,
                 stimulated_emission_factor,

--- a/tardis/opacities/macro_atom/macroatom_solver.py
+++ b/tardis/opacities/macro_atom/macroatom_solver.py
@@ -167,7 +167,7 @@ class MacroAtomSolver:
         macro_block_references = atomic_data.macro_atom_references[
             "block_references"
         ]
-        macro_atom_info = legacy_plasma.atomic_data.macro_atom_data
+        macro_atom_info = atomic_data.macro_atom_data
 
         return MacroAtomState(
             transition_probabilities,
@@ -175,5 +175,5 @@ class MacroAtomSolver:
             macro_atom_info["destination_level_idx"],
             macro_atom_info["lines_idx"],
             macro_block_references,
-            legacy_plasma.atomic_data.lines_upper2macro_reference_idx,
+            atomic_data.lines_upper2macro_reference_idx,
         )

--- a/tardis/opacities/macro_atom/macroatom_state.py
+++ b/tardis/opacities/macro_atom/macroatom_state.py
@@ -1,5 +1,5 @@
-from tardis.transport.montecarlo.configuration import montecarlo_globals
 from tardis.io.util import HDFWriterMixin
+from tardis.transport.montecarlo.configuration import montecarlo_globals
 
 
 class MacroAtomState(HDFWriterMixin):

--- a/tardis/opacities/tests/test_opacity_solver.py
+++ b/tardis/opacities/tests/test_opacity_solver.py
@@ -41,7 +41,7 @@ def test_opacity_solver(
         pass
     else:
         macroatom_state = MacroAtomSolver().solve(
-            legacy_plasma,
+            legacy_plasma.j_blues,
             legacy_plasma.atomic_data,
             actual.tau_sobolev,
             legacy_plasma.stimulated_emission_factor,

--- a/tardis/opacities/tests/test_opacity_solver.py
+++ b/tardis/opacities/tests/test_opacity_solver.py
@@ -45,6 +45,8 @@ def test_opacity_solver(
             legacy_plasma.atomic_data,
             actual.tau_sobolev,
             legacy_plasma.stimulated_emission_factor,
+            beta_sobolev=actual.beta_sobolev,
+            legacy_mode=False,
         )
         pdt.assert_frame_equal(
             macroatom_state.transition_probabilities,

--- a/tardis/opacities/tests/test_opacity_state_numba.py
+++ b/tardis/opacities/tests/test_opacity_state_numba.py
@@ -32,12 +32,12 @@ def test_opacity_state_to_numba(
             legacy_plasma.atomic_data,
             opacity_state.tau_sobolev,
             legacy_plasma.stimulated_emission_factor,
+            beta_sobolev=opacity_state.beta_sobolev,
+            legacy_mode=False,
         )
     else:
         macro_atom_state = None
-    actual = opacity_state.to_numba(
-        macro_atom_state, line_interaction_type
-    )
+    actual = opacity_state.to_numba(macro_atom_state, line_interaction_type)
 
     if sliced:
         index = slice(2, 5)

--- a/tardis/opacities/tests/test_opacity_state_numba.py
+++ b/tardis/opacities/tests/test_opacity_state_numba.py
@@ -28,7 +28,7 @@ def test_opacity_state_to_numba(
     opacity_state = opacity_solver.legacy_solve(legacy_plasma)
     if line_interaction_type in ("downbranch", "macroatom"):
         macro_atom_state = MacroAtomSolver().solve(
-            legacy_plasma,
+            legacy_plasma.j_blues,
             legacy_plasma.atomic_data,
             opacity_state.tau_sobolev,
             legacy_plasma.stimulated_emission_factor,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -453,10 +453,12 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 )  # TODO: Impliment
             else:
                 macro_atom_state = self.macro_atom.solve(
-                    self.plasma,
+                    self.plasma.j_blues,
                     self.plasma.atomic_data,
                     opacity_state.tau_sobolev,
                     self.plasma.stimulated_emission_factor,
+                    opacity_state.beta_sobolev,
+                    legacy_mode=False,
                 )
 
         transport_state = self.transport.initialize_transport_state(

--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -347,7 +347,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
             macro_atom_state = None
         else:
             macro_atom_state = self.macro_atom_solver.solve(
-                self.plasma_solver,
+                self.plasma_solver.j_blues,
                 self.plasma_solver.atomic_data,
                 opacity_state.tau_sobolev,
                 self.plasma_solver.stimulated_emission_factor,


### PR DESCRIPTION
This makes the macroatom take computed plasma properties rather than the plasma itself. It also fixes up the macroatom test to not use legacy mode. 

Currently as a draft because I want to know whether I can get rid of legacy mode altogether. Being that the function no longer takes the plasma itself anyway, I don't think we need to keep around a version that is compatible with legacy plasma since whatever changes to the plasma should be handled higher up. 