### PR TITLE
Use lockfiles from TARDIS instead of from TARDISBase

### DIFF
--- a/.github/actions/setup_env/action.yml
+++ b/.github/actions/setup_env/action.yml
@@ -11,6 +11,6 @@ runs:
   using: "composite"
   steps:
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: ${{ inputs.os-label }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -102,7 +102,7 @@ jobs:
           atom-data-sparse: true
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: linux-64
           lockfile-path: ./conda-linux-64.lock

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -29,7 +29,7 @@ jobs:
         if: github.event_name == 'pull_request_target'
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: "linux-64"
           lockfile-path: ./conda-linux-64.lock

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: linux-64
           lockfile-path: ./conda-linux-64.lock

--- a/.github/workflows/compare-regdata.yml
+++ b/.github/workflows/compare-regdata.yml
@@ -128,7 +128,7 @@ jobs:
         uses: ./.github/actions/setup_lfs
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: ${{ matrix.label }}
           lockfile-path: ./conda-${{ matrix.label }}.lock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: "linux-64"
           lockfile-path: ./conda-linux-64.lock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
         uses: tardis-sn/tardis-actions/setup-lfs@main
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: ${{ matrix.label }}
           lockfile-path: ./conda-${{ matrix.label }}.lock
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup environment
-        uses: tardis-sn/tardis-actions/setup-env@lockfile-path
+        uses: tardis-sn/tardis-actions/setup-env@main
         with:
           os-label: linux-64
           lockfile-path: ./conda-linux-64.lock


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

https://github.com/tardis-sn/tardis/issues/3151#issuecomment-3224558294
- [X] Requires https://github.com/tardis-sn/tardis-actions/pull/7 to be merged before. 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
