### PR TITLE
Add the non-numba opacity_state as a attribute of the simulation object

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -422,7 +422,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             self.plasma.beta_sobolev = None
             macro_atom_state = None
 
-        opacity_state = self.opacity.legacy_solve(self.plasma)
+        self.opacity_state = self.opacity.legacy_solve(self.plasma)
         if self.macro_atom is not None:
             if montecarlo_globals.CONTINUUM_PROCESSES_ENABLED:
                 macro_atom_state = LegacyMacroAtomState.from_legacy_plasma(
@@ -432,14 +432,14 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 macro_atom_state = self.macro_atom.solve(
                     self.plasma.j_blues,
                     self.plasma.atomic_data,
-                    opacity_state.tau_sobolev,
+                    self.opacity_state.tau_sobolev,
                     self.plasma.stimulated_emission_factor,
-                    opacity_state.beta_sobolev,
+                    self.opacity_state.beta_sobolev,
                 )
 
         transport_state = self.transport.initialize_transport_state(
             self.simulation_state,
-            opacity_state,
+            self.opacity_state,
             macro_atom_state,
             self.plasma,
             no_of_packets,


### PR DESCRIPTION
When calculating the integrated tau using the `tardis.workflows.util.get_tau_integ`, the opacity_state should be the non-numba version, in which the opacity_state.tau_sobolev is a dataframe with atomic number, ionization number and level number as indexes. 

However, currently the non-numba opacity_state is not a attribute of the simulation object, and the only opacity state we can access is the `simulation.transport.transport_state.opacity_state`, which is a numba version. 

In this PR, the quick fix is to add the opacity_state as a attribute of the simulation class. The `simulation.transport.transport_state.opacity_state` should be renamed to be more clear about this, see issue #3206
