### PR TITLE
Remove script to automatically remove `git-lfs-pull` label

### DIFF
--- a/.github/workflows/compare-regdata.yml
+++ b/.github/workflows/compare-regdata.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.BOT_TOKEN }}
+          personal_token: ${{ secrets.BOT_TOKEN }}
           publish_branch: ${{ env.DEPLOY_BRANCH }}
           publish_dir: comparison-artifacts
           destination_dir: ${{ env.DEST_DIR }}

--- a/.github/workflows/compare-regdata.yml
+++ b/.github/workflows/compare-regdata.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.BOT_TOKEN }}
+          personal_token: ${{ secrets.BOT_TOKEN }} # personal_token since pushing to external repo
           publish_branch: ${{ env.DEPLOY_BRANCH }}
           publish_dir: comparison-artifacts
           destination_dir: ${{ env.DEST_DIR }}

--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -111,21 +111,3 @@ jobs:
         with:
           path: tardis-regression-data/.git/lfs
           key: tardis-regression-${{ inputs.atom-data-sparse == true && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
-
-      - name: Remove label
-        if: ${{ inputs.allow_lfs_pull }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                name: 'git-lfs-pull'
-              });
-              console.log('Successfully removed git-lfs-pull label');
-            } catch (error) {
-              console.log(`Unable to remove git-lfs-pull label: ${error.message}`);
-            }


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The lfs-cache had a mechanism to automatically remove the `git-lfs-pull` label to prevent future pulls. 
This removes that feature. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
