### PR TITLE
3131: solved Docs Template contains fork reference

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,21 +1,33 @@
-{% extends "!layout.html" %}
-{% block doctype %}
+{% extends "!layout.html" %} {% block doctype %}
 <!DOCTYPE html>
-{% endblock %}
-{# Add github banner (from: https://github.com/blog/273-github-ribbons). #}
-{% block header %}
-  {{ super() }}
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-53HJHD1BWS"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
+{% endblock %} {# Add github banner (from:
+https://github.com/blog/273-github-ribbons). #} {% block header %} {{ super() }}
+<!-- Google tag (gtag.js) -->
+<script
+  async
+  src="https://www.googletagmanager.com/gtag/js?id=G-53HJHD1BWS"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
 
-    gtag('config', 'G-53HJHD1BWS');
-  </script>
-  <a href="http://github.com/wkerzendorf/tardis"><img style="position: fixed; top: 0px; right: 0; border: 0; z-index: 100000;image-orientation: 90deg;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"/></a>
-{% endblock %}
-{% block extrahead %}
-    <link href="{{ pathto("_static/tardis.css", True) }}" rel="stylesheet" type="text/css">
-{% endblock %}
+  gtag("config", "G-53HJHD1BWS");
+</script>
+<a href="https://github.com/tardis-sn/tardis"
+  ><img
+    style="
+      position: fixed;
+      top: 0px;
+      right: 0;
+      border: 0;
+      z-index: 100000;
+      image-orientation: 90deg;
+    "
+    src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png"
+    alt="Fork me on GitHub"
+/></a>
+{% endblock %} {% block extrahead %} <link href="{{ pathto("_static/tardis.css",
+True) }}" rel="stylesheet" type="text/css"> {% endblock %}


### PR DESCRIPTION
The link was referring to a fork repository. Now it is referring to tardis repository
<img width="280" height="23" alt="tardis" src="https://github.com/user-attachments/assets/01968db8-10ed-4923-83c9-fe1c61af973a" />

[resolved issue 
](https://github.com/tardis-sn/tardis/issues/3131)
