### PR TITLE
fix FileNotFoundError in regression tests

### DIFF
--- a/tardis/plasma/equilibrium/tests/test_level_populations.py
+++ b/tardis/plasma/equilibrium/tests/test_level_populations.py
@@ -68,7 +68,11 @@ class TestLevelPopulationSolver:
 
     def test_solve(self, regression_data):
         """Test the solve method."""
-        expected_populations = False
         result = self.solver.solve()
-        expected_populations = regression_data.sync_dataframe(result)
+
+        # The order of parameters in the auto-generated filename has changed.
+        # We manually specify the path to the existing regression file.
+        expected_fname = "test_solve__collisional_rate_solver0-radiative_transitions0__.h5"
+        expected_fpath = regression_data.fpath.parent / expected_fname
+        expected_populations = pd.read_hdf(expected_fpath)
         pdt.assert_frame_equal(result, expected_populations, atol=0, rtol=1e-15)

--- a/tardis/plasma/equilibrium/tests/test_rate_matrix.py
+++ b/tardis/plasma/equilibrium/tests/test_rate_matrix.py
@@ -33,7 +33,11 @@ def test_rate_matrix_solver(
 
     actual = rate_matrix_solver.solve(rad_field, electron_dist)
 
-    expected = regression_data.sync_dataframe(actual)
+    # The order of parameters in the auto-generated filename has changed.
+    # We manually specify the path to the existing regression file.
+    expected_fname = "test_rate_matrix_solver__collisional_rate_solver0-radiative_transitions0__.h5"
+    expected_fpath = regression_data.fpath.parent / expected_fname
+    expected = pd.read_hdf(expected_fpath)
 
     pdt.assert_frame_equal(actual, expected, atol=0, rtol=1e-15)
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

While running the full test suite with the regression data, two equilibrium plasma tests fail due to filename mismatch between the expected files and the files present in the tardis-regression-data repository
- In test_level_populations.py::test_solve the file name is manually specified
- In test_rate_matrix.py::test_rate_matrix_solver the file name for regression data is manually specifed

It happened due to change in order of parameters in the auto generated file name by regression_data.sync_dataframe()

**Before:**
 <img width="1452" height="568" alt="Screenshot From 2026-02-27 12-38-12" src="https://github.com/user-attachments/assets/d140d6aa-912c-4cd1-bf6e-7df00537db65" />

**Now:**
<img width="1452" height="486" alt="Screenshot From 2026-02-27 14-42-51" src="https://github.com/user-attachments/assets/d045d283-92a2-4abd-9dc6-56b06c73c5b2" />


Resolves #3354 

### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.

### AI Usage
I have read the checklist and the [AI usage policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy)
No AI or LLM tools were used in any part of the contribution.