### PR TITLE
fix #3287: lazy load visualization modules and progress bars to preve…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,3 +309,4 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+Pratyksh Gupta <pratykshgupta9999@gmail.com> guptapratykshh <pratykshgupta9999@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -28,3 +28,5 @@ erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
+pratykshgupta9999@gmail.com,0000-0000-0000-0000
+pratykshgupta9999@gmail.com,0000-0000-0000-0000

--- a/tardis/transport/montecarlo/progress_bars.py
+++ b/tardis/transport/montecarlo/progress_bars.py
@@ -6,17 +6,25 @@ from tqdm.auto import tqdm
 
 from tardis.util.environment import Environment
 
-# Global progress bar instances - initialized at import time for thread safety
-# Use tqdm.auto which automatically detects environment
-iterations_pbar = tqdm(
-    desc="Iterations:",
-    bar_format="{desc:<}{bar}{n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]",
-)
-packet_pbar = tqdm(
-    desc="Packets:   ",
-    postfix="0",
-    bar_format="{desc:<}{bar}{n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]",
-)
+# Global progress bar instances - lazily initialized when first used
+iterations_pbar = None
+packet_pbar = None
+
+
+def _ensure_pbars_initialized():
+    """initialize progress bars lazily to prevent import side effects."""
+    global iterations_pbar, packet_pbar
+    if iterations_pbar is None:
+        iterations_pbar = tqdm(
+            desc="Iterations:",
+            bar_format="{desc:<}{bar}{n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]",
+        )
+    if packet_pbar is None:
+        packet_pbar = tqdm(
+            desc="Packets:   ",
+            postfix="0",
+            bar_format="{desc:<}{bar}{n_fmt}/{total_fmt} [{elapsed}<{remaining}, {rate_fmt}]",
+        )
 
 def update_packets_pbar(i: int, no_of_packets: int) -> None:
     """
@@ -32,6 +40,7 @@ def update_packets_pbar(i: int, no_of_packets: int) -> None:
     no_of_packets : int
         Total number of packets in one iteration.
     """
+    _ensure_pbars_initialized()
     # Initialize packet progress bar if needed
     if packet_pbar.total is None:
         fix_bar_layout(packet_pbar, no_of_packets=no_of_packets)
@@ -48,6 +57,7 @@ def reset_packet_pbar(no_of_packets: int) -> None:
     no_of_packets : int
         Total number of packets in the iteration.
     """
+    _ensure_pbars_initialized()
     packet_pbar.reset(total=no_of_packets)
 
 
@@ -58,6 +68,7 @@ def refresh_packet_pbar() -> None:
     This function refreshes the visual display of the packet progress bar
     to ensure accurate rendering after each iteration completes.
     """
+    _ensure_pbars_initialized()
     packet_pbar.refresh()
 
 
@@ -70,6 +81,7 @@ def update_iterations_pbar(i: int) -> None:
     i : int
         Amount by which the progress bar needs to be updated.
     """
+    _ensure_pbars_initialized()
     iterations_pbar.update(i)
 
 
@@ -82,6 +94,7 @@ def initialize_iterations_pbar(total_iterations: int) -> None:
     total_iterations : int
         Total number of iterations.
     """
+    _ensure_pbars_initialized()
     if iterations_pbar.total is None:
         fix_bar_layout(iterations_pbar, total_iterations=total_iterations)
 

--- a/tardis/visualization/__init__.py
+++ b/tardis/visualization/__init__.py
@@ -13,6 +13,26 @@ from tardis.visualization.widgets.shell_info import (
 )
 
 
-print("Initializing tabulator and plotly panel extensions for widgets to work")
-import panel as pn
-pn.extension("tabulator", "plotly")
+
+__all__ = [
+    "ConvergencePlots",
+    "CustomAbundanceWidget",
+    "GrotrianWidget",
+    "LIVPlotter",
+    "LineInfoWidget",
+    "RPacketPlotter",
+    "SDECPlotter",
+    "shell_info_from_hdf",
+    "shell_info_from_simulation",
+]
+
+_panel_initialized = False
+
+
+def _ensure_panel_initialized():
+    """initialize panel extensions lazily to prevent import side effects."""
+    global _panel_initialized
+    if not _panel_initialized:
+        import panel as pn
+        pn.extension("tabulator", "plotly")
+        _panel_initialized = True

--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -1,28 +1,34 @@
 """Convergence Plots to see the convergence of the simulation in real time."""
 
 from collections import defaultdict
-import warnings
 
 import ipywidgets as widgets
 import numpy as np
