### PR TITLE
fix test_convergence_plot_command_line 

### DIFF
--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -223,7 +223,7 @@ def test_convergence_plot_command_line(
     config_verysimple, atomic_dataset, monkeysession
 ):
     monkeysession.setattr(
-        "tardis.util.environment.Environment.is_notebook",
+        "tardis.util.environment.Environment.allows_widget_display",
         lambda: False,
     )
     atomic_data = deepcopy(atomic_dataset)

--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -220,9 +220,9 @@ def test_override_plot_parameters(convergence_plots):
 
 
 def test_convergence_plot_command_line(
-    config_verysimple, atomic_dataset, monkeysession
+    config_verysimple, atomic_dataset, monkeypatch
 ):
-    monkeysession.setattr(
+    monkeypatch.setattr(
         "tardis.util.environment.Environment.allows_widget_display",
         lambda: False,
     )


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

fixes #3417
- previously for the environment only is_notebook was set to False, but under the VS Code test interface allows_widget_display still evaluated to True.
- mocking allows_widget_display to False to correct this bug, now the test passes on both CLI and vscode test interface
<img width="1841" height="1022" alt="Screenshot From 2026-02-17 02-35-35" src="https://github.com/user-attachments/assets/eecafbd0-3724-4648-bf10-e8737415db7d" />


### :pushpin: Resources



### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.

### AI Usage
I have read the checklist and the [AI usage policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy)
No AI or LLM tools were used in any part of the contribution.
