### PR TITLE
`docstr` coverage ignore tests

### DIFF
--- a/.github/workflows/docstr-cov.yml
+++ b/.github/workflows/docstr-cov.yml
@@ -69,4 +69,36 @@ jobs:
 
       - name: Get new coverage
         run: echo "NEW_COV=$(interrogate tardis -c pyproject.toml | python .ci-helpers/get_min_docstr_cov.py)" >> $GITHUB_ENV
-        if: always()
+        if: always() && github.event_name == 'push'
+
+      - name: Set label color
+        run: |
+          if [[ $NEW_COV -ge $(echo {${{ env.RANGE }}} | awk '{print $NF;}') ]]; then
+            echo "COLOR=green" >> $GITHUB_ENV
+
+          elif [[ $NEW_COV -lt $(echo {${{ env.RANGE }}} | awk '{print $1;}') ]]; then
+            echo "COLOR=red" >> $GITHUB_ENV
+
+          else
+            echo "COLOR=orange" >> $GITHUB_ENV
+
+          fi
+        if: always() && github.event_name == 'push'
+
+      - name: Post results
+        run: |
+          echo "New coverage is: $NEW_COV%"
+          curl -X POST $ENDPOINT/badges/docstr-cov \
+          -H "authorization: token $TOKEN" \
+          -d "{ \"schemaVersion\": 1, \"label\": \"docstr-cov\", \
+                \"message\": \"$NEW_COV%\", \"color\": \"$COLOR\" }"
+        if: always() && github.event_name == 'push'
+
+      - name: Set public endpoint
+        run: |
+          curl -X PUT $ENDPOINT/_perms -H "authorization: token $TOKEN"
+        if: always() && github.event_name == 'push'
+
+      - name: Show badge URL
+        run: echo "https://img.shields.io/endpoint?url=$ENDPOINT/badges/docstr-cov"
+        if: always() && github.event_name == 'push'


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The exclude option was commented out- this adds that back and adds the tests regex to filter tests

Previously- 
```
d69f790f0e32ac0c24b18a226c8d552e18f5b08d coverage was: 67.25%
Previous HEAD position was d69f790f0 Fix default `interpolate_shells` in Formal Integral (#3249)
HEAD is now at 615106f5c more regex
/opt/hostedtoolcache/Python/3.13.6/x64/lib/python3.13/site-packages/interrogate/badge_gen.py:11: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
============= Coverage for /home/runner/work/tardis/tardis/tardis/ =============
----------------------------------- Summary ------------------------------------
| Name                                                                   | Total | Miss | Cover | Cover% |
|------------------------------------------------------------------------|-------|------|-------|--------|
| analysis.py                                                            |    19 |   18 |     1 |     5% |
| base.py                                                                |     1 |    0 |     1 |   100% |
| conftest.py                                                            |    15 |   14 |     1 |     7% |
| analysis/opacities.py                                                  |     1 |    0 |     1 |   100% |
| energy_input/decay_radiation.py                                        |     1 |    0 |     1 |   100% |
| energy_input/energy_source.py                                          |     9 |    0 |     9 |   100% |
| energy_input/gamma_ray_channel.py                                      |     5 |    0 |     5 |   100% |
| energy_input/gamma_ray_estimators.py                                   |     6 |    4 |     2 |    33% |
| energy_input/gamma_ray_packet_source.py                                |    10 |    1 |     9 |    90% |
| energy_input/gamma_ray_transport.py                                    |     4 |    3 |     1 |    25% |
| energy_input/main_gamma_ray_loop.py                                    |     4 |    0 |     4 |   100% |
| energy_input/nuclear_energy_source.py                                  |     2 |    0 |     2 |   100% |
| energy_input/samplers.py                                               |     8 |    1 |     7 |    88% |
| energy_input/util.py                                                   |    18 |    0 |    18 |   100% |
| energy_input/tests/test_gamma_ray_channel.py                           |     2 |    0 |     2 |   100% |
| energy_input/tests/test_gamma_ray_packet_source_minimal.py             |    10 |    0 |    10 |   100% |
| energy_input/tests/test_gamma_ray_transport.py                         |     3 |    0 |     3 |   100% |
| energy_input/transport/GXPacket.py                                     |     4 |    1 |     3 |    75% |
| energy_input/transport/gamma_packet_loop.py                            |     2 |    0 |     2 |   100% |
| energy_input/transport/gamma_ray_grid.py                               |     3 |    0 |     3 |   100% |
| energy_input/transport/gamma_ray_interactions.py                       |     7 |    0 |     7 |   100% |
| energy_input/transport/tests/conftest.py                               |     1 |    0 |     1 |   100% |
| grid/base.py                                                           |     6 |    0 |     6 |   100% |
| gui/datahandler.py                                                     |    37 |    0 |    37 |   100% |
| gui/interface.py                                                       |     1 |    0 |     1 |   100% |
| gui/widgets.py                                                         |    46 |    0 |    46 |   100% |
| gui/tests/test_gui.py                                                  |     2 |    2 |     0 |     0% |
| io/hdf_writer_mixin.py                                                 |     8 |    0 |     8 |   100% |
| io/util.py                                                             |    12 |    0 |    12 |   100% |
| io/atom_data/atom_web_download.py                                      |     2 |    0 |     2 |   100% |
| io/atom_data/base.py        
```

