### PR TITLE
Fix tardis version fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ requires = ["setuptools",
             "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.interrogate]
 color = true
 #exclude = ["docs", "build"]

--- a/tardis/__init__.py
+++ b/tardis/__init__.py
@@ -4,12 +4,13 @@
 # should keep this content at the top.
 # ----------------------------------------------------------------------------
 import os
+from importlib.metadata import PackageNotFoundError, version
 
 __all__ = ['__version__', 'test']
 
 try:
-    from .version import version as __version__
-except ImportError:
+    __version__ = version("package-name")
+except PackageNotFoundError:
     __version__ = ''
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
### :pencil: Description
This PR aims to fix the tardis version.
Solution:
https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme
Solves: https://github.com/tardis-sn/tardis/issues/3073

![image](https://github.com/user-attachments/assets/ba30e464-a930-4644-9404-eca072160970)

### :pushpin: Resources

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
