### PR TITLE
Citations fixing

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Wait for Zenodo webhook
+        run: sleep 180
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -65,6 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+
+      - name: Wait for Zenodo webhook
+        run: sleep 180
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

Citation fails sporadically-
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.14.2/x64/bin/doi2cff", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/doi2cff/cli.py", line 62, in init
    zenodo_record = fetch_zenodo_by_doiurl(doi)
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/doi2cff/fetchers.py", line 8, in fetch_zenodo_by_doiurl
    return fetch_zenodo_by_doi(zenodo_id)
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/doi2cff/fetchers.py", line 13, in fetch_zenodo_by_doi
    return fetch_zenodo_by_id(zenodo_id)
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/doi2cff/fetchers.py", line 21, in fetch_zenodo_by_id
    response.raise_for_status()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/site-packages/requests/models.py", line 1026, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 429 Client Error: Too Many Requests for url: https://zenodo.org/api/records/18004973

```

https://github.com/tardis-sn/tardis/actions/runs/20428414720/attempts/1 

https://github.com/tardis-sn/tardis/actions/runs/20428493111/job/58694266862 can be used to test the retry mechanism 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
