### PR TITLE
[GSOC] input validation to opacity calculator

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,3 +309,5 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+Palak Bisht <palakb273@gmail.com>
+

--- a/tardis/analysis/opacities.py
+++ b/tardis/analysis/opacities.py
@@ -5,7 +5,10 @@ import logging
 
 import astropy.units as units
 import numpy as np
-from astropy.modeling.models import Blackbody
+try:
+    from astropy.modeling.models import Blackbody
+except ImportError:
+    from astropy.modeling.models import BlackBody as Blackbody
 
 from tardis import constants as const
 
@@ -123,6 +126,22 @@ class OpacityCalculator:
 
         self._reset_opacities()
 
+    @staticmethod
+    def _coerce_wavelength_boundary(val, name):
+        if val is None:
+            raise ValueError(f"{name} cannot be None")
+
+        try:
+            return val.to("AA")
+        except AttributeError:
+            logger.warning("%s provided without units; assuming AA", name)
+            return val * units.AA
+
+    @staticmethod
+    def _validate_wavelength_order(lam_min, lam_max):
+        if lam_min >= lam_max:
+            raise ValueError("lam_min must be smaller than lam_max")
+
     @property
     def bin_scaling(self):
         return self._bin_scaling
@@ -139,17 +158,28 @@ class OpacityCalculator:
         self._bin_scaling = val
 
     @property
+    def nbins(self):
+        return self._nbins
+
+    @nbins.setter
+    def nbins(self, val):
+        if isinstance(val, bool) or not isinstance(val, int | np.integer):
+            raise ValueError("nbins must be a positive integer")
+        if val <= 0:
+            raise ValueError("nbins must be a positive integer")
+        self._reset_bins()
+        self._nbins = val
+
+    @property
     def lam_min(self):
         return self._lam_min
 
     @lam_min.setter
     def lam_min(self, val):
+        val = self._coerce_wavelength_boundary(val, "lam_min")
+        if self.lam_max is not None:
+            self._validate_wavelength_order(val, self.lam_max)
         self._reset_bins()
-        try:
-            val.to("AA")
-        except AttributeError:
-            logger.warning("lam_min provided without units; assuming AA")
-            val *= units.AA
         self._lam_min = val
 
     @property
@@ -158,12 +188,10 @@ class OpacityCalculator:
 
     @lam_max.setter
     def lam_max(self, val):
+        val = self._coerce_wavelength_boundary(val, "lam_max")
+        if self.lam_min is not None:
+            self._validate_wavelength_order(self.lam_min, val)
         self._reset_bins()
-        try:
-            val.to("AA")
-        except AttributeError:
-            logger.warning("lam_max provided without units; assuming AA")
-            val *= units.AA
         self._lam_max = val
 
     @property
@@ -172,6 +200,8 @@ class OpacityCalculator:
 
     @mdl.setter
     def mdl(self, val):
+        if val is None:
+            raise ValueError("mdl cannot be None")
         self._reset_model()
         self._mdl = val
 

--- a/tardis/analysis/tests/test_opacities.py
+++ b/tardis/analysis/tests/test_opacities.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+
+import astropy.units as u
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "opacities.py"
+SPEC = importlib.util.spec_from_file_location("tardis_analysis_opacities", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+OpacityCalculator = MODULE.OpacityCalculator
+
+
+class DummyModel:
+    pass
+
+
+@pytest.mark.parametrize("nbins", [0, -1, 1.5, True])
+def test_opacity_calculator_rejects_invalid_nbins(nbins):
+    with pytest.raises(ValueError, match="nbins must be a positive integer"):
+        OpacityCalculator(DummyModel(), nbins=nbins)
+
+
+def test_opacity_calculator_rejects_none_model():
+    with pytest.raises(ValueError, match="mdl cannot be None"):
+        OpacityCalculator(None)
+
+
+@pytest.mark.parametrize(
+    ("lam_min", "lam_max"),
+    [
+        (2000 * u.AA, 1000 * u.AA),
+        (1000 * u.AA, 1000 * u.AA),
+    ],
+)
+def test_opacity_calculator_rejects_invalid_wavelength_order(lam_min, lam_max):
+    with pytest.raises(ValueError, match="lam_min must be smaller than lam_max"):
+        OpacityCalculator(DummyModel(), lam_min=lam_min, lam_max=lam_max)
+
+
+@pytest.mark.parametrize("boundary_name", ["lam_min", "lam_max"])
+def test_opacity_calculator_rejects_none_wavelength_boundaries(boundary_name):
+    kwargs = {boundary_name: None}
+
+    with pytest.raises(ValueError, match=rf"{boundary_name} cannot be None"):
+        OpacityCalculator(DummyModel(), **kwargs)


### PR DESCRIPTION
# OpacityCalculator Input Validation README

## Description

This change adds explicit input validation to `OpacityCalculator.__init__` in:

- `tardis/analysis/opacities.py`

Previously, some invalid constructor arguments were accepted and only failed later during frequency-grid setup or opacity calculations. That made the error source less obvious.

This update makes invalid inputs fail immediately with clear `ValueError` messages for the following cases:

- `mdl is None`
- `nbins <= 0`
- `nbins` is not an integer
- `lam_min >= lam_max`
- `lam_min is None`
- `lam_max is None`

The existing behavior for unitless wavelength inputs is preserved:

- unitless `lam_min` / `lam_max` values are still interpreted as Angstrom

An Astropy compatibility fallback was also added so the module imports cleanly when
`astropy.modeling.models.BlackBody` is available instead of `Blackbody`.

### What changed

- Added explicit validation for `mdl` in `OpacityCalculator.mdl`.
- Added a proper `nbins` property with validation enforcing a positive integer.
- Added helper methods to:
  - coerce wavelength boundaries to Angstrom
  - validate wavelength ordering
- Updated `lam_min` and `lam_max` setters to reject invalid or missing bounds.
- Added focused regression tests covering the invalid input cases.

**Fixes:** #3465

##  AI Usage Statement

AI tools were used for this contribution.

- Tool: Chatgpt
- Usage: Assisted with implementing the validation changes, and drafting this README.
- Verification: I reviewed and understand all AI-assisted changes and can
explain them.

## Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

### Local verification

- Ran:
  - `pytest tardis/analysis/tests/test_opacities.py`
- Result:
  - `9 passed`
- Also checked:
  - `python -m compileall tardis/analysis/opacities.py tardis/analysis/tests/test_opacities.py`

## PR Checklist Mapping

- [x] One pull request for one specific task (input validation only)
- [x] Explicit AI usage statement included
- [x] PR description content prepared in template style
- [ ] PR title includes `[GSoC]` (apply when opening PR)
- [ ] Address review/bot comments within 48 hours (follow during review)
- [ ] Subject understanding confirmed before opening PR
