### PR TITLE
add plugin to display writing symbol and not skip test

### DIFF
--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -4,8 +4,6 @@ from pathlib import Path
 
 import pytest
 from astropy.version import version as astropy_version
-import tardisbase.testing
-import tardisbase.testing
 
 from tardis import run_tardis
 from tardis.io.configuration.config_reader import Configuration


### PR DESCRIPTION
This is should be merged with https://github.com/tardis-sn/tardisbase/pull/17 to not break things.

This adds a plugin to change the behavior of the --generate-reference flag. Instead of calling pyest.skip() which immediately terminates the test, the test should continue with this and display a W and log the test with the "written" status.

This should specifically enable the behavior where you can do regression_data.sync_dataframe() on a test, and pass a different key, so that multiple dataframes can be saved to the same hdf file for the same test.

I believe np.save by default will also just append to the file sequentially and also read them in the same way (see https://numpy.org/doc/stable/reference/generated/numpy.save.html) so sync_ndararay might just work with no modifications. 