### PR TITLE
Add pinned env.yml for stable ASV benchmarking

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,11 @@
+name: tardis-asv
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - numpy=1.24.3
+  - scipy=1.10.1
+  - astropy=5.1
+  - pandas=1.4.4
+
+


### PR DESCRIPTION
This PR adds a env.yml Conda environment file that pins specific package versions used for benchmarking with ASV.

*Pins Python and key scientific libraries (numpy, scipy, astropy, pandas) to stable versions.

*Helps ensure consistent and reproducible benchmark results by avoiding unexpected dependency updates.

*Matches the environment used in development/testing as closely as possible.