### PR TITLE
Continuum transition probabilities

### DIFF
--- a/tardis/opacities/macro_atom/macroatom_transitions.py
+++ b/tardis/opacities/macro_atom/macroatom_transitions.py
@@ -307,7 +307,7 @@ def set_index(p, photo_ion_idx, transition_type=0, reverse=True):
         p = p.set_index(index, drop=True)
         return p
 
-def recombination(alpha_sp, nu_i, energy_i, photoionization_index):
+def continuum_transition_recombination(alpha_sp, nu_i, energy_i, photoionization_index):
     '''Unnormalized probabilities of radiative recombination
     alpha_sp : pandas.Series, dtype float
         Rate coefficient for spontaneous recombination from `k` to level `i`
@@ -352,7 +352,7 @@ def recombination(alpha_sp, nu_i, energy_i, photoionization_index):
     return p_recombination, recombination_metadata
 
 
-def photoionization(gamma_corr, energy_i, photo_ion_idx):
+def continuum_transition_photoionization(gamma_corr, energy_i, photo_ion_idx):
     '''
     Photoionization probability unnormalized
         gamma_corr : pandas.Series, dtype float
@@ -386,7 +386,7 @@ def photoionization(gamma_corr, energy_i, photo_ion_idx):
 
 
 
-def collisional(
+def continuum_transition_collisional(
     self,
     coll_exc_coeff,
     coll_deexc_coeff,


### PR DESCRIPTION
### :pencil: Added computation for the continuum transition probabilities for the macroatom to the macroatom transition probabilities

**Type:** ::roller_coaster: `infrastructure`

This creates more generic functions for computing the recombination, photoionization, and collisional transition probabilities from the macroatom that don't require the full plasma to compute.

depends on #3070 (sort of, it is independent but is really only useful with that PR)

### :pushpin: Resources

None right now

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)
- [x] My changes haven't been tested (And is marked draft)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label


