### PR TITLE
mention the intel lockfile in installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,9 +31,12 @@ We strongly recommend installing TARDIS using this method by following the steps
 
    .. code-block:: bash
 
-       wget -q https://github.com/tardis-sn/tardisbase/master/conda-{platform}-64.lock
+       wget -q https://github.com/tardis-sn/tardisbase/master/conda-{platform}.lock
 
-   Replace ``{platform}`` with ``linux`` or ``osx-arm`` based on your operating system.
+   Replace ``{platform}`` with ``linux-64``, ``osx-arm64``, or ``osx-64`` (Mac Intel CPU) based on your operating system and CPU architecture.
+
+   .. warning::
+            Use the ``conda-osx-64.lock`` at your own risk. This lockfile is not tested, so we recommend :ref:`running the tests <running-tests>` before using any of the TARDIS ecosystem packages with this environment. 
 
 2. Create the environment:
 


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation`

Updated the installation documentation to mention the existence of the lockfile for Mac's with Intel CPUs.  Also, includes a warning about the lockfile not being tested.

Before:
<img width="915" alt="Screenshot 2025-06-27 at 10 56 39 AM" src="https://github.com/user-attachments/assets/12757b7c-90ff-4ceb-a45f-c116bf758e16" />

After:
<img width="920" alt="Screenshot 2025-06-27 at 10 56 12 AM" src="https://github.com/user-attachments/assets/1002119d-45ff-4bcf-bb62-7863d6164c67" />

### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label
