### PR TITLE
Remove duplicate OpacityStateNumba class

### DIFF
--- a/.orcid.csv
+++ b/.orcid.csv
@@ -27,3 +27,4 @@ hmlperkins@gmail.com,0009-0000-5561-9116
 erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
+

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -26,3 +26,4 @@ swayamshah66@gmail.com,0009-0005-8092-547X
 hmlperkins@gmail.com,0009-0000-5561-9116
 erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
+b.connor.mcc@gmail.com,0000-0002-6040-8281


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

Removed duplicate class for `OpacityStateNumba` defined in [tardis/opacities/opacity_state.py](../blob/master/tardis/opacities/opacity_state.py). This class duplicates the functionality of the `OpacityStateNumba` class in [tardis/opacities/opacity_state_numba.py](../blob/master/tardis/opacities/opacity_state_numba.py) and isn't used elsewhere.

Changed internal reference to `OpacityStateNumba` in [tardis/opacities/opacity_state.py](../blob/master/tardis/opacities/opacity_state.py), importing the class from [tardis/opacities/opacity_state_numba.py](../blob/master/tardis/opacities/opacity_state_numba.py) instead.

Resolves  #3300.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
