### PR TITLE
append dummy index to references and fix docs

### DIFF
--- a/docs/io/grid/how_to_TardisGridTutorial.ipynb
+++ b/docs/io/grid/how_to_TardisGridTutorial.ipynb
@@ -171,18 +171,11 @@
     "# using the grid.\n",
     "sim = tg.run_sim_from_grid(row_index=0)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tardis",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -196,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,

--- a/docs/io/grid/how_to_TardisGridTutorial.ipynb
+++ b/docs/io/grid/how_to_TardisGridTutorial.ipynb
@@ -171,11 +171,18 @@
     "# using the grid.\n",
     "sim = tg.run_sim_from_grid(row_index=0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tardis",
    "language": "python",
    "name": "python3"
   },
@@ -189,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/run_montecarlo_transport.ipynb
+++ b/docs/tutorials/run_montecarlo_transport.ipynb
@@ -95,10 +95,8 @@
     "if sim.macro_atom is not None:\n",
     "    sim.macro_atom_state = sim.macro_atom.solve(\n",
     "        sim.plasma.j_blues,\n",
-    "        sim.plasma.atomic_data,\n",
-    "        sim.opacity_state.tau_sobolev,\n",
-    "        sim.plasma.stimulated_emission_factor,\n",
     "        sim.opacity_state.beta_sobolev,\n",
+    "        sim.plasma.stimulated_emission_factor,\n",
     "    )\n",
     "else:\n",
     "    sim.macro_atom_state = None\n",
@@ -371,7 +369,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tardis-X",
+   "display_name": "tardis",
    "language": "python",
    "name": "python3"
   },
@@ -385,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/tardis/conftest.py
+++ b/tardis/conftest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from astropy.version import version as astropy_version
+from astropy import units as u
 
 from tardis import run_tardis
 from tardis.io.configuration.config_reader import Configuration
@@ -167,11 +168,17 @@ def generate_reference(request):
 
 @pytest.fixture(scope="session")
 def tardis_regression_path(request):
-    tardis_regression_path = request.config.getoption("--tardis-regression-data")
+    tardis_regression_path = request.config.getoption(
+        "--tardis-regression-data"
+    )
     if tardis_regression_path is None:
         pytest.skip("--tardis-regression-data was not specified")
     else:
-        return Path(os.path.expandvars(tardis_regression_path)).expanduser().resolve()
+        return (
+            Path(os.path.expandvars(tardis_regression_path))
+            .expanduser()
+            .resolve()
+        )
 
 
 @pytest.fixture(scope="function")
@@ -180,6 +187,7 @@ def tardis_config_verysimple():
         "tardis/io/configuration/tests/data/tardis_configv1_verysimple.yml",
         YAMLLoader,
     )
+
 
 @pytest.fixture(scope="session")
 def config_verysimple_for_simulation_one_loop(
@@ -190,6 +198,17 @@ def config_verysimple_for_simulation_one_loop(
     config.montecarlo.iterations = 2
     config.montecarlo.no_of_packets = int(4e4)
     config.montecarlo.last_no_of_packets = int(4e4)
+    return config
+
+
+@pytest.fixture(scope="function")
+def config_verysimple_hydrogen_only(config_verysimple):
+    config = deepcopy(config_verysimple)
+    config.model.abundances = {
+        "type": "uniform",
+        "H": 1.0,
+        "model_isotope_time_0": 0.0 * u.s,
+    }
     return config
 
 

--- a/tardis/opacities/macro_atom/macroatom_solver.py
+++ b/tardis/opacities/macro_atom/macroatom_solver.py
@@ -441,10 +441,8 @@ class BoundBoundMacroAtomSolver:
         )
 
         macro_atom_transition_metadata["source_level_idx"] = (
-            (macro_atom_transition_metadata.source.map(source_to_index))
-            .fillna(-99)
-            .astype(np.int64)
-        )
+            macro_atom_transition_metadata.source.map(source_to_index)
+        ).astype(np.int64)
 
         macro_block_references = create_macro_block_references(
             macro_atom_transition_metadata

--- a/tardis/opacities/macro_atom/macroatom_solver.py
+++ b/tardis/opacities/macro_atom/macroatom_solver.py
@@ -442,7 +442,7 @@ class BoundBoundMacroAtomSolver:
 
         macro_atom_transition_metadata["source_level_idx"] = (
             (macro_atom_transition_metadata.source.map(source_to_index))
-            .fillna(0)
+            .fillna(-99)
             .astype(np.int64)
         )
 
@@ -596,8 +596,21 @@ def create_macro_block_references(macro_atom_transition_metadata):
         .groupby("source")
         .apply(lambda x: x.index[0])
     )
