### PR TITLE
[GSoC] Rename MonteCarloTransportState.opacity_state to opacity_state_numba

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,3 +309,4 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+Manivenkat <proman36122678@gmail.com> <proman36122678@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -28,3 +28,4 @@ erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
+proman36122678@gmail.com,0009-0002-1324-1703

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -288,7 +288,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
                 self.transport.transport_state.time_explosion,
                 self.transport.transport_state.time_of_simulation,
                 self.transport.transport_state.geometry_state.volume,
-                self.transport.transport_state.opacity_state.line_list_nu,
+                self.transport.transport_state.opacity_state_numba.line_list_nu,
             )
         )
 

--- a/tardis/transport/montecarlo/modes/classic/solver.py
+++ b/tardis/transport/montecarlo/modes/classic/solver.py
@@ -133,7 +133,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
         transport_state = MonteCarloTransportState(
             packet_collection,
             geometry_state=geometry_state,
-            opacity_state=opacity_state_numba,
+            opacity_state_numba=opacity_state_numba,
             time_explosion=simulation_state.time_explosion,
             n_levels_bf_species_by_n_cells_tuple=n_levels_bf_species_by_n_cells_tuple,
         )
@@ -221,7 +221,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
             transport_state.packet_collection,
             transport_state.geometry_state,
             transport_state.time_explosion.cgs.value,
-            transport_state.opacity_state,
+            transport_state.opacity_state_numba,
             self.montecarlo_configuration,
             self.spectrum_frequency_grid.value,
             trackers_list,

--- a/tardis/transport/montecarlo/modes/iip/solver.py
+++ b/tardis/transport/montecarlo/modes/iip/solver.py
@@ -133,7 +133,7 @@ class MCTransportSolverIIP(HDFWriterMixin):
         transport_state = MonteCarloTransportState(
             packet_collection,
             geometry_state=geometry_state,
-            opacity_state=opacity_state_numba,
+            opacity_state_numba=opacity_state_numba,
             time_explosion=simulation_state.time_explosion,
             n_levels_bf_species_by_n_cells_tuple=n_levels_bf_species_by_n_cells_tuple,
         )
@@ -197,7 +197,7 @@ class MCTransportSolverIIP(HDFWriterMixin):
             transport_state.packet_collection,
             transport_state.geometry_state,
             transport_state.time_explosion.cgs.value,
-            transport_state.opacity_state,
+            transport_state.opacity_state_numba,
             self.montecarlo_configuration,
             transport_state.n_levels_bf_species_by_n_cells_tuple,
             trackers_list,

--- a/tardis/transport/montecarlo/montecarlo_transport_state.py
+++ b/tardis/transport/montecarlo/montecarlo_transport_state.py
@@ -51,7 +51,7 @@ class MonteCarloTransportState(HDFWriterMixin):
         self,
         packet_collection,
         geometry_state,
-        opacity_state,
+        opacity_state_numba,
         time_explosion,
         n_levels_bf_species_by_n_cells_tuple,
         tracker_full_df=None,
@@ -69,7 +69,7 @@ class MonteCarloTransportState(HDFWriterMixin):
         self.enable_continuum_processes = False
         self.time_explosion = time_explosion
         self.geometry_state = geometry_state
-        self.opacity_state = opacity_state
+        self.opacity_state_numba = opacity_state_numba
         self.tracker_full_df = tracker_full_df
         self.tracker_last_interaction_df = tracker_last_interaction_df
         self.vpacket_tracker = vpacket_tracker

--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -204,7 +204,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
                 self.transport_state.time_explosion,
                 self.transport_state.time_of_simulation,
                 self.transport_state.geometry_state.volume,
-                self.transport_state.opacity_state.line_list_nu,
+                self.transport_state.opacity_state_numba.line_list_nu,
             )
         )
 

--- a/tardis/workflows/standard_tardis_workflow.py
+++ b/tardis/workflows/standard_tardis_workflow.py
@@ -125,7 +125,7 @@ class StandardTARDISWorkflow(
                 self.transport_state.time_explosion,
                 self.transport_state.time_of_simulation,
                 self.transport_state.geometry_state.volume,
-                self.transport_state.opacity_state.line_list_nu,
+                self.transport_state.opacity_state_numba.line_list_nu,
             )
         )
 

--- a/tardis/workflows/type_iip_workflow.py
+++ b/tardis/workflows/type_iip_workflow.py
@@ -323,7 +323,7 @@ class TypeIIPWorkflow(WorkflowLogging):
                 self.transport_state.time_explosion,
                 self.transport_state.time_of_simulation,
                 self.transport_state.geometry_state.volume,
-                self.transport_state.opacity_state.line_list_nu,
+                self.transport_state.opacity_state_numba.line_list_nu,
             )
         )
 


### PR DESCRIPTION
Closes #3206

### :pencil: Description

**Type:** :memo: `codestyle`

Renames the `opacity_state` attribute in `MonteCarloTransportState` to `opacity_state_numba` to clearly distinguish it from the non-numba `OpacityState` DataFrame version (`sim.opacity_state`) added in PR #3205.

**Context:**
- PR #3205 added `sim.opacity_state` (non-numba DataFrame version) to the Simulation class for use with functions like `get_tau_integ()` that require DataFrame indexing
- However, `transport_state.opacity_state` also existed but stored the numba-compatible version
- This naming overlap caused confusion about which version is which

**Changes:**
- Renamed parameter and attribute in `MonteCarloTransportState.__init__`: `opacity_state` → `opacity_state_numba`
- Updated all usages in:
  - base.py
  - base.py
  - simple_tardis_workflow.py
  - standard_tardis_workflow.py
  - transport_montecarlo_main_loop.py

**After this PR:**
- `sim.opacity_state` → non-numba DataFrame version (for `get_tau_integ`, formal integral, etc.)
- `transport_state.opacity_state_numba` → numba-compatible version (for Monte Carlo transport)

### :pushpin: Resources

- Related issue: #3206
- Related PR: #3205

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method (describe)
  - Verified all imports work correctly
  - Ran transport tests (20 passed)
  - Ran spectrum tests (46 passed)
  - Verified no remaining references to old attribute name
- [ ] My changes can't be tested (explain why)

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] My changes can't be tested

AI Usage Statement
Tool used: GitHub Copilot
How used: Refining code changes and improving PR wording.

Confirmation: I confirm that I have read the [PR Checklist](https://tardis-sn.github.io/summer_of_code/pr_checklist/) and the [AI and LLM Usage Policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy/). I fully understand all AI-assisted changes and can explain every modification in this PR.