### PR TITLE
Disable IIP workflow notebook rendering

### DIFF
--- a/docs/workflows/iip_workflow/iip_workflow.ipynb
+++ b/docs/workflows/iip_workflow/iip_workflow.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "cce5e0f6",
    "metadata": {},
    "outputs": [],
@@ -177,7 +177,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tardis-devel",
+   "display_name": "tardis",
    "language": "python",
    "name": "python3"
   },
@@ -191,10 +191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3",
-   "nbsphinx": {
-     "execute": "never"
-   }
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :memo: `documentation` 

Prevents the IIP workflow notebook rendering so that the docs build can complete. 

### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
