### PR TITLE
mention intel lockfile and tabs for different platforms to install docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ extensions = [
     "matplotlib.sphinxext.plot_directive",
     "sphinxcontrib.jquery",
     "nbsphinx",
+    "sphinx_tabs.tabs",
     "numpydoc",
     "recommonmark",
 ]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,19 +29,55 @@ We strongly recommend installing TARDIS using this method by following the steps
 
 1. Download the lockfile for your platform:
 
-   .. code-block:: bash
+   .. tabs:: 
 
-       wget -q https://github.com/tardis-sn/tardisbase/master/conda-{platform}-64.lock
+      .. group-tab:: OSX (Arm CPU)
 
-   Replace ``{platform}`` with ``linux`` or ``osx-arm`` based on your operating system.
+        .. code-block:: bash
+
+            wget -q https://github.com/tardis-sn/tardisbase/master/conda-osx-arm64.lock
+        
+      
+      .. group-tab:: Linux
+
+        .. code-block:: bash
+
+            wget -q https://github.com/tardis-sn/tardisbase/master/conda-linux-64.lock
+      
+      .. group-tab:: OSX (Intel CPU)
+
+        .. code-block:: bash
+
+            wget -q https://github.com/tardis-sn/tardisbase/master/conda-osx-64.lock
+        
+        .. warning::
+            Use at your own risk. This lockfile is not tested, so we recommend :ref:`running the test <running-tests>`) before using any of the TARDIS ecosystem packages with this environment.
 
 2. Create the environment:
 
-   .. code-block:: bash
+Replace ``{project_name}`` with a name for your TARDIS project.
 
-       conda create --name tardis-{project_name} --file conda-{platform}.lock
-       
-   Replace ``{project_name}`` with a name for your TARDIS project.
+   .. tabs:: 
+
+      .. group-tab:: OSX (Arm CPU)
+
+        .. code-block:: bash
+
+            conda create --name tardis-{project_name} --file conda-osx-arm64.lock
+        
+      
+      .. group-tab:: Linux
+
+        .. code-block:: bash
+
+            conda create --name tardis-{project_name} --file conda-linux-64.lock
+      
+      .. group-tab:: OSX (Intel CPU)
+
+        .. code-block:: bash
+
+            conda create --name tardis-{project_name} --file conda-osx-64.lock
+
 
 3. Activate the environment:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,7 @@ We strongly recommend installing TARDIS using this method by following the steps
             wget -q https://github.com/tardis-sn/tardisbase/master/conda-osx-64.lock
         
         .. warning::
-            Use at your own risk. This lockfile is not tested, so we recommend :ref:`running the test <running-tests>`) before using any of the TARDIS ecosystem packages with this environment.
+            Use at your own risk. This lockfile is not tested, so we recommend :ref:`running the test <running-tests>` before using any of the TARDIS ecosystem packages with this environment.
 
 2. Create the environment:
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` 

Adds the intel cpu lockfile to the installation instructions and uses [`sphinx-tabs`](https://sphinx-tabs.readthedocs.io/en/latest/) to have tabs per platform.

<img width="914" alt="Screenshot 2025-06-23 at 7 29 53 PM" src="https://github.com/user-attachments/assets/5e570ac3-7842-4c7a-b4d4-5e8c506c01ac" />

The intel cpu tab includes a warning about that lack of testing for its lockfile.
<img width="934" alt="Screenshot 2025-06-23 at 7 30 11 PM" src="https://github.com/user-attachments/assets/5ef551e3-9548-45f4-9a2a-d4bc0037fa55" />


