### PR TITLE
Revert "Restructure/transport solver v1"

### DIFF
--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -437,20 +437,22 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                     self.opacity_state.beta_sobolev,
                 )
 
-        v_packets_energy_hist = self.transport.run(
-            self.simulation_state.geometry,
+        transport_state = self.transport.initialize_transport_state(
+            self.simulation_state,
             self.opacity_state,
             macro_atom_state,
             self.plasma,
             no_of_packets,
             no_of_virtual_packets=no_of_virtual_packets,
             iteration=self.iterations_executed,
+        )
+
+        v_packets_energy_hist = self.transport.run(
+            transport_state,
+            iteration=self.iterations_executed,
             total_iterations=self.iterations,
             show_progress_bars=self.show_progress_bars,
         )
-
-        # Get transport state for further processing
-        transport_state = self.transport.transport_state
 
         output_energy = self.transport.transport_state.packet_collection.output_energies
         if np.sum(output_energy < 0) == len(output_energy):

--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -403,7 +403,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
         macro_atom_state = opacity_states["macro_atom_state"]
 
         self.transport_state = self.transport_solver.initialize_transport_state(
-            self.simulation_state.geometry,
+            self.simulation_state,
             opacity_state,
             macro_atom_state,
             self.plasma_solver,


### PR DESCRIPTION
Reverts tardis-sn/tardis#3218

This PR broke some fundamental features of the workflow, and I strongly disagree with the approach taken to break up the transport state and generally move away from the intended state-solver design pattern.