### PR TITLE
GSoC: Clarify that ASV local benchmarks do not require regression data

### DIFF
--- a/docs/contributing/development/benchmarks.rst
+++ b/docs/contributing/development/benchmarks.rst
@@ -65,6 +65,20 @@ and store the results through the ``asv.conf.json`` file.
     > asv machine --yes
 
 
+Local ASV Benchmarks
+====================
+
+Running ASV benchmarks locally does not require regression data.
+
+Only the standard TARDIS atomic data is required for running benchmarks on
+a local machine. Regression data is used exclusively in continuous
+integration (CI) to compare performance between commits.
+
+If you encounter errors related to missing regression data when running
+ASV locally, this usually indicates a misconfigured environment rather
+than a missing dependency.
+
+
 Execution
 =========
 


### PR DESCRIPTION
### What does this PR do?
This PR clarifies that running ASV benchmarks locally does not require
regression data, and that regression data is only used in CI for performance
comparison between commits.

### Why is this needed?
The existing documentation was unclear about whether regression data is
required for local ASV runs, which caused confusion for users running
benchmarks locally.

### Related issue
Fixes #3230

