### PR TITLE
GSoC: Fix mailmap workflow to validate all PR authors

### DIFF
--- a/.github/workflows/mailmap.yml
+++ b/.github/workflows/mailmap.yml
@@ -18,7 +18,23 @@ jobs:
           fetch-depth: 0
 
       - name: Check PR authors
-        run: cat .mailmap | grep "$(git log $PR_BASE_SHA..HEAD --pretty='%aN <%aE>')"
+        run: |
+          authors="$(git log "$PR_BASE_SHA"..HEAD --pretty='%aN <%aE>' | sort -u)"
+          missing_authors=()
+
+          while IFS= read -r author; do
+            [ -z "$author" ] && continue
+
+            if ! grep -Fq "$author" .mailmap; then
+              missing_authors+=("$author")
+            fi
+          done <<< "$authors"
+
+          if [ "${#missing_authors[@]}" -gt 0 ]; then
+            echo "The following PR authors are missing from .mailmap:"
+            printf ' - %s\n' "${missing_authors[@]}"
+            exit 1
+          fi
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 

--- a/.mailmap
+++ b/.mailmap
@@ -147,6 +147,8 @@ Marc Williamson <marxwillia@gmail.com> Marc Williamson <marcwilliamson@10-17-70-
 
 Mark Magee <53613663+MarkMageeAstro@users.noreply.github.com>
 
+ManthanNimodiya <manthannimodiya989898@gmail.com>
+
 Martin Reinecke <martin@mpa-garching.mpg.de>
 
 Maryam Patel <maryam.patel22@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -28,3 +28,4 @@ erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
+manthannimodiya989898@gmail.com,0009-0001-8977-0540


### PR DESCRIPTION
### :pencil: Description

**Type:** CI/CD `bug`

Fixes #3338.

The current mailmap workflow checks PR authors with a single grep call:
- this can pass when only one author matches
- other missing PR authors can be missed

This update validates **every unique author** in the PR range and fails with a clear missing-author list.

### :pushpin: Resources

- Issue: #3338
- Workflow updated: `.github/workflows/mailmap.yml`
- Related onboarding checks: `.mailmap`, `.orcid.csv`

### :vertical_traffic_light: Testing

How were these changes tested?

- [x] Workflow logic validated locally (multi-author/missing-author simulation)
- [x] YAML parsing sanity check
- [ ] Full CI run on PR

### Additional updates

To satisfy contributor bot checks for this PR:
- Added commit email entry to `.mailmap`
- Added ORCID mapping to `.orcid.csv`

### AI Disclosure

AI tooling was used for workflow analysis and drafting. All changes were reviewed and validated before submission.
