### PR TITLE
Restructure/transport solver v1

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -438,7 +438,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 )
 
         transport_state = self.transport.initialize_transport_state(
-            self.simulation_state,
+            self.simulation_state.geometry,
             self.opacity_state,
             macro_atom_state,
             self.plasma,

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -437,7 +437,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                     self.opacity_state.beta_sobolev,
                 )
 
-        transport_state = self.transport.initialize_transport_state(
+        v_packets_energy_hist = self.transport.run(
             self.simulation_state.geometry,
             self.opacity_state,
             macro_atom_state,
@@ -445,14 +445,12 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
             no_of_packets,
             no_of_virtual_packets=no_of_virtual_packets,
             iteration=self.iterations_executed,
-        )
-
-        v_packets_energy_hist = self.transport.run(
-            transport_state,
-            iteration=self.iterations_executed,
             total_iterations=self.iterations,
             show_progress_bars=self.show_progress_bars,
         )
+
+        # Get transport state for further processing
+        transport_state = self.transport.transport_state
 
         output_energy = self.transport.transport_state.packet_collection.output_energies
         if np.sum(output_energy < 0) == len(output_energy):

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -97,7 +97,7 @@ class MonteCarloTransportSolver(HDFWriterMixin):
 
     def initialize_transport_state(
         self,
-        simulation_state,
+        geometry_state,
         opacity_state,
         macro_atom_state,
         plasma,
@@ -114,13 +114,13 @@ class MonteCarloTransportSolver(HDFWriterMixin):
             no_of_packets, seed_offset=iteration
         )
 
-        geometry_state = simulation_state.geometry.to_numba()
+        geometry_state_numba = geometry_state.to_numba()
         opacity_state_numba = opacity_state.to_numba(
             macro_atom_state,
             self.line_interaction_type,
         )
         opacity_state_numba = opacity_state_numba[
-            simulation_state.geometry.v_inner_boundary_index : simulation_state.geometry.v_outer_boundary_index
+            geometry_state.v_inner_boundary_index : geometry_state.v_outer_boundary_index
         ]
 
         estimators = initialize_estimator_statistics(
@@ -130,9 +130,9 @@ class MonteCarloTransportSolver(HDFWriterMixin):
         transport_state = MonteCarloTransportState(
             packet_collection,
             estimators,
-            geometry_state=geometry_state,
+            geometry_state=geometry_state_numba,
             opacity_state=opacity_state_numba,
-            time_explosion=simulation_state.time_explosion,
+            time_explosion=geometry_state.time_explosion,
         )
 
         transport_state.enable_full_relativity = (

--- a/tardis/transport/montecarlo/base.py
+++ b/tardis/transport/montecarlo/base.py
@@ -147,7 +147,12 @@ class MonteCarloTransportSolver(HDFWriterMixin):
 
     def run(
         self,
-        transport_state,
+        geometry_state,
+        opacity_state,
+        macro_atom_state,
+        plasma,
+        no_of_packets,
+        no_of_virtual_packets=0,
         iteration=0,
         total_iterations=0,
         show_progress_bars=True,
@@ -157,18 +162,43 @@ class MonteCarloTransportSolver(HDFWriterMixin):
 
         Parameters
         ----------
-        model : tardis.model.SimulationState
+        geometry_state : tardis.model.geometry.Geometry
+            The geometry state of the simulation
+        opacity_state : tardis.opacities.opacity_state.OpacityState
+            The opacity state
+        macro_atom_state : tardis.opacities.macro_atom.macroatom_state.LegacyMacroAtomState
+            The macro atom state
         plasma : tardis.plasma.BasePlasma
+            The plasma state
         no_of_packets : int
+            Number of packets to run
         no_of_virtual_packets : int
+            Number of virtual packets
+        iteration : int
+            Current iteration number
         total_iterations : int
             The total number of iterations in the simulation.
+        show_progress_bars : bool
+            Whether to show progress bars
 
         Returns
         -------
-        None
+        v_packets_energy_hist : numpy.ndarray
+            Virtual packet energy histogram
         """
         set_num_threads(self.nthreads)
+
+        # Initialize transport state
+        transport_state = self.initialize_transport_state(
+            geometry_state,
+            opacity_state,
+            macro_atom_state,
+            plasma,
+            no_of_packets,
+            no_of_virtual_packets=no_of_virtual_packets,
+            iteration=iteration,
+        )
+
         self.transport_state = transport_state
 
         number_of_vpackets = self.montecarlo_configuration.NUMBER_OF_VPACKETS

--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -403,7 +403,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
         macro_atom_state = opacity_states["macro_atom_state"]
 
         self.transport_state = self.transport_solver.initialize_transport_state(
-            self.simulation_state,
+            self.simulation_state.geometry,
             opacity_state,
             macro_atom_state,
             self.plasma_solver,


### PR DESCRIPTION
This pull request refactors the transport-related code in the TARDIS simulation framework to improve modularity and clarity. The changes primarily involve decoupling the `geometry_state` from the `simulation_state` and updating method signatures and logic accordingly. The most significant updates are detailed below.

### Refactoring of Transport State Initialization and Usage

* The `initialize_transport_state` method in `tardis/transport/montecarlo/base.py` now accepts `geometry_state` instead of `simulation_state`, improving separation of concerns. The `geometry_state` is converted to a Numba-compatible format (`geometry_state_numba`) for further processing. [[1]](diffhunk://#diff-b4d4fe6b28a99493db197b52c0a68a8403df1abd4b48d085e3184ed32518004aL100-R100) [[2]](diffhunk://#diff-b4d4fe6b28a99493db197b52c0a68a8403df1abd4b48d085e3184ed32518004aL117-R123) [[3]](diffhunk://#diff-b4d4fe6b28a99493db197b52c0a68a8403df1abd4b48d085e3184ed32518004aL133-R135)

* The `run` method in `tardis/transport/montecarlo/base.py` has been updated to directly initialize the transport state using the decoupled `geometry_state`, `opacity_state`, `macro_atom_state`, and other parameters. It now returns a virtual packet energy histogram (`v_packets_energy_hist`). [[1]](diffhunk://#diff-b4d4fe6b28a99493db197b52c0a68a8403df1abd4b48d085e3184ed32518004aL150-R155) [[2]](diffhunk://#diff-b4d4fe6b28a99493db197b52c0a68a8403df1abd4b48d085e3184ed32518004aL160-R201)

### Updates to Simulation Workflow

* In `tardis/simulation/base.py`, the `iterate` method has been updated to call the refactored `run` method instead of initializing the transport state separately. This change simplifies the workflow and aligns with the new method signature.

* The `solve_montecarlo` method in `tardis/workflows/simple_tardis_workflow.py` has been updated to pass `geometry_state` instead of `simulation_state` when initializing the transport state.