### PR TITLE
3131: solved Docs Template contains fork reference

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -14,7 +14,7 @@
 
     gtag('config', 'G-53HJHD1BWS');
   </script>
-  <a href="http://github.com/wkerzendorf/tardis"><img style="position: fixed; top: 0px; right: 0; border: 0; z-index: 100000;image-orientation: 90deg;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"/></a>
+  <a href="https://github.com/tardis-sn/tardis"><img style="position: fixed; top: 0px; right: 0; border: 0; z-index: 100000;image-orientation: 90deg;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"/></a>
 {% endblock %}
 {% block extrahead %}
     <link href="{{ pathto("_static/tardis.css", True) }}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
The link was referring to a fork repository. Now it is referring to tardis repository
This is a follow-up to PR #3199, created as a clean version with only the intended change.

<img width="611" height="29" alt="image" src="https://github.com/user-attachments/assets/22774081-6016-4f7b-843e-a86d73d8e7a0" />
Resolved #3131 
Please let me know if further correction needed!