### PR TITLE
[GSOC] Add radiative rates solver tests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -308,4 +308,5 @@ Haille Perkins <haillep2@illinois.edu>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
-Connor McClellan <b.connor.mcc@gmail.com>
+Connor McClellan <b.connor.mcc@gmail.com>Punya Shree S <punyasomashekara@gmail.com>
+

--- a/tardis/plasma/equilibrium/tests/test_radiative_rates_solver.py
+++ b/tardis/plasma/equilibrium/tests/test_radiative_rates_solver.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from tardis.plasma.equilibrium.rates.radiative_rates import (
+    RadiativeRatesSolver,
+)
+
+
+def make_valid_einstein_df():
+    index = pd.MultiIndex.from_tuples(
+        [(1, 0, 0, 1)],
+        names=[
+            "atomic_number",
+            "ion_number",
+            "level_number_lower",
+            "level_number_upper",
+        ],
+    )
+
+    return pd.DataFrame(
+        {
+            "A_ul": [1.0],
+            "B_ul": [2.0],
+            "B_lu": [3.0],
+            "nu": [4.0],
+        },
+        index=index,
+    )
+
+
+def test_missing_required_column_raises():
+    df = make_valid_einstein_df().drop(columns=["A_ul"])
+
+    with pytest.raises(AssertionError):
+        RadiativeRatesSolver(df)
+
+
+class DummyRadiationField:
+    def calculate_mean_intensity(self, nu):
+        return np.ones_like(nu)
+
+
+def test_solve_returns_dataframe():
+    df = make_valid_einstein_df()
+    solver = RadiativeRatesSolver(df)
+
+    rad_field = DummyRadiationField()
+    result = solver.solve(rad_field)
+
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+
+
+def test_solve_output_index_structure():
+    df = make_valid_einstein_df()
+    solver = RadiativeRatesSolver(df)
+
+    rad_field = DummyRadiationField()
+    result = solver.solve(rad_field)
+
+    expected_index_names = [
+        "atomic_number",
+        "ion_number",
+        "ion_number_source",
+        "ion_number_destination",
+        "level_number_source",
+        "level_number_destination",
+    ]
+
+    assert list(result.index.names) == expected_index_names


### PR DESCRIPTION
### :pencil: Description

Type: 🚦 testing

This PR adds focused unit tests for the RadiativeRatesSolver class to improve direct coverage of the plasma module.
Currently, parts of the plasma are primarily validated through larger workflow and regression tests, which can make failures harder to localize. These tests exercise the solver in isolation and validate key behaviors.


### :vertical_traffic_light: Testing

☑️ Testing pipeline
⬜️ Other method (describe)
⬜️ My changes can't be tested


Tests run locally with:

pytest tardis/plasma/equilibrium/tests/test_radiative_rates_solver.py -q


🤖 AI Usage Statement
- I used ChatGPT to understand the core physics constraints to write tests and to undersatnd the classes or functions that were being tested.
- I fully undersatnd the code i generated and I've done background checks to verify it's correctness.
- I take full responsibility of this PR


### :ballot_box_with_check: Checklist

- ☑️ I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

