### PR TITLE
Fix incorrect function call in livplot

### DIFF
--- a/docs/analyzing_tardis/liv_plot_notebook.ipynb
+++ b/docs/analyzing_tardis/liv_plot_notebook.ipynb
@@ -258,7 +258,16 @@
     "msk = np.isin(species_flat_list, species_in_model)\n",
     "species = np.array(species_flat_list)[msk]\n",
     "\n",
-    "species_name = pu.make_colorbar_labels(species, species_flat_list, species_mapped)"
+    "species_name = []\n",
+    "for species_key, species_ids in species_mapped.items():\n",
+    "    if any(spec_id in species for spec_id in species_ids):\n",
+    "        atomic_number, ion_number = divmod(species_key, 100) #(quotient, remainder) Eg: 1402 = (14, 02)\n",
+    "        if ion_number == 0:\n",
+    "            label = atomic_number2element_symbol(atomic_number)\n",
+    "        else:\n",
+    "            ion_numeral = int_to_roman(ion_number + 1)\n",
+    "            label = f\"{atomic_number2element_symbol(atomic_number)} {ion_numeral}\"\n",
+    "        species_name.append(label)"
    ]
   },
   {


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`
This PR aims at fixing the error in liv plot notebook. The util function for creating colorbar labels was shifted from plot util file to inside of the Livplotter class. 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