Now- 
```
d69f790f0e32ac0c24b18a226c8d552e18f5b08d coverage was: 67.25%
Previous HEAD position was d69f790f0 Fix default `interpolate_shells` in Formal Integral (#3249)
HEAD is now at b53566d57 exclude option
/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/site-packages/interrogate/badge_gen.py:11: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
============= Coverage for /home/runner/work/tardis/tardis/tardis/ =============
----------------------------------- Summary ------------------------------------
| Name                                                                   | Total | Miss | Cover | Cover% |
|------------------------------------------------------------------------|-------|------|-------|--------|
| analysis.py                                                            |    19 |   18 |     1 |     5% |
| base.py                                                                |     1 |    0 |     1 |   100% |
| analysis/opacities.py                                                  |     1 |    0 |     1 |   100% |
| energy_input/decay_radiation.py                                        |     1 |    0 |     1 |   100% |
| energy_input/energy_source.py                                          |     9 |    0 |     9 |   100% |
| energy_input/gamma_ray_channel.py                                      |     5 |    0 |     5 |   100% |
| energy_input/gamma_ray_estimators.py                                   |     6 |    4 |     2 |    33% |
| energy_input/gamma_ray_packet_source.py                                |    10 |    1 |     9 |    90% |
| energy_input/gamma_ray_transport.py                                    |     4 |    3 |     1 |    25% |
| energy_input/main_gamma_ray_loop.py                                    |     4 |    0 |     4 |   100% |
| energy_input/nuclear_energy_source.py                                  |     2 |    0 |     2 |   100% |
| energy_input/samplers.py                                               |     8 |    1 |     7 |    88% |
| energy_input/util.py                                                   |    18 |    0 |    18 |   100% |
| energy_input/transport/GXPacket.py                                     |     4 |    1 |     3 |    75% |
| energy_input/transport/gamma_packet_loop.py                            |     2 |    0 |     2 |   100% |
| energy_input/transport/gamma_ray_grid.py                               |     3 |    0 |     3 |   100% |
| energy_input/transport/gamma_ray_interactions.py                       |     7 |    0 |     7 |   100% |
| grid/base.py                                                           |     6 |    0 |     6 |   100% |
| gui/datahandler.py                                                     |    37 |    0 |    37 |   100% |
| gui/interface.py                                                       |     1 |    0 |     1 |   100% |
| gui/widgets.py                                                         |    46 |    0 |    46 |   100% |
| io/hdf_writer_mixin.py                                                 |     8 |    0 |     8 |   100% |
| io/util.py                                                             |    12 |    0 |    12 |   100% |
| io/atom_data/atom_web_download.py                                      |     2 |    0 |     2 |   100% |
| io/atom_data/base.py                                                   |    11 |    4 |     7 |    64% |
| io/atom_data/collision_data.py                                         |     2 |    0 |     2 |   100% |
| io/atom_data/macro_atom_data.py                                        |     1 |    0 |     1 |   100% |
| io/atom_data/nlte_data.py                                              |     2 |    1 |     1 |    50% |
| io/atom_data/util.py                                                   |     1 |    0 |     1 |   100% |
| io/configuration/config_internal.py                                    |     2 |    2 |     0 |     0% |
| io/configuration/config_reader.py                                      |    18 |    4 |    14 |    78% |
| io/configuration/config_validator.py                                  
```


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
