### PR TITLE
Fix macroatom docs break

### DIFF
--- a/docs/tutorials/run_montecarlo_transport.ipynb
+++ b/docs/tutorials/run_montecarlo_transport.ipynb
@@ -95,10 +95,8 @@
     "if sim.macro_atom is not None:\n",
     "    sim.macro_atom_state = sim.macro_atom.solve(\n",
     "        sim.plasma.j_blues,\n",
-    "        sim.plasma.atomic_data,\n",
-    "        sim.opacity_state.tau_sobolev,\n",
-    "        sim.plasma.stimulated_emission_factor,\n",
     "        sim.opacity_state.beta_sobolev,\n",
+    "        sim.plasma.stimulated_emission_factor,\n",
     "    )\n",
     "else:\n",
     "    sim.macro_atom_state = None\n",
@@ -371,7 +369,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tardis-X",
+   "display_name": "tardis",
    "language": "python",
    "name": "python3"
   },
@@ -385,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Should fix the parts of the docs that the new macroatom broke.

Not sure that I've got everywhere yet. 