### PR TITLE
[GSOC] fix test convergence plot which fails in vscode

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,3 +309,4 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+Palak Bisht <palakb273@gmail.com>

--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -223,7 +223,7 @@ def test_convergence_plot_command_line(
     config_verysimple, atomic_dataset, monkeysession
 ):
     monkeysession.setattr(
-        "tardis.util.environment.Environment.is_notebook",
+        "tardis.util.environment.Environment.allows_widget_display",
         lambda: False,
     )
     atomic_data = deepcopy(atomic_dataset)


### PR DESCRIPTION
# Convergence Plot VSCode Test Fix README

## Description

This change fixes a test mismatch reported in local VSCode runs for:

- `tardis/visualization/tools/tests/test_convergence_plot.py::test_convergence_plot_command_line`

The test previously monkeypatched:

- `Environment.is_notebook = False`

But the runtime check now uses:

- `Environment.allows_widget_display()`

In VSCode, `allows_widget_display()` can still return `True`, so the test no
longer reliably triggered the expected `RuntimeError`.

### What changed

- Updated the monkeypatch target in the test from:
  - `Environment.is_notebook`
- To:
  - `Environment.allows_widget_display`

This aligns the test with the actual guard used in production code and makes
the behavior consistent across terminal/VSCode environments.

**Fixes:** #3417

## AI Usage Statement

AI tools were used for this contribution.

- Tool: Chat gpt
- Usage: Assisted with root-cause analysis and this README.
- Verification: I reviewed and understand all AI-assisted changes and can
  explain them.

## Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

### Local verification

- Ran:
  - `pytest -q -rs tardis/visualization/tools/tests/test_convergence_plot.py -k convergence_plot_command_line`
- Result:
  - Test selection worked, but this test is skipped locally without
    `--tardis-regression-data`.
- Verified diff is limited to the monkeypatch target in the single test.

## PR Checklist Mapping

- [x] One pull request for one specific task (test fix only)
- [x] Explicit AI usage statement included
- [x] PR description content prepared in template style
- [ ] PR title includes `[GSoC]` (apply when opening PR)
- [ ] Address review/bot comments within 48 hours (follow during review)
- [ ] Subject understanding confirmed before opening PR


