### PR TITLE
fix \AA warnings with raw string

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -165,8 +165,8 @@
     "\n",
     "plt.xlim(500, 9000)\n",
     "plt.title(\"TARDIS example model spectrum\")\n",
-    "plt.xlabel(\"Wavelength [$\\AA$]\")\n",
-    "plt.ylabel(\"Luminosity density [erg/s/$\\AA$]\")\n",
+    "plt.xlabel(r\"Wavelength [$\\AA$]\")\n",
+    "plt.ylabel(r\"Luminosity density [erg/s/$\\AA$]\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation` 

Made the plot label inputs raw strings to remove the `SyntaxWarning: invalid escape sequence '\A'`.  (Same as stardis [PR#256](https://github.com/tardis-sn/stardis/pull/265).


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
