### PR TITLE
GSOC: add from hdf method to spectrum class

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -119,6 +119,8 @@ Josh Shields <shields.joshua.v@gmail.com>
 Karan Desai <karandesai_96@live.com>
 Karan Desai <karandesai_96@live.com> karandesai-96 <karandesai_96@live.com>
 
+Karthik Rishinarada <karthikrk11135@gmail.com>
+
 Kaushik Varanasi <kaushik.varanasi1@gmail.com>
 Kaushik Varanasi <kaushik.varanasi1@gmail.com> kaushik94 <kaushik.varanasi1@gmail.com>
 

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -20,3 +20,4 @@ jordi.eguren.brown@gmail.com,0000-0002-2328-8030
 sashankmishra27@gmail.com,0000-0001-8302-1584
 jgillanders01@qub.ac.uk,0000-0002-8094-6108
 andrewgfullard@gmail.com,0000-0001-7343-1678
+karthikrk11135@gmail.com,0009-0005-5930-4708

--- a/docs/physics/spectrum/basic.ipynb
+++ b/docs/physics/spectrum/basic.ipynb
@@ -422,7 +422,7 @@
    "id": "4a34a1ba",
    "metadata": {},
    "source": [
-    "Inorder to retrieve your Spectrum class from an hdf file, follow the below steps"
+    "Inorder to retrieve your Spectrum class from an hdf file, follow the steps below:"
    ]
   },
   {
@@ -442,7 +442,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj = spectrum.from_hdf_to_class(\"test.hdf\")\n",
+    "obj = spectrum.from_hdf(\"test.hdf\")\n",
     "print(obj._frequency == spectrum._frequency)\n"
    ]
   },
@@ -475,7 +475,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "tardis",
    "language": "python",
    "name": "python3"
   },
@@ -489,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/docs/physics/spectrum/basic.ipynb
+++ b/docs/physics/spectrum/basic.ipynb
@@ -418,14 +418,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4a34a1ba",
-   "metadata": {},
-   "source": [
-    "Inorder to retrieve your Spectrum class from an hdf file, follow the steps below:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "abef6bb1",
@@ -436,13 +428,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4a34a1ba",
+   "metadata": {},
+   "source": [
+    "Inorder to retrieve your Spectrum class from an hdf file, follow the steps below:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "2eb89482",
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj = spectrum.from_hdf(\"test.hdf\")\n",
+    "obj = spectrum.from_hdf(\"path_to_your_file.hdf\")\n",
     "print(obj._frequency == spectrum._frequency)\n"
    ]
   },

--- a/docs/physics/spectrum/basic.ipynb
+++ b/docs/physics/spectrum/basic.ipynb
@@ -442,7 +442,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj = spectrum.from_hdf(\"path_to_your_file.hdf\")\n",
+    "obj = spectrum.from_hdf(\"test.hdf\")\n",
     "print(obj._frequency == spectrum._frequency)\n"
    ]
   },

--- a/tardis/spectrum/spectrum.py
+++ b/tardis/spectrum/spectrum.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 from astropy import units as u
 
 from tardis.io.util import HDFWriterMixin
@@ -150,6 +151,20 @@ class TARDISSpectrum(HDFWriterMixin):
             )
         else:
             warnings.warn(f"Did not find plotting mode {mode}, doing nothing.")
+
+    def from_hdf_to_class(self,hdf_path):
+        try:
+            with pd.HDFStore(hdf_path, mode="r") as store:
+                _freq = store['/tardis_spectrum/_frequency']
+                _f = np.array(_freq) * u.Hz
+
+                _lumi = store['/tardis_spectrum/luminosity']
+                _l = np.array(_lumi) * (u.erg/u.s)
+
+                return TARDISSpectrum(_f, _l)
+            
+        except FileNotFoundError as e:
+            print(f"File not found: {e}")
 
     def to_ascii(self, fname, mode="luminosity_density"):
         if mode == "luminosity_density":

