### PR TITLE
[GSOC] fix keyerror when debug logging config section is missing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,3 +309,5 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
+Palak Bisht <palakb273@gmail.com>
+

--- a/.mailmap
+++ b/.mailmap
@@ -310,4 +310,3 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gm
 
 Connor McClellan <b.connor.mcc@gmail.com>
 Palak Bisht <palakb273@gmail.com>
-

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -87,20 +87,23 @@ class TARDISLogger:
         ValueError
             If an invalid log_level is provided.
         """
-        if "debug" in tardis_config:
-            specific_log_level = tardis_config["debug"].get(
+        debug_config = {}
+        if hasattr(tardis_config, "get"):
+            debug_config = tardis_config.get("debug") or {}
+
+        if isinstance(debug_config, dict) and debug_config:
+            specific_log_level = debug_config.get(
                 "specific_log_level", specific_log_level
             )
-            logging_level = log_level or tardis_config["debug"].get(
-                "log_level", "INFO"
-            )
-            if log_level and tardis_config["debug"].get("log_level"):
+            logging_level = log_level or debug_config.get("log_level", "INFO")
+            if log_level and debug_config.get("log_level"):
                 self.logger.debug(
                     "log_level is defined both in Functional Argument & YAML Configuration {debug section}, "
                     f"log_level = {log_level.upper()} will be used for Log Level Determination"
                 )
         else:
-            tardis_config["debug"] = {}
+            if hasattr(tardis_config, "__setitem__"):
+                tardis_config["debug"] = {}
             logging_level = log_level or self.config.DEFAULT_LEVEL
             specific_log_level = specific_log_level or self.config.DEFAULT_SPECIFIC_STATE
 

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -102,10 +102,9 @@ class TARDISLogger:
                     f"log_level = {log_level.upper()} will be used for Log Level Determination"
                 )
         else:
-            if hasattr(tardis_config, "__setitem__"):
-                tardis_config["debug"] = {}
             logging_level = log_level or self.config.DEFAULT_LEVEL
-            specific_log_level = specific_log_level or self.config.DEFAULT_SPECIFIC_STATE
+            if specific_log_level is None:
+                specific_log_level = self.config.DEFAULT_SPECIFIC_STATE
 
         logging_level = logging_level.upper()
         if logging_level not in self.config.LEVELS:


### PR DESCRIPTION
 Standard Workflow Logging Config Fix README

## Description

This change fixes a crash in the standard TARDIS workflow when logging
configuration is absent from the input config. Previously, the workflow
assumed `debug.log_level` existed and raised a `KeyError` in
`logging_state(...)` when the `debug` section was missing or empty.

This update makes logging configuration robust by:

- safely reading the `debug` section if present
- falling back to default logging levels when it is missing or empty
- avoiding `KeyError` for `log_level` and `specific_log_level`


## AI Usage Statement

AI tools were used for this contribution.

- Tool: Chatgpt
- Usage: Assisted with locating the logging configuration path and writing this readme.
- Verification: I reviewed and understand all AI-assisted changes and can explain them.

## Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

### Local verification

- Reviewed code paths to confirm missing `debug` no longer raises `KeyError`.
- Ensured default logging behavior is preserved when no configuration is set.

## PR Checklist Mapping

- [x] One pull request for one specific task (logging configuration robustness)
- [x] Explicit AI usage statement included
- [x] PR description content prepared in template style
- [ ] PR title includes `[GSoC]` (apply when opening PR)
- [ ] Address review/bot comments within 48 hours (follow during review)
- [ ] Subject understanding confirmed before opening PR
