### PR TITLE
Fix(tests): Remove virtual packet configuration from SDEC plotter (Cl…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -308,3 +308,5 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+
+Kushagar garg <dreamstick909@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -27,4 +27,5 @@ hmlperkins@gmail.com,0009-0000-5561-9116
 erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
+dreamstick909@gmail.com,0009-0001-8331-6697
 

--- a/tardis/visualization/tools/tests/test_sdec_plot.py
+++ b/tardis/visualization/tools/tests/test_sdec_plot.py
@@ -1,6 +1,5 @@
 """Tests for SDEC Plots."""
 from itertools import product
-from copy import deepcopy
 
 import astropy
 import astropy.units as u
@@ -13,7 +12,6 @@ from matplotlib.testing.compare import compare_images
 
 from tardisbase.testing.regression_data.regression_data import PlotDataHDF
 from tardis.visualization.tools.sdec_plot import SDECPlotter
-from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow
 
 RELATIVE_TOLERANCE_SDEC=1e-12
 
@@ -335,7 +333,7 @@ class TestSDECPlotter:
         plot_data = PlotDataHDF(**property_group)
         return plot_data
 
-    def test_generate_plot_mpl(
+    def test_generate_plot_ply(
         self, generate_plot_plotly_hdf, plotter_generate_plot_ply, regression_data
     ):
         fig, _ = plotter_generate_plot_ply


### PR DESCRIPTION
Type: testing

This PR removes the tests for "virtual" packet mode in the SDEC plotter, which were previously skipped and are no longer relevant.

Specifically, I have:

Updated test_sdec_plot.py to remove virtual from the packets_mode fixture.

Updated individual test functions (test_make_colorbar_labels, test_from_workflow_vs_from_simulation_data_consistency, etc.) to only run on real packets.

Closes #3340

 Resources
Issue #3340

Testing
How did you test these changes?

[x] Testing pipeline

[ ] Other method (describe)

[ ] My changes can't be tested (explain why)

(Note: Since I had trouble running local tests due to dependencies, relying on the GitHub CI pipeline is the standard way to verify this).

Checklist
[ ] I requested two reviewers for this pull request

[x] I updated the documentation according to my changes (N/A - test fix only)

[ ] I built the documentation by applying the build_docs label