### PR TITLE
[GSOC] Add unit tests for DilutePlanckianRadiationField

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -308,4 +308,5 @@ Haille Perkins <haillep2@illinois.edu>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
-Connor McClellan <b.connor.mcc@gmail.com>
+Connor McClellan <b.connor.mcc@gmail.com>Punya Shree S <punyasomashekara@gmail.com>
+

--- a/tardis/plasma/radiation_field/tests/test_dilute_planckian_radiation_field.py
+++ b/tardis/plasma/radiation_field/tests/test_dilute_planckian_radiation_field.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+import astropy.units as u
+
+from tardis.plasma.radiation_field.planck_rad_field import (
+    DilutePlanckianRadiationField,
+)
+
+
+def test_length_mismatch_raises():
+    """Temperature and dilution factor lengths must match."""
+    temperature = np.array([5000, 6000]) * u.K
+    dilution_factor = np.array([0.5])  
+
+    with pytest.raises(AssertionError):
+        DilutePlanckianRadiationField(temperature, dilution_factor)
+
+
+def test_negative_temperature_raises():
+    """Temperature must be positive."""
+    temperature = np.array([-5000, 6000]) * u.K
+    dilution_factor = np.array([0.5, 0.6])
+
+    with pytest.raises(AssertionError):
+        DilutePlanckianRadiationField(temperature, dilution_factor)
+
+
+def test_temperature_kelvin_property():
+    """temperature_kelvin should return values in Kelvin."""
+    temperature = np.array([5000, 6000]) * u.K
+    dilution_factor = np.array([0.5, 0.6])
+
+    rf = DilutePlanckianRadiationField(temperature, dilution_factor)
+
+    result = rf.temperature_kelvin
+
+    assert isinstance(result, np.ndarray)
+    assert np.allclose(result, np.array([5000, 6000]))

--- a/tardis/plasma/radiation_field/tests/test_dilute_planckian_radiation_field.py
+++ b/tardis/plasma/radiation_field/tests/test_dilute_planckian_radiation_field.py
@@ -30,9 +30,26 @@ def test_temperature_kelvin_property():
     temperature = np.array([5000, 6000]) * u.K
     dilution_factor = np.array([0.5, 0.6])
 
-    rf = DilutePlanckianRadiationField(temperature, dilution_factor)
+    radiation_field = DilutePlanckianRadiationField(temperature, dilution_factor)
 
-    result = rf.temperature_kelvin
+    result = radiation_field.temperature_kelvin
 
     assert isinstance(result, np.ndarray)
     assert np.allclose(result, np.array([5000, 6000]))
+
+
+
+def test_calculate_mean_intensity_shape():
+    temperature = np.array([5000, 6000]) * u.K
+    dilution_factor = np.array([0.5, 0.6])
+
+    radiation_field = DilutePlanckianRadiationField(
+        temperature, dilution_factor
+    )
+
+    nu = np.array([1e14, 2e14])
+
+    intensity = radiation_field.calculate_mean_intensity(nu)
+
+    # shape should be (n_shells, n_frequencies)
+    assert intensity.shape == (len(temperature), len(nu))

--- a/tardis/plasma/radiation_field/tests/test_dilute_planckian_radiation_field.py
+++ b/tardis/plasma/radiation_field/tests/test_dilute_planckian_radiation_field.py
@@ -10,7 +10,7 @@ from tardis.plasma.radiation_field.planck_rad_field import (
 def test_length_mismatch_raises():
     """Temperature and dilution factor lengths must match."""
     temperature = np.array([5000, 6000]) * u.K
-    dilution_factor = np.array([0.5])  
+    dilution_factor = np.array([0.5])
 
     with pytest.raises(AssertionError):
         DilutePlanckianRadiationField(temperature, dilution_factor)
@@ -38,8 +38,13 @@ def test_temperature_kelvin_property():
     assert np.allclose(result, np.array([5000, 6000]))
 
 
+def test_calculate_mean_intensity_regression():
+    """
+    Regression test for calculate_mean_intensity.
 
-def test_calculate_mean_intensity_shape():
+    Uses controlled input and compares against reference values
+    generated from a trusted run of the solver.
+    """
     temperature = np.array([5000, 6000]) * u.K
     dilution_factor = np.array([0.5, 0.6])
 
@@ -51,5 +56,20 @@ def test_calculate_mean_intensity_shape():
 
     intensity = radiation_field.calculate_mean_intensity(nu)
 
-    # shape should be (n_shells, n_frequencies)
-    assert intensity.shape == (len(temperature), len(nu))
+    # getting reference data
+    print(intensity)
+
+    # --- Custom reference data (regression values) ---
+    #replaced these values with actual output from a trusted run (intensity values)
+    expected = np.array([
+                [4.57549236e-06, 7.22050336e-06],
+                [1.01359416e-05, 1.79098807e-05],
+                ])
+
+    # --- Assertions ---
+    assert intensity.shape == expected.shape
+    assert np.all(np.isfinite(intensity))
+    assert np.all(intensity >= 0)
+
+    # Regression check
+    assert np.allclose(intensity, expected, rtol=1e-5)


### PR DESCRIPTION
:pencil: Description

Type: :vertical_traffic_light: testing

This PR adds focused unit tests for DilutePlanckianRadiationField.

Currently, the radiation field is exercised indirectly through higher-level plasma tests, but there are no dedicated unit tests validating its constructor guards and property behaviour. This PR improves test coverage and helps catch regressions earlier. I used regression data from a trusted run as regression data.

Changes introduced:
~ Added test for temperature and dilution length mismatch
~ Added test for negative temperature validation
~ Added test for temperature_kelvin property behavior
No production code was modified.

:pushpin: Resources
~TARDIS plasma radiation field module
~Existing plasma equilibrium tests used as reference for usage patterns

:vertical_traffic_light: Testing
How did you test these changes?
✅ Testing pipeline
[] Other method (describe)

Details:
- Ran targeted pytest on the new test file
- Verified all new tests pass locally
- Confirmed no regressions in existing test collection

:ballot_box_with_check: Checklist
⬜️ I requested two reviewers for this pull request
⬜️ I updated the documentation according to my changes
⬜️ I built the documentation by applying the build_docs label


### AI usage:
- I used ChatGPT to understand the core physics constraints to write tests and to undersatnd the classes or functions that were being tested.
- I fully undersatnd the code i generated and I've done background checks to verify it's correctness.
- I take full responsibility of this PR
