### PR TITLE
fix more \AA warnings

### DIFF
--- a/docs/io/optional/how_to_custom_source.ipynb
+++ b/docs/io/optional/how_to_custom_source.ipynb
@@ -196,8 +196,8 @@
     "plt.plot(mdl_norm.spectrum_solver.spectrum_virtual_packets.wavelength,\n",
     "         mdl_norm.spectrum_solver.spectrum_virtual_packets.luminosity_density_lambda,\n",
     "         color='blue', label='normal blackbody (default packet source)')\n",
-    "plt.xlabel('$\\lambda [\\AA]$')\n",
-    "plt.ylabel('$L_\\lambda$ [erg/s/$\\AA$]')\n",
+    "plt.xlabel(r'$\\lambda [\\AA]$')\n",
+    "plt.ylabel(r'$L_\\lambda$ [erg/s/$\\AA$]')\n",
     "plt.xlim(500, 10000)\n",
     "plt.legend()"
    ]

--- a/docs/workflows/simple_workflow.ipynb
+++ b/docs/workflows/simple_workflow.ipynb
@@ -85,8 +85,8 @@
     "\n",
     "plt.xlim(500, 9000)\n",
     "plt.title(\"TARDIS example model spectrum\")\n",
-    "plt.xlabel(\"Wavelength [$\\AA$]\")\n",
-    "plt.ylabel(\"Luminosity density [erg/s/$\\AA$]\")\n",
+    "plt.xlabel(r\"Wavelength [$\\AA$]\")\n",
+    "plt.ylabel(r\"Luminosity density [erg/s/$\\AA$]\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]

--- a/docs/workflows/simple_workflow_equilibrium.ipynb
+++ b/docs/workflows/simple_workflow_equilibrium.ipynb
@@ -342,8 +342,8 @@
     "\n",
     "plt.xlim(500, 9000)\n",
     "plt.title(\"TARDIS example model spectrum\")\n",
-    "plt.xlabel(\"Wavelength [$\\AA$]\")\n",
-    "plt.ylabel(\"Luminosity density [erg/s/$\\AA$]\")\n",
+    "plt.xlabel(r\"Wavelength [$\\AA$]\")\n",
+    "plt.ylabel(r\"Luminosity density [erg/s/$\\AA$]\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]

--- a/docs/workflows/standard_workflow.ipynb
+++ b/docs/workflows/standard_workflow.ipynb
@@ -85,8 +85,8 @@
     "\n",
     "plt.xlim(500, 9000)\n",
     "plt.title(\"TARDIS example model spectrum\")\n",
-    "plt.xlabel(\"Wavelength [$\\AA$]\")\n",
-    "plt.ylabel(\"Luminosity density [erg/s/$\\AA$]\")\n",
+    "plt.xlabel(r\"Wavelength [$\\AA$]\")\n",
+    "plt.ylabel(r\"Luminosity density [erg/s/$\\AA$]\")\n",
     "plt.legend()\n",
     "plt.show()"
    ]


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation` 

Turn plot label strings into raw strings to remove `SyntaxWarning: invalid escape sequence '\A'` (as in [PR#3209](https://github.com/tardis-sn/tardis/pull/3209)).

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
