### PR TITLE
Tests for workflows: Simple, Standard, and Inner Velocity Solver

### DIFF
--- a/tardis/io/configuration/tests/data/tardis_config_v_inner.yml
+++ b/tardis/io/configuration/tests/data/tardis_config_v_inner.yml
@@ -1,0 +1,63 @@
+# Configuration for v_inner boundary solver
+tardis_config_version: v1.0
+
+supernova:
+  luminosity_requested: 9.44 log_lsun
+  time_explosion: 13 day
+
+atom_data: kurucz_cd23_chianti_H_He.h5
+
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 5000 km/s
+      stop: 20000 km/s
+      num: 50
+    density:
+      type: branch85_w7
+
+  abundances:
+    type: uniform
+    O: 0.19
+    Mg: 0.03
+    Si: 0.52
+    S: 0.19
+    Ar: 0.04
+    Ca: 0.03
+
+plasma:
+  disable_electron_scattering: no
+  ionization: lte
+  excitation: lte
+  radiative_rates_type: dilute-blackbody
+  line_interaction_type: macroatom
+
+montecarlo:
+  seed: 23111963
+  no_of_packets: 4.0e+4
+  iterations: 20
+  nthreads: 1
+
+  last_no_of_packets: 1.e+5
+  no_of_virtual_packets: 10
+
+  convergence_strategy:
+    type: damped
+    damping_constant: 1.0
+    threshold: 0.05
+    fraction: 0.8
+    hold_iterations: 3
+    stop_if_converged: True
+    t_inner:
+      damping_constant: 0.5
+    v_inner_boundary:
+      damping_constant: 0.5
+      threshold: 0.01
+      type: damped
+      store_iteration_properties: False
+
+spectrum:
+  start: 500 angstrom
+  stop: 20000 angstrom
+  num: 10000

--- a/tardis/workflows/tests/test_workflows.py
+++ b/tardis/workflows/tests/test_workflows.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+
+from tardis.io.configuration.config_reader import Configuration
+from tardis.simulation import Simulation
+from tardis.workflows.v_inner_solver import InnerVelocitySolverWorkflow
+from tardis.workflows.simple_tardis_workflow import SimpleTARDISWorkflow
+from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow
+
+
+@pytest.fixture(scope="function")
+def v_inner_config(example_configuration_dir):
+    return Configuration.from_yaml(
+        example_configuration_dir / "tardis_config_v_inner.yml"
+    )
+
+@pytest.fixture(scope="function")
+def run_v_inner(v_inner_config, atomic_data_fname):
+    sim = InnerVelocitySolverWorkflow(v_inner_config)
+    sim.run()
+    return sim
+
+def test_v_inner_solver_workflow(run_v_inner):
+    actual = getattr(run_v_inner, 'completed_iterations')
+    if hasattr(actual, "value"):
+        actual = actual.value
+    expected = 10 
+    assert actual == expected

--- a/tardis/workflows/tests/test_workflows.py
+++ b/tardis/workflows/tests/test_workflows.py
@@ -1,12 +1,18 @@
-import pandas as pd
+from pathlib import Path
+
 import pytest
 
 from tardis.io.configuration.config_reader import Configuration
-from tardis.simulation import Simulation
+# from tardis.simulation import Simulation
 from tardis.workflows.v_inner_solver import InnerVelocitySolverWorkflow
 from tardis.workflows.simple_tardis_workflow import SimpleTARDISWorkflow
 from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow
 
+@pytest.fixture(scope="module")
+def config(example_configuration_dir):
+    return Configuration.from_yaml(
+        example_configuration_dir / "tardis_configv1_verysimple.yml"
+    )
 
 @pytest.fixture(scope="function")
 def v_inner_config(example_configuration_dir):
@@ -21,8 +27,20 @@ def run_v_inner(v_inner_config, atomic_data_fname):
     return sim
 
 def test_v_inner_solver_workflow(run_v_inner):
-    actual = getattr(run_v_inner, 'completed_iterations')
+    actual = getattr(run_v_inner, "completed_iterations")
     if hasattr(actual, "value"):
         actual = actual.value
     expected = 10 
     assert actual == expected
+
+def test_simple_tardis_workflow(config):
+    sim = SimpleTARDISWorkflow(config)
+    sim.run()
+    assert hasattr(sim, "completed_iterations")
+    assert sim.completed_iterations == 10 # placeholder value
+
+def test_standard_tardis_workflow(config):
+    sim = StandardTARDISWorkflow(config)
+    sim.run()
+    assert hasattr(sim, "completed_iterations")
+    assert sim.completed_iterations == 10 # placeholder value

