### PR TITLE
Fixes the ruff toml issues

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,8 @@
 # Ruff configuration file adapted from astropy
 extend = "pyproject.toml"
+
+extend-exclude = ["conda-osx-arm64.lock", "conda-linux-64.lock", "conda-lock.yml"]
+
 lint.ignore = [
     # NOTE: to find a good code to fix, run:
     # ruff --select="ALL" --statistics astropy/<subpackage>
@@ -214,8 +217,6 @@ lint.ignore = [
 lint.unfixable = [
     "E711"  # NoneComparison. Hard to fix b/c numpy has it's own None.
 ]
-
-exclude = ["conda-osx-arm64.lock", "conda-linux-64.lock", "conda-lock.yml"]
 
 [lint.extend-per-file-ignores]
 "docs/*" = []

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -215,7 +215,8 @@ lint.unfixable = [
     "E711"  # NoneComparison. Hard to fix b/c numpy has it's own None.
 ]
 
+exclude = ["conda-osx-arm64.lock", "conda-linux-64.lock", "conda-lock.yml"]
+
 [lint.extend-per-file-ignores]
 "docs/*" = []
 
-exclude = ["conda-osx-arm64.lock", "conda-linux-64.lock", "conda-lock.yml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ verbose = 0
 [tool.ruff]
 line-length = 80
 lint.select = ["ALL"]
-exclude=[]
 lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
 
     # flake8-builtins (A) : shadowing a Python built-in.


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

- Resolved the scope of `exclude` key

Fixes #3046 

I have tested this too,

```python
(tardis) swayam-shah@Swayam:/mnt/c/Users/admin/Desktop/tardis$ ruff check --select ANN001 tardis/constants.py
warning: The following rules have been removed and ignoring them has no effect:
    - ANN101
    - ANN102
    - PT004

All checks passed!
``` 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
