### PR TITLE
Fix broken link in installation instructions

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -31,7 +31,7 @@ We strongly recommend installing TARDIS using this method by following the steps
 
    .. code-block:: bash
 
-       wget https://raw.githubusercontent.com/tardis-sn/tardisbase/refs/heads/master/conda-{platform}-64.lock
+       wget https://raw.githubusercontent.com/tardis-sn/tardisbase/refs/heads/master/conda-{platform}.lock
 
    Replace ``{platform}`` with ``linux-64``, ``osx-arm64``, or ``osx-64`` (Mac Intel CPU) based on your operating system and CPU architecture.
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixed incorrect URL pointing to conda lockfile in [Getting Started](https://tardis-sn.github.io/tardis/getting_started/installation.html#install-with-lockfiles) documentation to direct to the "raw" lockfile. This avoids   downloading the entire HTML page when using wget.

Fixes #3323 



### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [X] My changes can't be tested (explain why)
This is documentation only

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [X] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
