### PR TITLE
use pytest.importorskip on optional visualization dependencies

### DIFF
--- a/tardis/visualization/tools/tests/test_lineid_plotter.py
+++ b/tardis/visualization/tools/tests/test_lineid_plotter.py
@@ -3,14 +3,8 @@ from tardis.visualization.tools.sdec_plot import SDECPlotter
 from matplotlib.testing.compare import compare_images
 
 # check if lineid_plot is installed
-try:
-    import lineid_plot
-
-    lineid_installed = True
-    from tardis.visualization.tools.lineid_plotter import lineid_plotter
-except ImportError:
-    lineid_installed = False
-
+lineid_plot = pytest.importorskip("lineid_plot", reason="lineid_plot is not installed")
+from tardis.visualization.tools.lineid_plotter import lineid_plotter
 
 @pytest.fixture(scope="module")
 def plotter(simulation_simple):

--- a/tardis/visualization/tools/tests/test_lineid_plotter.py
+++ b/tardis/visualization/tools/tests/test_lineid_plotter.py
@@ -43,9 +43,6 @@ def plotter(simulation_simple):
         ),
     ],
 )
-@pytest.mark.skipif(
-    not lineid_installed, reason="lineid_plot is not installed, skipping test"
-)
 def test_lineid_plotter(
     regression_data, plotter, tmp_path, wavelengths, labels, style
 ):

--- a/tardis/visualization/widgets/tests/test_line_info.py
+++ b/tardis/visualization/widgets/tests/test_line_info.py
@@ -4,6 +4,9 @@ import pytest
 from plotly.callbacks import BoxSelector, Points
 
 from tardis.util.base import species_string_to_tuple
+
+# check if qgrid is installed for the widgets
+qgrid = pytest.importorskip("qgrid", reason="qgrid is not installed")
 from tardis.visualization.widgets.line_info import LineInfoWidget
 
 

--- a/tardis/visualization/widgets/tests/test_line_info.py
+++ b/tardis/visualization/widgets/tests/test_line_info.py
@@ -6,7 +6,7 @@ from plotly.callbacks import BoxSelector, Points
 from tardis.util.base import species_string_to_tuple
 
 # check if qgrid is installed for the widgets
-qgrid = pytest.importorskip("qgrid", reason="qgrid is not installed")
+qgrid = pytest.importorskip("qgridnext", reason="qgrid is not installed")
 from tardis.visualization.widgets.line_info import LineInfoWidget
 
 

--- a/tardis/visualization/widgets/tests/test_line_info.py
+++ b/tardis/visualization/widgets/tests/test_line_info.py
@@ -6,7 +6,7 @@ from plotly.callbacks import BoxSelector, Points
 from tardis.util.base import species_string_to_tuple
 
 # check if qgrid is installed for the widgets
-qgrid = pytest.importorskip("qgridnext", reason="qgrid is not installed")
+qgridnext = pytest.importorskip("qgridnext", reason="qgridnext is not installed")
 from tardis.visualization.widgets.line_info import LineInfoWidget
 
 

--- a/tardis/visualization/widgets/tests/test_shell_info.py
+++ b/tardis/visualization/widgets/tests/test_shell_info.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas.testing as pdt
 import pytest
 
+qgrid = pytest.importorskip("qgrid", reason="qgrid is not installed")
 from tardis.visualization.widgets.shell_info import (
     BaseShellInfo,
     HDFShellInfo,

--- a/tardis/visualization/widgets/tests/test_shell_info.py
+++ b/tardis/visualization/widgets/tests/test_shell_info.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas.testing as pdt
 import pytest
 
-qgrid = pytest.importorskip("qgrid", reason="qgrid is not installed")
+qgrid = pytest.importorskip("qgridnext", reason="qgrid is not installed")
 from tardis.visualization.widgets.shell_info import (
     BaseShellInfo,
     HDFShellInfo,


### PR DESCRIPTION
### :pencil: Description

**Type:** :vertical_traffic_light: `testing` 

Now the widget tests are skipped in `gqrid` is not installed and both the `lineid_plotter` and `widget` tests now use `pytest.importorskip` to skip the test file if the required dependencies are not installed.