### PR TITLE
fix(ci): validate all PR authors against .mailmap (fixes #3338)

### DIFF
--- a/.github/workflows/mailmap.yml
+++ b/.github/workflows/mailmap.yml
@@ -18,7 +18,23 @@ jobs:
           fetch-depth: 0
 
       - name: Check PR authors
-        run: cat .mailmap | grep "$(git log $PR_BASE_SHA..HEAD --pretty='%aN <%aE>')"
+        run: |
+          authors="$(git log "$PR_BASE_SHA"..HEAD --pretty='%aN <%aE>' | sort -u)"
+          missing_authors=()
+
+          while IFS= read -r author; do
+            [ -z "$author" ] && continue
+
+            if ! grep -Fq "$author" .mailmap; then
+              missing_authors+=("$author")
+            fi
+          done <<< "$authors"
+
+          if [ "${#missing_authors[@]}" -gt 0 ]; then
+            echo "The following PR authors are missing from .mailmap:"
+            printf ' - %s\n' "${missing_authors[@]}"
+            exit 1
+          fi
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
 

--- a/.mailmap
+++ b/.mailmap
@@ -147,6 +147,8 @@ Marc Williamson <marxwillia@gmail.com> Marc Williamson <marcwilliamson@10-17-70-
 
 Mark Magee <53613663+MarkMageeAstro@users.noreply.github.com>
 
+ManthanNimodiya <manthannimodiya989898@gmail.com>
+
 Martin Reinecke <martin@mpa-garching.mpg.de>
 
 Maryam Patel <maryam.patel22@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -28,3 +28,4 @@ erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
+manthannimodiya989898@gmail.com,0009-0001-8977-0540


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #3338

The existing `mailmap.yml` workflow checks PR authors with a single `grep` call:

```
cat .mailmap | grep "$(git log $PR_BASE_SHA..HEAD --pretty='%aN <%aE>')"
```

This only works when a PR has a single author. If a PR contains commits from multiple authors, `git log --pretty='%aN <%aE>'` outputs multiple lines, and the single `grep` call can silently pass if just one author matches — letting other missing authors slip through.

The fix replaces the single `grep` with a loop that:
1. Extracts every unique author from `git log origin/master..HEAD` using `sort -u`
2. Validates each author individually against `.mailmap` using `grep -Fq`
3. Collects all missing authors and fails with a clear list if any are found

This PR supersedes #3435, which was closed after reviewer feedback because it contained unrelated ruff/lint changes. Those have been completely removed — this PR now only touches the workflow file and contributor metadata.

### :pushpin: Resources

- Issue: #3338
- Files changed:
  - `.github/workflows/mailmap.yml` — workflow fix
  - `.mailmap` — contributor entry for ManthanNimodiya
  - `.orcid.csv` — ORCID entry for ManthanNimodiya

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method
- [ ] My changes can't be tested

Tested locally by simulating multi-author commit ranges:
- Created test commits with different author names/emails
- Ran the updated shell script against a local `.mailmap`
- Verified it correctly identifies and reports all missing authors
- Verified it passes when all authors are present
- Verified YAML syntax is valid

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- not applicable, this is a CI-only change
- not applicable, this is a CI-only change

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.

### AI Disclosure

AI tooling was used for analyzing the existing workflow, drafting the shell script fix, and cleaning up the branch after reviewer feedback on #3435.

All changes have been reviewed, understood, and validated manually before submission. Per the [TARDIS AI Usage Policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy/), I take full responsibility for the code submitted.