+
+    # Append a dummy index so that the interactions can access a "block end" if a packet activates the macroatom highest level of the heaviest element in the montecarlo.
+    # Without this the kernel will crash trying to access an index that doesn't exist.
+    macro_data = np.append(
+        macro_data.values, len(macro_atom_transition_metadata)
+    )
+    unique_source_multi_index = unique_source_multi_index.append(
+        pd.MultiIndex.from_tuples(
+            [(-99, -99, -99)],
+            names=["atomic_number", "ion_number", "level_number"],
+        )
+    )
+
     macro_block_references = pd.Series(
-        data=macro_data.values,
+        data=macro_data,
         index=unique_source_multi_index,
         name="macro_block_references",
     )

--- a/tardis/transport/montecarlo/tests/test_montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/tests/test_montecarlo_main_loop.py
@@ -154,4 +154,6 @@ def test_montecarlo_main_loop_hydrogen_only(
     transport = montecarlo_main_loop_simulation.transport.transport_state
     assert transport.j_estimator is not None
     expected_j_estimator = regression_data.sync_ndarray(transport.j_estimator)
-    npt.assert_allclose(transport.j_estimator, expected_j_estimator)
+    npt.assert_allclose(
+        transport.j_estimator, expected_j_estimator, atol=0, rtol=1e-13
+    )

--- a/tardis/transport/montecarlo/tests/test_montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/tests/test_montecarlo_main_loop.py
@@ -137,3 +137,21 @@ def test_montecarlo_main_loop_vpacket_log(
         rtol=1e-12,
         atol=1e-15,
     )
+
+
+def test_montecarlo_main_loop_hydrogen_only(
+    config_verysimple_hydrogen_only, atomic_dataset, regression_data
+):
+    atomic_dataset = deepcopy(atomic_dataset)
+    montecarlo_main_loop_simulation = Simulation.from_config(
+        config_verysimple_hydrogen_only,
+        atom_data=atomic_dataset,
+        virtual_packet_logging=False,
+    )
+    montecarlo_main_loop_simulation.run_convergence()
+    montecarlo_main_loop_simulation.run_final()
+
+    transport = montecarlo_main_loop_simulation.transport.transport_state
+    assert transport.j_estimator is not None
+    expected_j_estimator = regression_data.sync_ndarray(transport.j_estimator)
+    npt.assert_allclose(transport.j_estimator, expected_j_estimator)

--- a/tardis/transport/montecarlo/tests/test_montecarlo_main_loop.py
+++ b/tardis/transport/montecarlo/tests/test_montecarlo_main_loop.py
@@ -155,5 +155,5 @@ def test_montecarlo_main_loop_hydrogen_only(
     assert transport.j_estimator is not None
     expected_j_estimator = regression_data.sync_ndarray(transport.j_estimator)
     npt.assert_allclose(
-        transport.j_estimator, expected_j_estimator, atol=0, rtol=1e-13
+        transport.j_estimator, expected_j_estimator, atol=0, rtol=1e-12
     )


### PR DESCRIPTION
Should fix the grid issue, which traces back to running a hydrogen only simulation, which crashes in the montecarlo part of the code when a packet activates the macroatom into the highest level of the heaviest element and can't find the end of the macroatom block.

Fixes another doc that was incorrectly accessing the new macroatom. 

Adds a test that runs the montecarlo main loop with hydrogen only, which explicitly tests the failure case that warranted this pr. 

Regression data here. https://github.com/tardis-sn/tardis-regression-data/pull/76

UPDATE: Regression data was merged and the tests pass on moria with that regression data so this should be good to go. 