-from astropy import units as u
-from IPython.display import HTML, display
 
 # Added the below as a (temporary) workaround to the latex
 # labels on the convergence plots not rendering correctly.
-import plotly
 import plotly.graph_objects as go
+from astropy import units as u
+from IPython.display import HTML, display
 
 import tardis.visualization.plot_util as pu
 
-plotly.offline.init_notebook_mode(connected=True)
-# mathjax needs to be loaded for latex labels to render correctly
-# see https://github.com/tardis-sn/tardis/issues/2446
-display(
-    HTML(
-        '<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG"></script>'
-    )
-)
+_notebook_mode_initialized = False
+
+
+def _initialize_notebook_mode():
+    """initialize plotly notebook mode lazily to prevent import side effects."""
+    global _notebook_mode_initialized
+    if not _notebook_mode_initialized:
+
+        # mathjax needs to be loaded for latex labels to render correctly
+        # see https://github.com/tardis-sn/tardis/issues/2446
+        display(
+            HTML(
+                '<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_SVG"></script>'
+            )
+        )
+        _notebook_mode_initialized = True
 
 
 class ConvergencePlots:
@@ -61,6 +67,7 @@ class ConvergencePlots:
     """
 
     def __init__(self, iterations, **kwargs):
+        _initialize_notebook_mode()
         self.iterable_data = {}
         self.value_data = defaultdict(list)
         self.iterations = iterations

--- a/tardis/visualization/widgets/line_info.py
+++ b/tardis/visualization/widgets/line_info.py
@@ -4,21 +4,17 @@ import numpy as np
 import pandas as pd
 import panel as pn
 from astropy import units as u
-
-from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource
-from tardis.analysis import LastLineInteraction
-from tardis.util.base import (
-    species_string_to_tuple,
-    species_tuple_to_string,
-)
+from bokeh.plotting import figure
 
+from tardis.analysis import LastLineInteraction
+from tardis.configuration.sorting_globals import SORTING_ALGORITHM
+from tardis.util.base import species_string_to_tuple, species_tuple_to_string
+from tardis.util.environment import Environment
 from tardis.visualization.widgets.util import (
     TableSummaryLabel,
     create_table_widget,
 )
-from tardis.util.environment import Environment
-from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 
 
 class LineInfoWidget:
@@ -74,6 +70,9 @@ class LineInfoWidget:
             Luminosity density lambda values of a virtual spectrum, having unit
             of (erg/s)/Angstrom
         """
+        from tardis.visualization import _ensure_panel_initialized
+        _ensure_panel_initialized()
+
         self.lines_data = lines_data
         self.line_interaction_analysis = line_interaction_analysis
 

--- a/tardis/visualization/widgets/shell_info.py
+++ b/tardis/visualization/widgets/shell_info.py
@@ -238,6 +238,9 @@ class ShellInfoWidget:
             Shell information object constructed from Simulation object or HDF
             file
         """
+        from tardis.visualization import _ensure_panel_initialized
+        _ensure_panel_initialized()
+
         self.data = shell_info_data
 
         # Creating the shells data table widget

--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import re
+
 import panel as pn
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,9 @@ class PanelTableWidget:
         table_options : dict, optional
             Table configuration options
         """
+        from tardis.visualization import _ensure_panel_initialized
+        _ensure_panel_initialized()
+
         self._df = data.copy()
         self.table_options = table_options or {}
         self._selected_rows = []


### PR DESCRIPTION
### :pencil: Description

Type: :beetle: bugfix

I've addressed the issue where importing TARDIS visualization modules caused unwanted output in the command line (such as Plotly configuration scripts and empty progress bars).

This PR implements lazy initialization for two main components:

Global Progress Bars: The tqdm instances in transport.montecarlo.progress_bars are now created only when they are first needed for a simulation, rather than continuously occupying global scope at import time.
Visualization Widgets: The initialization of panel extensions and plotly notebook mode has been moved from the module level to lazy loading functions (like _ensure_panel_initialized). These functions are now called inside the init methods of the widgets or plotting tools (e.g., CustomAbundanceWidget, ConvergencePlots) so that the configuration only happens when a user explicitly creates a visualization.
This ensures that a simple import tardis.visualization is now completely silent and side-effect free.

Closes #3287

### :pushpin: Resources
Issue #3287: Loading TARDIS modules in the commandline causes Plotly and progress bar text to show

### :vertical_traffic_light: Testing

How did you test these changes?
I created a local test script that captures sys.stdout and sys.stderr while importing tardis.visualization. I verified that before the fix, it captured the Plotly configuration text, and after the fix, both streams remained empty, confirming the import is silent.


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
