### PR TITLE
Fix post release workflow by pinning python version to 3.12

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install rst-include
         run: pip install rst-include==2.1.2.2 requests==2.27.1


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The post release workflow is failing because it uses latest version of python and "pipes" has been removed in version 3.13. So we pin it "3.12".
![image](https://github.com/user-attachments/assets/3890e689-e613-45f7-af12-e8ce49b7bb82)

Sample fork run:
https://github.com/KasukabeDefenceForce/tardis/actions/runs/13722247104

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
