### PR TITLE
Fix import noise

### DIFF
--- a/tardis/visualization/tools/rpacket_plot.py
+++ b/tardis/visualization/tools/rpacket_plot.py
@@ -310,11 +310,12 @@ class RPacketPlotter:
                 # photosphere
                 self.fig.add_shape(
                     **shape_props,
+                    layer="below",
                     line_color=self.theme_colors[theme][
                         "photosphere_line_color"
                     ],
                     fillcolor=self.theme_colors[theme]["photosphere_fillcolor"],
-                    opacity=1,
+                    opacity=0.25,
                 )
             elif shell_no == (len(self.sim.simulation_state.radius.value) - 1):
                 # outermost shell


### PR DESCRIPTION
### Description
   This PR removes unintended stdout output that occurs when importing TARDIS modules in a command-line environment.
Previously, importing certain visualization and transport modules triggered:
- Panel initialization messages
- Plotly/MathJax HTML display objects
-qdm progress bar text (Iterations, Packets)
These side effects occurred at module import time, even when users were not running simulations or displaying widgets. This resulted in unwanted console output in CLI workflows.
 ### Changes Made
1. Lazy initialization of Panel extensions
    - Removed Panel extension loading and print statements from import time.
    - Added a helper loader that initializes Panel extensions only when visualization widgets are instantiated.
    - Prevents stdout noise during CLI imports.
2. Lazy initialization of Plotly/MathJax notebook setup
    - Removed display(HTML(...)) and Plotly notebook initialization from module-level execution.
     - Added a guarded initialization function executed only when convergence plots are built and widget display is allowed.
     - Ensures notebook-specific rendering logic does not run in CLI environments.
3. Lazy creation of tqdm progress bars
    - Removed global tqdm progress bar instantiation from progress_bars.py.
    - Progress bars are now created only when simulations actually run.
    - Importing TARDIS no longer prints progress bar headers.

### Result
    Importing visualization or transport modules no longer produces console output:

    import tardis
    from tardis.visualization import CustomAbundanceWidget
Now runs silently in CLI environments.
Progress bars and notebook rendering still function correctly during:
- simulation runtime
- widget display in notebooks