### PR TITLE
FIx extra spacing after logger widget

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,6 +171,9 @@ nbsphinx_prolog = r"""
             margin-bottom: 0.4em;
             line-height: 2em;
         }
+        .nboutput:has(.prompt.empty):has(.output_area:empty) {
+            display: none;
+        }
     </style>
     
     <div class="admonition note">


### PR DESCRIPTION
### :pencil: Description

This PR aims at cleaning the extra space around the logger widget

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
