### PR TITLE
Relativity BugFix [2]

### DIFF
--- a/tardis/transport/montecarlo/packet_source.py
+++ b/tardis/transport/montecarlo/packet_source.py
@@ -334,7 +334,7 @@ class BlackBodySimpleSourceRelativistic(BlackBodySimpleSource, HDFWriterMixin):
         """
         if self.radius is None or self.time_explosion is None:
             raise ValueError("Black body Radius or Time of Explosion isn't set")
-        self.beta = ((self.radius / self.time_explosion) / const.c).to(u.dimensionless_unscaled).to_value()
+        self.beta = ((self.radius / self.time_explosion) / const.c).to(u.dimensionless_unscaled).value
         return super().create_packets(no_of_packets, *args, **kwargs)
 
     def create_packet_mus(self, no_of_packets):


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

A small one line modification to beta caused the spectrum to change when relativity is turned on

Beta was modified in April 4- 
https://github.com/tardis-sn/tardis/pull/2542
 
<img width="867" alt="image" src="https://github.com/user-attachments/assets/d43d6c40-42f2-4757-92c0-e64a1d636dde" />

<img width="826" alt="image" src="https://github.com/user-attachments/assets/2aa7bbb7-923d-4960-86fd-2cfd31d6dcd7" />


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
