### PR TITLE
Fix typo in SDEC tests causing name collision and incorrect regression data

### DIFF
--- a/tardis/visualization/tools/tests/test_sdec_plot.py
+++ b/tardis/visualization/tools/tests/test_sdec_plot.py
@@ -276,7 +276,7 @@ class TestSDECPlotter:
             # save artists which correspond to element contributions
             if isinstance(data, PolyCollection):
                 for index2, path in enumerate(data.get_paths()):
-                    np.testing.assert_almost_equal(
+                    np.testing.assert_allclose(
                         path.vertices,
                         expected.get(
                             "plot_data_hdf/"
@@ -286,6 +286,8 @@ class TestSDECPlotter:
                             + "ind_"
                             + str(index2)
                         ),
+                        atol=0,
+                        rtol=RELATIVE_TOLERANCE_SDEC
                     )
         expected.close()
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #3363.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [X] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label
