### PR TITLE
Rewrote .rst generating functions with pathlib logic for simplification

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -369,11 +369,11 @@ from shutil import copyfile
 def generate_tutorials_page(app):
     """Create tutorials.rst"""
     notebooks = ""
+    io_path = Path("io")
 
-    for root, dirs, fnames in os.walk("io/"):
-        for fname in fnames:
-            if fname.startswith("tutorial_") and fname.endswith(".ipynb") and "checkpoint" not in fname:
-                notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
+    for notebook in io_path.rglob("*.ipynb"):
+        if "tutorial_" in notebook.name and "checkpoint" not in notebook.name:
+            notebooks += f"\n* :doc:`{notebook.with_suffix('').as_posix()}`"
 
     title = "Tutorials\n*********\n"
     description = "The following pages contain the TARDIS tutorials:"
@@ -384,18 +384,17 @@ def generate_tutorials_page(app):
 def generate_how_to_guides_page(app):
     """Create how_to_guides.rst"""
     notebooks = ""
+    io_path = Path("io")
 
-    for root, dirs, fnames in os.walk("io/"):
-        for fname in fnames:
-            if fname.startswith("how_to_") and fname.endswith(".ipynb") and "checkpoint" not in fname:
-                notebooks += f"\n* :doc:`{root}/{fname[:-6]}`"
+    for notebook in io_path.rglob("*.ipynb"):
+        if "how_to_" in notebook.name and "checkpoint" not in notebook.name:
+            notebooks += f"\n* :doc:`{notebook.with_suffix('').as_posix()}`"
 
     title = "How-To Guides\n*********\n"
     description = "The following pages contain the TARDIS how-to guides:"
 
     with open("how_to_guides.rst", mode="wt", encoding="utf-8") as f:
         f.write(f"{title}\n{description}\n{notebooks}")
-
 
 def autodoc_skip_member(app, what, name, obj, skip, options):
     """Exclude specific functions/methods from the documentation"""


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation` 

generate_how_to_guides_page and generate_tutorials_page used os.walk, which got complicated and a little messy... rewrote this same logic using pathlib to hopefully simplify it. 

### :pushpin: Resources

Suggested [here](https://github.com/tardis-sn/tardis/pull/3043#discussion_r2031461749).

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
