### PR TITLE
Send a dispatch to tardis website to update credits

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -91,7 +91,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "Content-Type: application/json" \
-            -d '{ "event_type": "update-credits" }' \
+            -d '{ "event_type": "repo-push" }' \
             https://api.github.com/repos/tardis-sn/tardis-org-data/dispatches
 
   pull_request:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -85,6 +85,15 @@ jobs:
             README.rst
             docs/resources/credits.rst
 
+      - name: Dispatch to Tardis Website
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.BOT_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -d '{ "event_type": "update-credits" }' \
+            https://api.github.com/repos/tardis-sn/tardis-org-data/dispatches
+
   pull_request:
     needs: [changelog, citation, credits]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR aims to trigger a workflow on tardis website in order to update the credits page

Sample run:
tardis sends dispatch to org data: https://github.com/KasukabeDefenceForce/tardis/actions/runs/13722063478/job/38379575151
org data updates website content: https://github.com/KasukabeDefenceForce/tardis-org-data/actions/runs/13722115983
Deployed on fork: https://kasukabedefenceforce.github.io/tardis-sn.github.io/branch/master/credits/
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
