### PR TITLE
Add assertion check in v_inner_solver workflow

### DIFF
--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -49,6 +49,11 @@ class SimpleTARDISWorkflow(WorkflowLogging):
             self.simulation_state = SimulationState.from_csvy(
                 configuration, atom_data=atom_data
             )
+            assert (
+                self.simulation_state.v_inner_boundary
+                == self.simulation_state.geometry.v_inner[0]
+            ), "If using csvy in the v_inner_solver workflow, the initial v_inner_boundary must start with the first shell in the current status."
+
         else:
             self.simulation_state = SimulationState.from_config(
                 configuration,


### PR DESCRIPTION
In the current status of TARDIS, if using csvy in the v_inner_solver workflow, the initial v_inner_boundary has to be the first shell, otherwise it will have a dimension conflict, since the plasma solver and transport solver does not change its dimension after the initialization, the v_inner_solver update the sliced dimension only in each iteration. 

Hence, added an assertion error on this. 



### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
