### PR TITLE
Fix missing hyperlink for the tutorial notebooks in doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -374,7 +374,7 @@ def generate_tutorials_page(app):
 
     for notebook in io_path.rglob("*.ipynb"):
         if "tutorial_" in notebook.name and "checkpoint" not in notebook.name:
-            notebooks += f"\n* :doc:`{notebook.stem}`"
+            notebooks += f"\n* :doc:`{notebook.parent}/{notebook.stem}`"
 
     title = "Tutorials\n*********\n"
     description = "The following pages contain the TARDIS tutorials:"
@@ -389,7 +389,7 @@ def generate_how_to_guides_page(app):
 
     for notebook in io_path.rglob("*.ipynb"):
         if "how_to_" in notebook.name and "checkpoint" not in notebook.name:
-            notebooks += f"\n* :doc:`{notebook.stem}`"
+            notebooks += f"\n* :doc:`{notebook.parent}/{notebook.stem}`"
 
     title = "How-To Guides\n*********\n"
     description = "The following pages contain the TARDIS how-to guides:"
@@ -404,7 +404,7 @@ def generate_worflows_page(app):
 
     for notebook in workflows_path.rglob("*.ipynb"):
         if "workflow" in notebook.name and "checkpoint" not in notebook.name:
-            notebooks += f"\n* :doc:`{notebook.stem}`" 
+            notebooks += f"\n* :doc:`{notebook.parent}/{notebook.stem}`"
 
     title = "Workflows\n*********\n"
     description = "The following pages contain the TARDIS workflows:\n\n These examples are intended to help users explore specific modules within TARDIS, with the goal of supporting their individual scientific objectives."

--- a/docs/workflows/simple_workflow_equilibrium.ipynb
+++ b/docs/workflows/simple_workflow_equilibrium.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Equilibrium Plasma Workflow"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -203,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -108,7 +108,7 @@
    "source": [
     "spectrum = workflow.spectrum_solver.spectrum_real_packets\n",
     "spectrum_virtual = workflow.spectrum_solver.spectrum_virtual_packets\n",
-    "spectrum_integrated = workflow.spectrum_solver.spectrum_integrated"
+    "# spectrum_integrated = workflow.spectrum_solver.spectrum_integrated"
    ]
   },
   {
@@ -122,7 +122,7 @@
     "\n",
     "spectrum.plot(label=\"Normal packets\")\n",
     "spectrum_virtual.plot(label=\"Virtual packets\")\n",
-    "spectrum_integrated.plot(label='Formal integral')\n",
+    "# spectrum_integrated.plot(label='Formal integral')\n",
     "\n",
     "plt.xlim(500, 9000)\n",
     "plt.title(\"TARDIS example model spectrum\")\n",

--- a/docs/workflows/workflow_notebook.ipynb
+++ b/docs/workflows/workflow_notebook.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TARDIS High Energy (HE) Workflow"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
Fixing Issue #3079 that the notebook links are missing in the documentation page. 

Meantime also added simple title description for two of the new workflow notebooks. 

For the v_inner_workflow, the formal integral is commented for now due to dimensionality incompatible issue (probably because the v_inner is not at first shell.).