### PR TITLE
Return formal integral to `v_inner_solver_workflow.ipynb`

### DIFF
--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -222,11 +222,10 @@
     "cbar.set_label('Iteration Number', fontsize=12)"
    ]
   },
-# (Remove the above block entirely; no replacement lines are needed.)
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tardis-dev",
+   "display_name": "tardis",
    "language": "python",
    "name": "python3"
   },
@@ -240,7 +239,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -108,7 +108,7 @@
    "source": [
     "spectrum = workflow.spectrum_solver.spectrum_real_packets\n",
     "spectrum_virtual = workflow.spectrum_solver.spectrum_virtual_packets\n",
-    "# spectrum_integrated = workflow.spectrum_solver.spectrum_integrated"
+    "spectrum_integrated = workflow.spectrum_solver.spectrum_integrated"
    ]
   },
   {
@@ -122,7 +122,7 @@
     "\n",
     "spectrum.plot(label=\"Normal packets\")\n",
     "spectrum_virtual.plot(label=\"Virtual packets\")\n",
-    "# spectrum_integrated.plot(label='Formal integral')\n",
+    "spectrum_integrated.plot(label='Formal integral')\n",
     "\n",
     "plt.xlim(500, 9000)\n",
     "plt.title(\"TARDIS example model spectrum\")\n",
@@ -221,11 +221,18 @@
     "cbar = fig.colorbar(sm, ax=axes, orientation='vertical', fraction=0.025, pad=0.02)\n",
     "cbar.set_label('Iteration Number', fontsize=12)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tardis",
+   "display_name": "tardis-dev",
    "language": "python",
    "name": "python3"
   },
@@ -239,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -222,13 +222,7 @@
     "cbar.set_label('Iteration Number', fontsize=12)"
    ]
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
+# (Remove the above block entirely; no replacement lines are needed.)
  ],
  "metadata": {
   "kernelspec": {

--- a/docs/workflows/v_inner_solver_workflow.ipynb
+++ b/docs/workflows/v_inner_solver_workflow.ipynb
@@ -221,7 +221,7 @@
     "cbar = fig.colorbar(sm, ax=axes, orientation='vertical', fraction=0.025, pad=0.02)\n",
     "cbar.set_label('Iteration Number', fontsize=12)"
    ]
-  },
+  }
  ],
  "metadata": {
   "kernelspec": {


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` 

The formal integral is fixed, so it can be run in the `v_inner_solver_workflow.ipynb`

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline - tests pass
- [x] Other method - built the docs locally

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
