### PR TITLE
Add workflows to documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -385,11 +385,11 @@ def generate_how_to_guides_page(app):
 def generate_worflows_page(app):
     "Create workflows.rst"
     notebooks = ""
+    workflows_path = Path("workflows")
 
-    for root, dirs, fnames in os.walk("workflows/"):
-        for fname in fnames:
-            if 'workflow' in fname and fname.endswith(".ipynb") and "checkpoint" not in fname:
-                notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
+    for notebook in workflows_path.rglob("*.ipynb"):
+        if "workflow" in notebook.name and "checkpoint" not in notebook.name:
+            notebooks += f"\n* :doc:`{notebook.with_suffix('').as_posix()}`" 
 
     title = "Workflows\n*********\n"
     description = "The following pages contain the TARDIS workflows:\n\n These examples are intended to help users explore specific modules within TARDIS, with the goal of supporting their individual scientific objectives."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -382,6 +382,20 @@ def generate_how_to_guides_page(app):
     with open("how_to_guides.rst", mode="wt", encoding="utf-8") as f:
         f.write(f"{title}\n{description}\n{notebooks}")
 
+def generate_worflows_page(app):
+    "Create workflows.rst"
+    notebooks = ""
+
+    for root, dirs, fnames in os.walk("workflows/"):
+        for fname in fnames:
+            if 'workflow' in fname and fname.endswith(".ipynb") and "checkpoint" not in fname:
+                notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
+
+    title = "Workflows\n*********\n"
+    description = "The following pages contain the TARDIS workflows:"
+
+    with open("workflows.rst", mode="wt", encoding="utf-8") as f:
+        f.write(f"{title}\n{description}\n{notebooks}")
 
 def autodoc_skip_member(app, what, name, obj, skip, options):
     """Exclude specific functions/methods from the documentation"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -435,5 +435,6 @@ def create_redirect_files(app, docname):
 def setup(app):
     app.connect("builder-inited", generate_tutorials_page)
     app.connect("builder-inited", generate_how_to_guides_page)
+    app.connect("builder-inited", generate_worflows_page)
     app.connect("autodoc-skip-member", autodoc_skip_member)
     app.connect("build-finished", create_redirect_files)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -392,7 +392,7 @@ def generate_worflows_page(app):
                 notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
 
     title = "Workflows\n*********\n"
-    description = "The following pages contain the TARDIS workflows:"
+    description = "The following pages contain the TARDIS workflows:\n\n These examples are intended to help users explore specific modules within TARDIS, with the goal of supporting their individual scientific objectives."
 
     with open("workflows.rst", mode="wt", encoding="utf-8") as f:
         f.write(f"{title}\n{description}\n{notebooks}")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Mission Statement
     quickstart
     tutorials
     how_to_guides
+    workflows
     faq
     API <api/modules>
 

--- a/docs/workflows/simple_workflow.ipynb
+++ b/docs/workflows/simple_workflow.ipynb
@@ -1,13 +1,21 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simple TARDIS Workflow"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
     "from tardis.io.configuration.config_reader import Configuration\n",
-    "from tardis.workflows.simple_tardis_workflow import SimpleTARDISWorkflow\n"
+    "from tardis.workflows.simple_tardis_workflow import SimpleTARDISWorkflow"
    ]
   },
   {
@@ -35,15 +43,6 @@
    "outputs": [],
    "source": [
     "workflow.run()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/docs/workflows/simple_workflow.ipynb
+++ b/docs/workflows/simple_workflow.ipynb
@@ -8,6 +8,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The source code for this workflow can be found at: https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/simple_tardis_workflow.py."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
@@ -76,13 +83,6 @@
     "plt.legend()\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/workflows/simple_workflow.ipynb
+++ b/docs/workflows/simple_workflow.ipynb
@@ -15,6 +15,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a lightweight workflow designed for efficiency, particularly for those running large batches of TARDIS simulations. It minimizes saved output and logging information to streamline execution."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},

--- a/docs/workflows/standard_workflow.ipynb
+++ b/docs/workflows/standard_workflow.ipynb
@@ -1,13 +1,28 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Standard TARDIS Workflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The source code for this workflow can be found at: https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/standard_tardis_workflow.py."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import matplotlib.pyplot as plt\n",
     "from tardis.io.configuration.config_reader import Configuration\n",
-    "from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow\n"
+    "from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow"
    ]
   },
   {
@@ -35,15 +50,6 @@
    "outputs": [],
    "source": [
     "workflow.run()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -77,13 +83,6 @@
     "plt.legend()\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/workflows/standard_workflow.ipynb
+++ b/docs/workflows/standard_workflow.ipynb
@@ -15,6 +15,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This workflow produces the full suite of standard TARIDS outputs, including plots, logging information, and stored data. It is useful for users who want access to detailed output for analysis."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -11,9 +11,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This workflow is built on top of the [SimpleTARDISWorkflow](https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/simple_tardis_workflow.py) to solve the v_inner boundary, in addition to the remaining radiative properties.\n",
-    "\n",
     "The source code for this workflow can be found at: https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/v_inner_solver.py."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This workflow demonstrates how to use the TARDIS modules to perform targeted tasks. This workflow is built on top of the [SimpleTARDISWorkflow](https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/simple_tardis_workflow.py) to solve the v_inner boundary, in addition to the remaining radiative properties."
    ]
   },
   {

--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -1,6 +1,22 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Workflow to solve v_inner boundary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This workflow is built on top of the [SimpleTARDISWorkflow](https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/simple_tardis_workflow.py) to solve the v_inner boundary, in addition to the remaining radiative properties.\n",
+    "\n",
+    "The source code for this workflow can be found at: https://github.com/tardis-sn/tardis/blob/master/tardis/workflows/v_inner_solver.py."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

To display the workflow docs on the documentation, I generated a new function in conf.py that compiles all notebooks within the workflows folder into a workflows.rst file. Then, I added that new section to index.rst, so it appears between How-To Guides and FAQs on the top section of the documentation. 

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
