### PR TITLE
Vectorized fast array util

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -133,6 +133,8 @@ Kevin Yap <me@kevinyap.ca>
 Kim Lingemann <kim@tg-lingemann.de> kimsina <kim@tg-lingemann.de>
 Kim Lingemann <kim@tg-lingemann.de> kim <kim@tg-lingemann.de>
 
+Kunal Garg <gargkunal226@gmail.com>
+
 Laud Bentil <laudbentil@gmail.com>
 Laud Bentil <laudbentil@gmail.com> Laud Bentil <laud.bentil@meltwater.org>
 

--- a/tardis/plasma/properties/continuum_processes/fast_array_util.py
+++ b/tardis/plasma/properties/continuum_processes/fast_array_util.py
@@ -14,7 +14,7 @@ def numba_cumulative_trapezoid(f, x):
     Parameters
     ----------
     f : numpy.ndarray, dtype float
-        Input array to with multiple functions integrate.
+        Input array to integrate.
     x : numpy.ndarray, dtype float
         The coordinate to integrate along.
 

--- a/tardis/plasma/properties/continuum_processes/fast_array_util.py
+++ b/tardis/plasma/properties/continuum_processes/fast_array_util.py
@@ -37,7 +37,7 @@ def numba_cumulative_trapezoid_2d(f, dx):
     Parameters
     ----------
     f : numpy.ndarray, dtype float
-        Input array to with multiple functions integrate.
+        Input array with multiple functions to integrate.
     dx : numpy.ndarray, dtype float
         The width of each block to integrate along.
 

--- a/tardis/plasma/properties/continuum_processes/fast_array_util.py
+++ b/tardis/plasma/properties/continuum_processes/fast_array_util.py
@@ -14,7 +14,7 @@ def numba_cumulative_trapezoid(f, x):
     Parameters
     ----------
     f : numpy.ndarray, dtype float
-        Input array to integrate.
+        Input array to with multiple functions integrate.
     x : numpy.ndarray, dtype float
         The coordinate to integrate along.
 
@@ -23,6 +23,7 @@ def numba_cumulative_trapezoid(f, x):
     numpy.ndarray, dtype float
         The result of cumulative integration of f along x
     """
+
     integ = (np.diff(x) * (f[1:] + f[:-1]) / 2.0).cumsum()
     return integ / integ[-1]
 
@@ -54,12 +55,9 @@ def cumulative_integrate_array_by_blocks(f, x, block_references):
     """
     n_rows = len(block_references) - 1
     integrated = np.zeros_like(f)
-    for i in prange(f.shape[1]):  # columns
-        # TODO: Avoid this loop through vectorization of cumulative_trapezoid
-        for j in prange(n_rows):  # rows
-            start = block_references[j]
-            stop = block_references[j + 1]
-            integrated[start + 1 : stop, i] = numba_cumulative_trapezoid(
-                f[start:stop, i], x[start:stop]
-            )
+    for j in prange(n_rows):  # rows
+        start = block_references[j]
+        stop = block_references[j + 1]
+        integrated[start + 1: stop, :] = numba_cumulative_trapezoid(
+            f[start:stop, :], x[start:stop])
     return integrated


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

Optimized fast_array_util.py by vectorizing the functions. First, I tried by vectorizing both the functions, but the speedup was only around 5%, so then I made a new function for 2d arrays which would take in precomputed dx array, not having to do it again and again. I had to make a new function as the old one was being used in another file. Also made sure that there is no division by zero.

Resolves #2757 

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method
```
# It is currently not possible to use scipy.integrate.cumulative_trapezoid in
# numba. So here is my own implementation.
import numpy as np
from numba import njit, prange
import timeit

from tardis.transport.montecarlo import njit_dict


@njit(**njit_dict)
def numba_cumulative_trapezoid(f, x):
    integ = (np.diff(x) * (f[1:] + f[:-1]) / 2.0).cumsum()
    return integ / integ[-1]



@njit(**njit_dict)
def cumulative_integrate_array_by_blocks(f, x, block_references):
    
    n_rows = len(block_references) - 1
    integrated = np.zeros_like(f)
    for i in prange(f.shape[1]):  # columns
        # TODO: Avoid this loop through vectorization of cumulative_trapezoid
        for j in prange(n_rows):  # rows
            start = block_references[j]
            stop = block_references[j + 1]
            integrated[start + 1 : stop, i] = numba_cumulative_trapezoid(
                f[start:stop, i], x[start:stop]
            )
    return integrated


@njit(**njit_dict)
def numba_cumulative_trapezoid_2d(f, dx):
    n, m = f.shape
    trapz = dx.reshape(-1, 1) * (f[1:] + f[:-1]) / 2.0  # (n-1, m)
    integ = np.zeros_like(trapz)

    # Parallel cumulative sum over columns
    for i in prange(m):
        cumulative = 0.0
        for j in range(trapz.shape[0]):
            cumulative += trapz[j, i]
            integ[j, i] = cumulative
        if cumulative != 0:
            integ[:, i] /= cumulative
    return integ


@njit(**njit_dict)
def cumulative_integrate_array_by_blocks_optimized(f, x, block_references):
    dx = np.diff(x)  # Precompute once globally
    integrated = np.zeros_like(f)
    n_blocks = len(block_references) - 1

    # Parallelize over blocks
    for j in prange(n_blocks):
        start = block_references[j]
        stop = block_references[j + 1]
        dx_block = dx[start: stop - 1]
        f_block = f[start:stop, :]
        integrated[start + 1:stop, :] = numba_cumulative_trapezoid_2d(f_block, dx_block)

    return integrated



N_freq = 1000
N_shells = 100
N_blocks = 10

f = np.random.random((N_freq, N_shells))
x = np.linspace(0, 1, N_freq)
block_references = np.linspace(0, N_freq, N_blocks, dtype=int)

cumulative_integrate_array_by_blocks(f, x, block_references)
cumulative_integrate_array_by_blocks_optimized(f, x, block_references)

def wrapper_cumulative_integrate_array_by_blocks():
    return cumulative_integrate_array_by_blocks(f, x, block_references)

def wrapper_cumulative_integrate_array_by_blocks_optimized():
    return cumulative_integrate_array_by_blocks_optimized(f, x, block_references)

# Time the functions
timer1 = timeit.Timer(wrapper_cumulative_integrate_array_by_blocks)
timer2 = timeit.Timer(wrapper_cumulative_integrate_array_by_blocks_optimized)

time1 = timer1.timeit(number=10)
time2 = timer2.timeit(number=10)

print(f"Time for cumulative_integrate_array_by_blocks: {time1:.6f} seconds")
print(f"Time for cumulative_integrate_array_by_blocks_optimized: {time2:.6f} seconds")
print(f"Speedup: {time1/time2:.2f}")

result1 = cumulative_integrate_array_by_blocks(f, x, block_references)
result2 = cumulative_integrate_array_by_blocks_optimized(f, x, block_references)

max_diff = np.max(np.abs(result1 - result2))
print(f"Maximum absolute difference between results: {max_diff}")

are_equal = np.allclose(result1, result2)
print(f"Results are equivalent: {are_equal}")
```
Output:
```
Time for cumulative_integrate_array_by_blocks: 3.907853 seconds
Time for cumulative_integrate_array_by_blocks_optimized: 0.085217 seconds
Speedup: 45.86
Maximum absolute difference between results: 0.0
Results are equivalent: True
```

- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
