### PR TITLE
Complete job names for status checks

### DIFF
--- a/.github/workflows/compare-regdata.yml
+++ b/.github/workflows/compare-regdata.yml
@@ -13,6 +13,13 @@ on:
       - reopened
       - synchronize
       - labeled
+  workflow_call:
+    inputs:
+      pip_git:
+        description: "Whether or not to install tardis using git"
+        required: false
+        type: boolean
+        default: false
 
 env:
   CACHE_NUMBER: 0  # increase to reset cache manually
@@ -37,7 +44,7 @@ jobs:
       allow_lfs_pull: ${{ contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   tests:
-    name: ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ inputs.pip_git && 'pip tests enabled' || '' }}
+    name: compare-regdata ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ inputs.pip_git && 'pip tests enabled' || 'pip tests disabled' }}
     if: (github.repository_owner == 'tardis-sn') && contains(github.event.pull_request.labels.*.name, 'run-regression-comparison')
     needs: [test-cache]
     runs-on: ${{ matrix.os }}
@@ -94,7 +101,6 @@ jobs:
         if: ${{ !inputs.pip_git }}
         run: |
           pip install qgridnext
-
 
       - name: Regression Data Generation tests
         run: pytest tardis ${{ env.PYTEST_FLAGS }} --generate-reference -m "${{ matrix.continuum }} continuum"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,6 @@ on:
       - opened
       - reopened
       - synchronize
-
   workflow_call:
     inputs:
       pip_git:
@@ -46,7 +45,7 @@ jobs:
       allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   tests:
-    name: ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ inputs.pip_git && 'pip tests enabled' || '' }}
+    name: tests ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ inputs.pip_git && 'pip tests enabled' || 'pip tests disabled' }}
     if: github.repository_owner == 'tardis-sn'
     needs: [test-cache]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`  :roller_coaster: `infrastructure`

The branch rulesets require workflows/status checks to pass before merging. Currently the job names are duplicated in test and compare regression data workflows. This pull request makes these names more complete for GitHub to recognize them and make sure the checks pass before allowing merging.

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
