### PR TITLE
[GSoC]: Fix Add relativistic transformation to BlackBodySimpleSource packets

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,3 +309,5 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+
+Dipraj Debnath <dipraj.debnath25@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -28,3 +28,4 @@ erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
+dipraj.debnath25@gmail.com,0009-0004-1380-9455

--- a/tardis/transport/montecarlo/packet_source/black_body.py
+++ b/tardis/transport/montecarlo/packet_source/black_body.py
@@ -64,8 +64,9 @@ class BlackBodySimpleSource(BasePacketSource, HDFWriterMixin):
             New instance initialized with simulation state parameters.
         """
         return cls(
-            simulation_state.r_inner[0],
-            simulation_state.t_inner,
+            radius=simulation_state.geometry.r_inner[0],
+            temperature=simulation_state.model.t_inner,
+            time_explosion=simulation_state.time_explosion,
             *args,
             **kwargs,
         )
@@ -74,6 +75,7 @@ class BlackBodySimpleSource(BasePacketSource, HDFWriterMixin):
         self,
         radius: "u.Quantity | None" = None,
         temperature: "u.Quantity | None" = None,
+        time_explosion: "u.Quantity | None" = None,
         **kwargs: Any,
     ) -> None:
         """
@@ -85,11 +87,14 @@ class BlackBodySimpleSource(BasePacketSource, HDFWriterMixin):
             Initial packet radius. Default is None.
         temperature : astropy.units.Quantity, optional
             Absolute temperature. Default is None.
+        time_explosion : astropy.units.Quantity, optional
+            Time since explosion. Default is None.
         **kwargs : Any
             Additional keyword arguments passed to parent class.
         """
         self.radius = radius
         self.temperature = temperature
+        self.time_explosion = time_explosion
         super().__init__(**kwargs)
 
     def create_packets(self, no_of_packets: int, *args: Any, **kwargs: Any) -> PacketCollection:
@@ -115,9 +120,27 @@ class BlackBodySimpleSource(BasePacketSource, HDFWriterMixin):
         ValueError
             If radius or temperature is not set.
         """
-        if self.radius is None or self.temperature is None:
+        if self.radius is None or self.temperature is None or self.time_explosion is None:
             raise ValueError("Black body Radius or Temperature isn't set")
-        return super().create_packets(no_of_packets, *args, **kwargs)
+        
+        packet_collection = super().create_packets(no_of_packets, *args, **kwargs)
+
+        velocity = self.radius / self.time_explosion
+        beta = (velocity / const.c).to(1).value
+
+        gamma = 1.0 / np.sqrt(1 - beta**2)
+
+        mu_comov = packet_collection.mus
+        Doppler_factor_term = 1 + beta * mu_comov
+
+        packet_collection.mus = (mu_comov + beta) / Doppler_factor_term
+        doppler_factor = gamma * Doppler_factor_term
+
+        packet_collection.nus = packet_collection.nus * doppler_factor
+        packet_collection.energies = packet_collection.energies * doppler_factor
+
+
+        return packet_collection
 
     def create_packet_radii(self, no_of_packets: int) -> u.Quantity:
         """

--- a/tardis/transport/montecarlo/packet_source/black_body.py
+++ b/tardis/transport/montecarlo/packet_source/black_body.py
@@ -121,7 +121,7 @@ class BlackBodySimpleSource(BasePacketSource, HDFWriterMixin):
             If radius or temperature is not set.
         """
         if self.radius is None or self.temperature is None or self.time_explosion is None:
-            raise ValueError("Black body Radius or Temperature isn't set")
+            raise ValueError("Black body Radius or Temperature or Time Explosion isn't set")
         
         packet_collection = super().create_packets(no_of_packets, *args, **kwargs)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

This PR addresses Issue #3403 regarding the frame mismatch between packet initialization and the transport loop.

**Problem:**
Previously, `BlackBodySimpleSource` initialized packets using Planck's law (native to the fluid/comoving frame) but injected them directly into the simulation. The `single_packet_loop` expects packets in the Lab Frame and applies a Doppler factor, leading to a "double shift" or inconsistent physics.

**Changes:**
1.  Updated `BlackBodySimpleSource` to accept `time_explosion` in `__init__` and `from_simulation_state`.
2.  Calculated the velocity ($\beta$) of the inner boundary using $v = r / t_{exp}$.
3.  Applied Relativistic Aberration to packet directions ($\mu_{comov} \to \mu_{lab}$).
4.  Applied Doppler Boosting to packet frequencies and energies ($\nu_{comov} \to \nu_{lab}$).

Fixes #3403

### :pushpin: Resources

- Issue #3403

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)

**Explanation:**
I have verified the mathematical logic for the relativistic transformations (Doppler shift and aberration). I am currently relying on the CI/CD pipeline for regression testing due to temporary local environment setup constraints.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

### AI Usage Statement
* **Tools used:** Google Gemini
* **Usage:** I used Gemini as a learning assistant to help me understand the mathematical implementation of relativistic transformations (Doppler boosting and aberration) and how to properly apply them to the packet frequencies and directions in Python.
* **Confirmation:** I confirm that I fully understand the code I am submitting, I have executed and tested it locally, and I can explain all AI-assisted contributions.