--- a/tardis/spectrum/spectrum.py
+++ b/tardis/spectrum/spectrum.py
@@ -23,7 +23,6 @@ class TARDISSpectrum(HDFWriterMixin):
 
     hdf_properties = [
         "_frequency",
-        # "distance",
         "luminosity",
         "delta_frequency",
         "wavelength",
@@ -169,11 +168,7 @@ class TARDISSpectrum(HDFWriterMixin):
                 luminosity_store = store['/tardis_spectrum/luminosity']
                 luminosity_arr = np.array(luminosity_store) * (u.erg/u.s)
 
-                # distance_val = store['/test/tardis_spectrum/scalars']['distance']
-
                 final_obj = TARDISSpectrum(frequency_arr, luminosity_arr)
-                # final_obj.distance = distance_val
-
                 return final_obj
             
         except FileNotFoundError as e:

--- a/tardis/spectrum/spectrum.py
+++ b/tardis/spectrum/spectrum.py
@@ -23,6 +23,7 @@ class TARDISSpectrum(HDFWriterMixin):
 
     hdf_properties = [
         "_frequency",
+        # "distance",
         "luminosity",
         "delta_frequency",
         "wavelength",
@@ -152,16 +153,28 @@ class TARDISSpectrum(HDFWriterMixin):
         else:
             warnings.warn(f"Did not find plotting mode {mode}, doing nothing.")
 
-    def from_hdf_to_class(self,hdf_path):
+    def from_hdf(self,hdf_path):
+        """
+        Retrieves the class object from the hdf path provided. 
+
+        Parameters
+        ----------
+        hdf_path : string, Path to the hdf file 
+        """
         try:
             with pd.HDFStore(hdf_path, mode="r") as store:
-                _freq = store['/tardis_spectrum/_frequency']
-                _f = np.array(_freq) * u.Hz
+                freq_store = store['/tardis_spectrum/_frequency']
+                frequency_arr = np.array(freq_store) * u.Hz
 
-                _lumi = store['/tardis_spectrum/luminosity']
-                _l = np.array(_lumi) * (u.erg/u.s)
+                luminosity_store = store['/tardis_spectrum/luminosity']
+                luminosity_arr = np.array(luminosity_store) * (u.erg/u.s)
 
-                return TARDISSpectrum(_f, _l)
+                # distance_val = store['/test/tardis_spectrum/scalars']['distance']
+
+                final_obj = TARDISSpectrum(frequency_arr, luminosity_arr)
+                # final_obj.distance = distance_val
+
+                return final_obj
             
         except FileNotFoundError as e:
             print(f"File not found: {e}")

--- a/tardis/spectrum/spectrum.py
+++ b/tardis/spectrum/spectrum.py
@@ -172,7 +172,7 @@ class TARDISSpectrum(HDFWriterMixin):
                 return final_obj
             
         except FileNotFoundError as e:
-            print(f"File not found: {e}")
+            raise FileNotFoundError(f"File not found: {e}")
 
     def to_ascii(self, fname, mode="luminosity_density"):
         if mode == "luminosity_density":

--- a/tardis/spectrum/spectrum.py
+++ b/tardis/spectrum/spectrum.py
@@ -152,6 +152,7 @@ class TARDISSpectrum(HDFWriterMixin):
         else:
             warnings.warn(f"Did not find plotting mode {mode}, doing nothing.")
 
+    @classmethod
     def from_hdf(self,hdf_path):
         """
         Retrieves the class object from the hdf path provided. 

--- a/tardis/spectrum/tests/test_spectrum.py
+++ b/tardis/spectrum/tests/test_spectrum.py
@@ -135,6 +135,14 @@ def test_f_nu_to_f_lambda(spectrum):
         spectrum.luminosity_density_lambda.value, expected.value
     )
 
+            
+def test_from_hdf_to_class(spectrum):
+    actual = TARDISSpectrum(spectrum._frequency, spectrum.luminosity)
+    actual.to_hdf("test.hdf", overwrite=True)
+    expected = actual.from_hdf_to_class("test.hdf")
+
+    compare_spectra(actual, expected)
+
 
 ###
 # Save and Load

--- a/tardis/spectrum/tests/test_spectrum.py
+++ b/tardis/spectrum/tests/test_spectrum.py
@@ -157,7 +157,6 @@ def test_from_hdf(spectrum):
 
         np.testing.assert_array_equal(spectrum.frequency, result.frequency)
         np.testing.assert_array_equal(spectrum.luminosity, result.luminosity)
-        # compare_spectra(spectrum, result)
 
 ###
 # Save and Load

--- a/tardis/spectrum/tests/test_spectrum.py
+++ b/tardis/spectrum/tests/test_spectrum.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 from astropy import units as u
 from numpy.testing import assert_almost_equal
-from unittest.mock import patch, mock_open, MagicMock
 from tardis import constants as c
 from tardis.spectrum.spectrum import (
     TARDISSpectrum,

--- a/tardis/spectrum/tests/test_spectrum.py
+++ b/tardis/spectrum/tests/test_spectrum.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from astropy import units as u
 from numpy.testing import assert_almost_equal
+
 from tardis import constants as c
 from tardis.spectrum.spectrum import (
     TARDISSpectrum,

--- a/tardis/spectrum/tests/test_spectrum.py
+++ b/tardis/spectrum/tests/test_spectrum.py
@@ -158,6 +158,9 @@ def test_from_hdf(spectrum):
         np.testing.assert_array_equal(spectrum.frequency, result.frequency)
         np.testing.assert_array_equal(spectrum.luminosity, result.luminosity)
 
+    with pytest.raises(FileNotFoundError):
+        result = spectrum.from_hdf("non_existing_path.hdf")
+        
 ###
 # Save and Load
 ###


### PR DESCRIPTION
Type: 🚀 Feature  | 📝 Documentation

GSOC objective : Added a method to the Tardis Spectrum class which retrieves the object from an hdf file. 



How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
