### PR TITLE
First Time Contributor Workflow Bugfixes

### DIFF
--- a/.github/workflows/util.yml
+++ b/.github/workflows/util.yml
@@ -37,9 +37,15 @@ jobs:
           repo-token: ${{ secrets.BOT_TOKEN }}
           pr-message: |
             👋 Welcome @${{ github.event.pull_request.user.login }}! Thank you for your first contribution to this repository!
-            Before asking for reviews, please make sure all checks have passed.
 
-  
+            Before asking for reviews, please fill out the PR description template and ensure that all checks are passing.
+
+            If you are applying to GSoC, please read our [AI Usage Policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy/) and make sure to add GSoC to the PR title like so:
+
+            `GSoC: <title of your pull request>`
+
+            Please mark the pull request as draft if you are not ready for review yet or if there are things you will be adding.
+
   check-orcid:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

Fixes the first time contributor workflow. Uses an action now instead of checking GitHub context. 

https://github.com/actions/first-interaction

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
