### PR TITLE
[GSOC] use previous iteration ion populations as first guess in NLTE solver

### DIFF
--- a/tardis/plasma/properties/nlte.py
+++ b/tardis/plasma/properties/nlte.py
@@ -9,6 +9,7 @@ from tardis.plasma.properties.base import (
 __all__ = [
     "PreviousElectronDensities",
     "PreviousBetaSobolev",
+    "PreviousIonNumberDensity",
 ]
 
 logger = logging.getLogger(__name__)
@@ -47,3 +48,16 @@ class PreviousBetaSobolev(PreviousIterationProperty):
             columns=kwargs["number_density"].columns,
         )
         self._set_initial_value(initial_value)
+
+
+class PreviousIonNumberDensity(PreviousIterationProperty):
+    """
+    Attributes
+    ----------
+    previous_ion_number_density : The ion number densities converged upon in the previous iteration.
+    """
+
+    outputs = ("previous_ion_number_density",)
+
+    def set_initial_value(self, kwargs):
+        self._set_initial_value(None)

--- a/tardis/plasma/properties/property_collections.py
+++ b/tardis/plasma/properties/property_collections.py
@@ -62,7 +62,7 @@ nlte_properties = PlasmaPropertyCollection(
     ]
 )
 nlte_root_solver_properties = PlasmaPropertyCollection(
-    [NLTEIndexHelper, NLTEPopulationSolverRoot]
+    [NLTEIndexHelper, NLTEPopulationSolverRoot, PreviousIonNumberDensity]
 )
 nlte_lu_solver_properties = PlasmaPropertyCollection(
     [NLTEIndexHelper, NLTEPopulationSolverLU]


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

This PR improves the convergence speed of the NLTE solver by using the ion populations and electron densities from the previous iteration as the initial guess for subsequent iterations, rather than resetting to the default "all singly ionized" guess every time.

**Changes:**
- `tardis/plasma/properties/nlte.py`: Added `PreviousIonNumberDensity` class to store ion number densities from the previous iteration
- `tardis/plasma/properties/nlte_rate_equation_solver.py`: Modified `calculate_first_guess` to utilize these previous values if they exist
- Added Regression Tests for it
<img width="577" height="335" alt="Screenshot From 2026-02-21 03-31-06" src="https://github.com/user-attachments/assets/541dfb16-1de6-4d1d-b5b7-2998abc7392a" />

Closes #2485 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method (self tested and then added regression tests for the same)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.

### AI Usage
Gemini 2.5 is used for research and understanding parts of code.
Github Copilot is used for better naming of variables and framing docstrings sentences
I have read the checklist and the [AI usage policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy)