### PR TITLE
Install qgridnext and lineid plot via pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,6 @@ jobs:
         if: ${{ !inputs.pip_git }}
         run: |
           pip install -e ".[viz]"
-      
-      - name: check numpy version
-        run: | 
-          python -c "import numpy; print(f'Version: {numpy.__version__}'); print(f'Path: {numpy.__file__}')"
 
       - name: Install package git
         if: ${{ inputs.pip_git }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install package editable
         if: ${{ !inputs.pip_git }}
         run: |
-          pip install -e ".[viz]" --user
+          pip install -e ".[viz]"
       
       - name: check numpy version
         run: | 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,10 @@ jobs:
         if: ${{ !inputs.pip_git }}
         run: |
           pip install -e ".[viz]" --user
+      
+      - name: check numpy version
+        run: | 
+          python -c "import numpy; print(f'Version: {numpy.__version__}'); print(f'Path: {numpy.__file__}')"
 
       - name: Install package git
         if: ${{ inputs.pip_git }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,16 +77,12 @@ jobs:
       - name: Install package editable
         if: ${{ !inputs.pip_git }}
         run: |
-          pip install -e . --user
+          pip install -e ".[viz]" --user
 
       - name: Install package git
         if: ${{ inputs.pip_git }}
         run: |
-          pip install git+https://github.com/tardis-sn/tardis.git@master
-
-      - name: Install qgridnext
-        run: |
-          pip install qgridnext
+          pip install "git+https://github.com/tardis-sn/tardis.git@master[viz]"
 
       - name: Run tests
         run: pytest tardis ${{ env.PYTEST_FLAGS }} -m "${{ matrix.continuum }} continuum"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = ["astropy"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+viz = ["qgridnext", "lineid_plot"]
 test = ["pytest-astropy"]
 docs = ["sphinx-astropy"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 viz = ["qgridnext", "lineid_plot"]
-test = ["pytest-astropy"]
-docs = ["sphinx-astropy"]
 
 [project.scripts]
 cmfgen2tardis = "tardis.scripts.cmfgen2tardis:main"


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Moves lined_plot and qgridnext to optional dependencies in pyproject.toml

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
