### PR TITLE
CMFGEN URL Bugfix

### DIFF
--- a/docs/io/configuration/components/models/converters/cmfgen.rst
+++ b/docs/io/configuration/components/models/converters/cmfgen.rst
@@ -2,7 +2,7 @@ Convert CMFGEN files to TARDIS file format
 ==========================================
 
 This script converts `CMFGEN
-<http://kookaburra.phyast.pitt.edu/hillier/web/CMFGEN.htm>`_ input files so that
+<https://sites.pitt.edu/~hillier/web/CMFGEN.htm>`_ input files so that
 they can be used as input for TARDIS. The script expects the path to the CMFGEN
 files and the destination path for the TARDIS files as parameters
 (:code:`cmfgen2tardis /path/to/input_file path/to/output/`):


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes the CMFGEN URL which doesn't work anymore

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