--- a/tardis/workflows/tests/test_workflows.py
+++ b/tardis/workflows/tests/test_workflows.py
@@ -1,46 +1,59 @@
-from pathlib import Path
-
 import pytest
+import numpy as np
+from astropy import units as u
 
 from tardis.io.configuration.config_reader import Configuration
-# from tardis.simulation import Simulation
 from tardis.workflows.v_inner_solver import InnerVelocitySolverWorkflow
 from tardis.workflows.simple_tardis_workflow import SimpleTARDISWorkflow
 from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow
 
 @pytest.fixture(scope="module")
-def config(example_configuration_dir):
-    return Configuration.from_yaml(
-        example_configuration_dir / "tardis_configv1_verysimple.yml"
-    )
+def simulation_simple_workflow(config_verysimple, atomic_data_fname):
+    sim = SimpleTARDISWorkflow(config_verysimple, csvy=True)
+    sim.run()
+    return sim
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
+def simulation_standard_workflow(config_verysimple, atomic_data_fname):
+    sim = StandardTARDISWorkflow(config_verysimple, csvy=True)
+    sim.run()
+    return sim
+
+@pytest.fixture(scope="module")
 def v_inner_config(example_configuration_dir):
     return Configuration.from_yaml(
         example_configuration_dir / "tardis_config_v_inner.yml"
     )
 
-@pytest.fixture(scope="function")
-def run_v_inner(v_inner_config, atomic_data_fname):
+@pytest.fixture(scope="module")
+def simulation_v_inner_workflow(v_inner_config, atomic_data_fname):
     sim = InnerVelocitySolverWorkflow(v_inner_config)
     sim.run()
     return sim
 
-def test_v_inner_solver_workflow(run_v_inner):
-    actual = getattr(run_v_inner, "completed_iterations")
-    if hasattr(actual, "value"):
-        actual = actual.value
-    expected = 10 
-    assert actual == expected
+def test_v_inner_solver_workflow_iterations(simulation_v_inner_workflow):
+    assert hasattr(simulation_v_inner_workflow, "completed_iterations")
+    assert simulation_v_inner_workflow.completed_iterations == 10
 
-def test_simple_tardis_workflow(config):
-    sim = SimpleTARDISWorkflow(config)
-    sim.run()
-    assert hasattr(sim, "completed_iterations")
-    assert sim.completed_iterations == 10 # placeholder value
+@pytest.mark.parametrize(["key","expected"],[("t_inner",10684.13082565328 * u.K),("v_inner",1970000000.0 * u.cm / u.s)])
+def test_v_inner_solver_workflow_convergence(key, expected, simulation_v_inner_workflow):
+    actual = getattr(simulation_v_inner_workflow.simulation_state, key)
+    if not actual.isscalar:
+        actual = actual[-1]    
+    assert np.allclose(actual.to_value(), expected.to_value())
 
-def test_standard_tardis_workflow(config):
-    sim = StandardTARDISWorkflow(config)
-    sim.run()
-    assert hasattr(sim, "completed_iterations")
-    assert sim.completed_iterations == 10 # placeholder value
+@pytest.mark.parametrize("key",["t_radiative","dilution_factor","t_inner"])
+def test_simple_tardis_workflow(key, simulation_simple_workflow, simulation_verysimple):
+    actual = getattr(simulation_simple_workflow.simulation_state, key)
+    actual = actual.to_value() if hasattr(actual, "to_value") else actual
+    expected = getattr(simulation_verysimple.simulation_state, key)
+    expected = expected.to_value() if hasattr(expected, "to_value") else expected
+    assert np.allclose(actual, expected)
+
+@pytest.mark.parametrize("key",["t_radiative","dilution_factor","t_inner"])
+def test_standard_tardis_workflow(key, simulation_standard_workflow, simulation_verysimple):
+    actual = getattr(simulation_standard_workflow.simulation_state, key)
+    actual = actual.to_value() if hasattr(actual, "to_value") else actual
+    expected = getattr(simulation_verysimple.simulation_state, key)
+    expected = expected.to_value() if hasattr(expected, "to_value") else expected
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
### :pencil: Description

**Type:** :vertical_traffic_light: `testing`

Added tests to cover the Simple and Standard TARDIS Workflows using the [config_verysimple](https://github.com/tardis-sn/tardis/blob/2eeb45f9002c32f81d73d88abfe0000ed97bfe81/tardis/conftest.py#L206) and [simulation_verysimple](https://github.com/tardis-sn/tardis/blob/2eeb45f9002c32f81d73d88abfe0000ed97bfe81/tardis/conftest.py#L228) as defined in conftest.py.

Added tests to cover the v_inner_solver workflow. Created a new config file,  tardis_config_v_inner.yml, to run simulation including parameters only required for this workflow. 

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
