### PR TITLE
[GSoC] Fix namespace collision issue #3021 by replacing tardis.__path__ with Path(__file__)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -157,6 +157,8 @@ Maryam Patel <maryam.patel22@gmail.com> maryampatel <maryam.patel22@gmail.com>
 Matthew Bartnik <bartnikm@msu.edu>
 Matthew Bartnik <bartnikm@msu.edu> bartnikm <72052791+bartnikm@users.noreply.github.com>
 
+Manivenkat <proman36122678@gmail.com> <proman36122678@gmail.com>
+
 Michael Klauser <michael@klauser.biz>
 Michael Klauser <michael@klauser.biz> Michael.Klauser <michael@klauser.biz>
 Michael Klauser <michael@klauser.biz> Michael <mklauser@mpa-garching.mpg.de>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -29,3 +29,4 @@ lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
 araut7798@gmail.com ,0009-0009-4508-2218
+proman36122678@gmail.com,0009-0002-1324-1703

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal.py
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal.py
@@ -7,7 +7,6 @@ import pytest
 from astropy import units as u
 from numpy.testing import assert_allclose
 
-import tardis
 from tardis.energy_input.gamma_ray_channel import (
     calculate_total_decays,
     create_inventories_dict,
@@ -18,6 +17,7 @@ from tardis.energy_input.gamma_ray_channel import (
 from tardis.transport.montecarlo.packet_source.high_energy import GammaRayPacketSource
 from tardis.energy_input.main_gamma_ray_loop import get_effective_time_array
 from tardis.io.configuration.config_reader import Configuration
+from tardis.io.util import TARDIS_PATH
 from tardis.model import SimulationState
 
 
@@ -26,7 +26,7 @@ def simulation_state(atomic_dataset):
     """Create a simulation state from the HE workflow config."""
 
     # Get tardis root directory
-    tardis_root = Path(tardis.__path__[0])
+    tardis_root = TARDIS_PATH
     config_path = (
         tardis_root
         / "workflows"

--- a/tardis/grid/tests/test_grid.py
+++ b/tardis/grid/tests/test_grid.py
@@ -3,10 +3,10 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-import tardis
 import tardis.grid as grid
+from tardis.io.util import TARDIS_PATH
 
-DATA_PATH = Path(tardis.__path__[0]) / "grid" / "tests" / "data"
+DATA_PATH = TARDIS_PATH / "grid" / "tests" / "data"
 
 
 def test_grid(atomic_dataset):

--- a/tardis/gui/widgets.py
+++ b/tardis/gui/widgets.py
@@ -28,6 +28,7 @@ from astropy import units as u
 
 import tardis
 from tardis import analysis, util
+from tardis.io.util import TARDIS_PATH
 
 
 class MatplotlibWidget(FigureCanvas):
@@ -1264,7 +1265,7 @@ class Tardis(QtWidgets.QMainWindow):
         QtWidgets.QMainWindow.__init__(self, parent)
 
         # path to icons folder
-        self.path = Path(tardis.__path__[0]) / "gui" / "images"
+        self.path = TARDIS_PATH / "gui" / "images"
 
         # Check if configuration file was provided
         self.mode = "passive"

--- a/tardis/iip_plasma/tests/conftest.py
+++ b/tardis/iip_plasma/tests/conftest.py
@@ -5,9 +5,9 @@ import pandas as pd
 import pytest
 from astropy import units as u
 
-import tardis
 from tardis.iip_plasma.properties import *
 from tardis.io.atom_data import AtomData
+from tardis.io.util import TARDIS_PATH
 
 # INPUTS
 
@@ -15,7 +15,7 @@ from tardis.io.atom_data import AtomData
 @pytest.fixture
 def atomic_data():
     atomic_db_fname = os.path.join(
-        tardis.__path__[0], "tests", "data", "chianti_he_db.h5"
+        str(TARDIS_PATH), "tests", "data", "chianti_he_db.h5"
     )
     return AtomData.from_hdf(atomic_db_fname)
 

--- a/tardis/iip_plasma/tests/test_plasmas_full.py
+++ b/tardis/iip_plasma/tests/test_plasmas_full.py
@@ -6,15 +6,15 @@ import pytest
 import yaml
 from astropy import units as u
 
-import tardis
 from tardis.base import run_tardis
+from tardis.io.util import TARDIS_PATH
 
 pytestmark = pytest.mark.skip("Skipping tests due to old format")
 
 
 def data_path(fname):
     return os.path.join(
-        tardis.__path__[0], "iip_plasma", "tests", "data", fname
+        str(TARDIS_PATH), "iip_plasma", "tests", "data", fname
     )
 
 

--- a/tardis/io/configuration/config_internal.py
+++ b/tardis/io/configuration/config_internal.py
@@ -1,13 +1,13 @@
 import logging
 import shutil
 from pathlib import Path
+from importlib import resources
 
 import yaml
 from astropy.config import get_config_dir
 
-from tardis import __path__ as TARDIS_PATH
+TARDIS_PATH = Path(str(resources.files("tardis")))
 
-TARDIS_PATH = Path(TARDIS_PATH[0])
 DEFAULT_CONFIG_PATH = (
     TARDIS_PATH / "data" / "default_tardis_internal_config.yml"
 )

--- a/tardis/io/configuration/config_internal.py
+++ b/tardis/io/configuration/config_internal.py
@@ -1,12 +1,13 @@
 import logging
 import shutil
-from importlib import resources
 from pathlib import Path
 
 import yaml
 from astropy.config import get_config_dir
 
-TARDIS_PATH = Path(str(resources.files("tardis")))
+# Use __file__ to get the TARDIS package path robustly.
+# This avoids issues when a local 'tardis' directory exists (Issue #3021).
+TARDIS_PATH = Path(__file__).resolve().parent.parent.parent
 
 DEFAULT_CONFIG_PATH = (
     TARDIS_PATH / "data" / "default_tardis_internal_config.yml"
@@ -21,8 +22,7 @@ def get_internal_configuration():
     config_fpath = Path(get_config_dir()) / "tardis_internal_config.yml"
     if not config_fpath.exists():
         logger.warning(
-            "Configuration File %s does not exist - creating new one from default", 
-            config_fpath
+            f"Configuration File {config_fpath} does not exist - creating new one from default"
         )
         shutil.copy(DEFAULT_CONFIG_PATH, config_fpath)
     with open(config_fpath) as config_fh:
@@ -35,17 +35,11 @@ def get_data_dir():
     if data_dir is None:
         config_fpath = Path(get_config_dir()) / "tardis_internal_config.yml"
         logging.critical(
-            "\n%s\n\nTARDIS will download different kinds of data (e.g. atomic) to its data directory %s\n\n"
-            "TARDIS DATA DIRECTORY not specified in %s:\n\n"
-            "ASSUMING DEFAULT DATA DIRECTORY %s\n "
-            "YOU CAN CHANGE THIS AT ANY TIME IN %s \n\n"
-            "%s \n\n",
-            "*" * 80,
-            DEFAULT_DATA_DIR,
-            config_fpath,
-            DEFAULT_DATA_DIR,
-            config_fpath,
-            "*" * 80
+            f"\n{'*' * 80}\n\nTARDIS will download different kinds of data (e.g. atomic) to its data directory {DEFAULT_DATA_DIR}\n\n"
+            f"TARDIS DATA DIRECTORY not specified in {config_fpath}:\n\n"
+            f"ASSUMING DEFAULT DATA DIRECTORY {DEFAULT_DATA_DIR}\n "
+            f"YOU CAN CHANGE THIS AT ANY TIME IN {config_fpath} \n\n"
+            f"{'*' * 80} \n\n"
         )
         if not DEFAULT_DATA_DIR.exists():
             DEFAULT_DATA_DIR.mkdir(parents=True, exist_ok=True)

--- a/tardis/io/configuration/config_internal.py
+++ b/tardis/io/configuration/config_internal.py
@@ -1,7 +1,7 @@
 import logging
 import shutil
-from pathlib import Path
 from importlib import resources
+from pathlib import Path
 
 import yaml
 from astropy.config import get_config_dir
@@ -21,7 +21,8 @@ def get_internal_configuration():
     config_fpath = Path(get_config_dir()) / "tardis_internal_config.yml"
     if not config_fpath.exists():
         logger.warning(
-            f"Configuration File {config_fpath} does not exist - creating new one from default"
+            "Configuration File %s does not exist - creating new one from default", 
+            config_fpath
         )
         shutil.copy(DEFAULT_CONFIG_PATH, config_fpath)
     with open(config_fpath) as config_fh:
@@ -34,11 +35,17 @@ def get_data_dir():
     if data_dir is None:
         config_fpath = Path(get_config_dir()) / "tardis_internal_config.yml"
         logging.critical(
-            f"\n{'*' * 80}\n\nTARDIS will download different kinds of data (e.g. atomic) to its data directory {DEFAULT_DATA_DIR}\n\n"
-            f"TARDIS DATA DIRECTORY not specified in {config_fpath}:\n\n"
-            f"ASSUMING DEFAULT DATA DIRECTORY {DEFAULT_DATA_DIR}\n "
-            f"YOU CAN CHANGE THIS AT ANY TIME IN {config_fpath} \n\n"
-            f"{'*' * 80} \n\n"
+            "\n%s\n\nTARDIS will download different kinds of data (e.g. atomic) to its data directory %s\n\n"
+            "TARDIS DATA DIRECTORY not specified in %s:\n\n"
+            "ASSUMING DEFAULT DATA DIRECTORY %s\n "
+            "YOU CAN CHANGE THIS AT ANY TIME IN %s \n\n"
+            "%s \n\n",
+            "*" * 80,
+            DEFAULT_DATA_DIR,
+            config_fpath,
+            DEFAULT_DATA_DIR,
+            config_fpath,
+            "*" * 80
         )
         if not DEFAULT_DATA_DIR.exists():
             DEFAULT_DATA_DIR.mkdir(parents=True, exist_ok=True)

--- a/tardis/io/hdf_writer_mixin.py
+++ b/tardis/io/hdf_writer_mixin.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import re
+from importlib.metadata import version as get_version
 from pathlib import Path
 from typing import Any, Union, Optional, Dict, List
 
 import numpy as np
 import pandas as pd
 
-from tardis import __version__
+# Use importlib.metadata to get version - works even with namespace collision (Issue #3021)
+__version__ = get_version("tardis")
 from tardis.io.util import logger
 
 

--- a/tardis/io/tests/test_HDFWriter.py
+++ b/tardis/io/tests/test_HDFWriter.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version as get_version
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -5,7 +7,9 @@ from astropy import units as u
 from numpy.testing import assert_array_almost_equal
 
 from tardis.io.hdf_writer_mixin import HDFWriterMixin
-from tardis import __version__
+
+# Use importlib.metadata to get version - works even with namespace collision (Issue #3021)
+__version__ = get_version("tardis")
 
 # Test Cases
 

--- a/tardis/io/util.py
+++ b/tardis/io/util.py
@@ -14,10 +14,14 @@ import yaml
 from astropy import units as u
 from astropy.utils.data import download_file
 
-from tardis import __path__ as TARDIS_PATH
 from tardis import constants as const
 
 logger = logging.getLogger(__name__)
+
+# Use __file__ to get the TARDIS package path robustly.
+# This avoids issues when a local 'tardis' directory exists (Issue #3021).
+# __file__ always points to the actual installed file location.
+TARDIS_PATH = Path(__file__).resolve().parent.parent
 
 
 def get_internal_data_path(fname: str) -> str:
@@ -33,8 +37,14 @@ def get_internal_data_path(fname: str) -> str:
     -------
     str
         Internal data path of TARDIS joined with the filename.
+
+    Notes
+    -----
+    This function uses ``__file__`` to resolve the path, which works
+    correctly even when a local 'tardis' directory exists in the
+    current working directory (see Issue #3021).
     """
-    return str(Path(TARDIS_PATH[0]) / "data" / fname)
+    return str(TARDIS_PATH / "data" / fname)
 
 
 def quantity_from_str(text: str) -> u.Quantity:

--- a/tardis/plasma/tests/test_plasma_vboundary.py
+++ b/tardis/plasma/tests/test_plasma_vboundary.py
@@ -3,11 +3,11 @@ from pathlib import Path
 import astropy.units as u
 import pytest
 
-import tardis
 from tardis.io.configuration.config_reader import Configuration
+from tardis.io.util import TARDIS_PATH
 from tardis.simulation import Simulation
 
-DATA_PATH = Path(tardis.__path__[0]) / "plasma" / "tests" / "data"
+DATA_PATH = TARDIS_PATH / "plasma" / "tests" / "data"
 
 
 @pytest.fixture

--- a/tardis/simulation/base.py
+++ b/tardis/simulation/base.py
@@ -1,12 +1,12 @@
 import logging
 import time
 from collections import OrderedDict
+from importlib.metadata import version as get_version
 
 import numpy as np
 import pandas as pd
 from astropy import units as u
 
-import tardis
 from tardis import constants as const
 from tardis.io.atom_data.parse_atom_data import parse_atom_data
 from tardis.io.configuration.config_reader import ConfigurationError
@@ -174,7 +174,7 @@ class Simulation(PlasmaStateStorerMixin, HDFWriterMixin):
         self.luminosity_requested = luminosity_requested
         self.spectrum_solver = spectrum_solver
         self.show_progress_bars = show_progress_bars
-        self.version = tardis.__version__
+        self.version = get_version("tardis")
 
         # Convergence
         self.convergence_strategy = convergence_strategy

--- a/tardis/simulation/tests/test_simulation.py
+++ b/tardis/simulation/tests/test_simulation.py
@@ -2,8 +2,9 @@ import astropy.units as u
 import numpy as np
 import pandas as pd
 import pytest
+from copy import deepcopy
+from importlib.metadata import version as get_version
 
-import tardis
 from tardis.io.configuration.config_reader import Configuration
 from tardis.simulation import Simulation
 
@@ -122,4 +123,4 @@ def test_plasma_state_storer_reshape(
 
 
 def test_version_tag(simulation_without_loop):
-    assert simulation_without_loop.version == tardis.__version__
+    assert simulation_without_loop.version == get_version("tardis")

--- a/tardis/transport/montecarlo/tests/test_montecarlo.py
+++ b/tardis/transport/montecarlo/tests/test_montecarlo.py
@@ -28,13 +28,13 @@ from numpy.testing import (
     assert_almost_equal,
 )
 
-from tardis import __path__ as path
+from tardis.io.util import TARDIS_PATH
 
 
 @pytest.fixture(scope="module")
 def continuum_compare_data_fname():
     fname = "continuum_compare_data.hdf"
-    return str(Path(path[0]) / "montecarlo" / "tests" / "data" / fname)
+    return str(TARDIS_PATH / "montecarlo" / "tests" / "data" / fname)
 
 
 @pytest.fixture(scope="module")

--- a/tardis/util/base.py
+++ b/tardis/util/base.py
@@ -13,9 +13,8 @@ from astropy import units as u
 from radioactivedecay import DEFAULTDATA
 from radioactivedecay.utils import Z_DICT, parse_nuclide
 
-import tardis
 from tardis import constants
-from tardis.io.util import get_internal_data_path
+from tardis.io.util import get_internal_data_path, TARDIS_PATH
 from tardis.util.environment import Environment
 
 k_B_cgs = constants.k_B.cgs.value
@@ -25,7 +24,7 @@ m_e_cgs = constants.m_e.cgs.value
 e_charge_gauss = constants.e.gauss.value
 
 logger = logging.getLogger(__name__)
-tardis_dir = Path(tardis.__path__[0]).resolve()
+tardis_dir = TARDIS_PATH.resolve()
 
 ATOMIC_SYMBOLS_DATA = (
     pd.read_csv(

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -11,7 +11,6 @@ from astropy import units as u
 from radioactivedecay import Nuclide
 from radioactivedecay.utils import Z_DICT, elem_to_Z
 
-import tardis
 import tardis.visualization.plot_util as pu
 from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 from tardis.io.atom_data.base import AtomData
@@ -25,6 +24,7 @@ from tardis.io.model.parse_density_configuration import (
     calculate_power_law_density,
 )
 from tardis.io.model.readers.generic_readers import read_uniform_mass_fractions
+from tardis.io.util import TARDIS_PATH
 from tardis.model import SimulationState
 from tardis.util.base import (
     atomic_number2element_symbol,
@@ -34,7 +34,7 @@ from tardis.util.base import (
 from tardis.util.environment import Environment
 from tardis.visualization.widgets.util import debounce
 
-BASE_DIR = tardis.__path__[0]
+BASE_DIR = str(TARDIS_PATH)
 YAML_DELIMITER = "---"
 
 


### PR DESCRIPTION
---

### :pencil: Description

**Type:** :beetle: `bugfix`

This PR fixes the namespace collision issue where TARDIS fails to locate its internal data directory when a local folder named tardis exists in the user's working directory.

**Problem:**  
When a user creates or has a folder named tardis in their current working directory, Python treats it as a namespace package. This caused `tardis.__path__` to return the local folder path instead of the installed package path, breaking internal data file lookups and causing import failures like:
```python
from tardis.workflows.v_inner_solver import *  # FileNotFoundError
```

**Solution:**  
- Replaced all uses of `tardis.__path__[0]` with `Path(__file__).resolve()` for robust path resolution
- Replaced all uses of `tardis.__version__` with `importlib.metadata.version("tardis")` for reliable version access
- Created a centralized `TARDIS_PATH` constant in util.py that other modules import

**Fixes:** #3021

---

### :pushpin: Resources

- [Python pathlib documentation](https://docs.python.org/3/library/pathlib.html)
- [Python importlib.metadata documentation](https://docs.python.org/3/library/importlib.metadata.html)

---

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [x] Other method (describe)

**Manual verification:**
1. Created a local tardis directory in `~/Downloads` to simulate namespace collision
2. Verified `tardis.__path__` returns wrong path (expected Python behavior, cannot change)
3. Verified `TARDIS_PATH` correctly resolves to installed package path
4. Confirmed `from tardis.workflows.v_inner_solver import *` works without error

```python
# Test with namespace collision
>>> import tardis
>>> tardis.__path__
['/home/user/Downloads/tardis']  # Wrong (Python namespace behavior)

>>> from tardis.io.util import TARDIS_PATH
>>> print(TARDIS_PATH)
/home/user/tardis/tardis  # Correct!

>>> from tardis.workflows.v_inner_solver import *
SUCCESS  # Import works!
```

---

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

AI Usage Statement
Tool used: GitHub Copilot (GPT-5.3-Codex)
How used: Refining code changes, checking imports/path handling, and improving PR wording.

Confirmation: I confirm that I have read the [PR Checklist](https://tardis-sn.github.io/summer_of_code/pr_checklist/) and the [AI and LLM Usage Policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy/). I fully understand all AI-assisted changes and can explain every modification in this PR.