### PR TITLE
[GSoC] Add TARDIS Plot Generator Script for Setups Gallery

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -170,6 +170,8 @@ Morgan Sandler <msandler8@gmail.com> Morgan <msandler8@gmail.com>
 Musabbiha Zaheer <family5zaheer@gmail.com>
 Musabbiha Zaheer <family5zaheer@gmail.com> musabbihaz <78879726+musabbihaz@users.noreply.github.com>
 
+Milan Parmar <milanparmar3351@gmail.com>
+
 Nance Sarafina <31808841+sarafina325@users.noreply.github.com>
 
 Nathan Kowalski <56104113+kowal180@users.noreply.github.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -28,4 +28,13 @@ erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
+<<<<<<< HEAD
+<<<<<<< HEAD
+milanparmar3351@gmail.com,0009-0000-6464-0339
+=======
 araut7798@gmail.com ,0009-0009-4508-2218
+>>>>>>> upstream/master
+=======
+milanparmar3351@gmail.com,0009-0000-6464-0339
+araut7798@gmail.com ,0009-0009-4508-2218
+>>>>>>> ea867fcae75bd940c1c28ec2945daf690c56c229

--- a/docs/tardis_setups_gallery/.gitignore
+++ b/docs/tardis_setups_gallery/.gitignore
@@ -1,0 +1,4 @@
+outputs/
+__pycache__/
+*.pyc
+.ipynb_checkpoints/

--- a/docs/tardis_setups_gallery/README.md
+++ b/docs/tardis_setups_gallery/README.md
@@ -1,0 +1,66 @@
+# TARDIS Plot Generator
+
+This contribution introduces a small utility script that runs a TARDIS simulation 
+from a YAML configuration file and automatically generates commonly used diagnostic plots.
+
+The goal of this tool is to provide a simple way to explore simulation outputs and 
+visualize important properties of the synthetic spectrum.
+
+## Features
+
+The script generates three plots from a TARDIS simulation:
+
+- **Synthetic Spectrum** — Shows luminosity density as a function of wavelength for real and virtual packets.
+- **SDEC Plot** — Visualizes packet interaction processes such as electron scattering and line interactions.
+- **LIV Plot** — Displays the last interaction velocity distribution of packets by element.
+
+All plots are saved automatically as PNG files.
+
+## Files Included
+
+- `generate_plots.py` — Command-line script that runs the simulation and produces plots.
+- `tardis_example.yml` — Example configuration file used to run a minimal TARDIS simulation.
+
+## Requirements
+
+- Python
+- TARDIS
+- matplotlib
+
+Make sure TARDIS and its dependencies are installed before running the script:
+```bash
+pip install tardis matplotlib
+```
+
+## Usage
+
+Run the script from the command line:
+```bash
+python generate_plots.py --yml tardis_example.yml
+```
+
+Optional: specify a custom output directory (default is `outputs/`):
+```bash
+python generate_plots.py --yml tardis_example.yml --output my_outputs
+```
+
+## Output
+
+The script generates the following files inside the output directory:
+```
+outputs/
+├── spectrum_plot.png
+├── sdec_plot.png
+└── liv_plot.png
+```
+
+These plots provide a quick visual overview of the simulation results.
+
+## Example Workflow
+
+1. Provide a TARDIS YAML configuration file.
+2. Run the script.
+3. Inspect the generated plots in the output directory.
+
+This utility is intended as a lightweight exploration tool for users working with 
+TARDIS simulations and may serve as a starting point for building automated plot galleries.

--- a/docs/tardis_setups_gallery/generate_plots.py
+++ b/docs/tardis_setups_gallery/generate_plots.py
@@ -1,0 +1,155 @@
+"""
+Run a TARDIS simulation from a YAML configuration file,
+generate Spectrum, SDEC, and LIV plots, and save them as PNG or PDF files.
+
+Usage:
+    python generate_plots.py config.yml
+    python generate_plots.py config.yml --atom-data kurucz.h5 --format pdf --output my_plots
+"""
+
+import argparse
+import os
+import sys
+
+import matplotlib as mpl
+
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+from tardis import run_tardis
+from tardis.visualization import LIVPlotter, SDECPlotter
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Generate TARDIS plots from a YAML configuration file."
+    )
+    parser.add_argument(
+        "config",
+        type=str,
+        help="Path to the TARDIS YAML configuration file.",
+    )
+    parser.add_argument(
+        "--atom-data",
+        type=str,
+        default=None,
+        help="Path to the atomic dataset (.h5).",
+    )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["png", "pdf"],
+        default="png",
+        help="Output format: png or pdf.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="outputs",
+        help="Output folder for plots.",
+    )
+    return parser.parse_args()
+
+
+def run_simulation(config_path, atom_data=None):
+    print(f"\n[1/4] Running TARDIS simulation from: {config_path}")
+    try:
+        kwargs = {}
+        if atom_data is not None:
+            kwargs["atom_data"] = atom_data
+        sim = run_tardis(
+            config_path,
+            virtual_packet_logging=True,
+            **kwargs,
+        )
+    except Exception as e:
+        print(f"Error: Simulation failed: {e}")
+        sys.exit(1)
+    print("      Simulation complete!")
+    return sim
+
+
+def generate_spectrum_plot(sim, output_dir, fmt="png"):
+    print("\n[2/4] Generating Spectrum plot...")
+    try:
+        fig, ax = plt.subplots(figsize=(10, 6))
+
+        spectrum = sim.spectrum_solver.spectrum_real_packets
+        spectrum_virtual = sim.spectrum_solver.spectrum_virtual_packets
+
+        ax.plot(
+            spectrum.wavelength.value,
+            spectrum.luminosity_density_lambda.value,
+            label="Real packets",
+            color="steelblue",
+        )
+        ax.plot(
+            spectrum_virtual.wavelength.value,
+            spectrum_virtual.luminosity_density_lambda.value,
+            label="Virtual packets",
+            color="darkorange",
+            linestyle="--",
+        )
+        ax.set_xlabel("Wavelength (A)")
+        ax.set_ylabel("Luminosity Density (erg/s/A)")
+        ax.set_title("TARDIS Synthetic Spectrum")
+        ax.legend()
+        ax.grid(True, alpha=0.3)
+        output_path = os.path.join(output_dir, f"spectrum_plot.{fmt}")
+        fig.savefig(output_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"      Saved -> {output_path}")
+    except Exception as e:
+        print(f"      Warning: Spectrum plot failed: {e}")
+        plt.close("all")
+
+
+def generate_sdec_plot(sim, output_dir, fmt="png"):
+    print("\n[3/4] Generating SDEC plots...")
+    try:
+        plotter = SDECPlotter.from_simulation(sim)
+        for mode in ["real", "virtual"]:
+            print(f"\n  Generating SDEC plot [packets_mode={mode}]...")
+            ax = plotter.generate_plot_mpl(packets_mode=mode)
+            output_path = os.path.join(output_dir, f"sdec_{mode}.{fmt}")
+            ax.get_figure().savefig(output_path, dpi=150, bbox_inches="tight")
+            plt.close("all")
+            print(f"      Saved -> {output_path}")
+    except Exception as e:
+        print(f"      Warning: SDEC plot failed: {e}")
+        plt.close("all")
+
+
+def generate_liv_plot(sim, output_dir, fmt="png"):
+    print("\n[4/4] Generating LIV plots...")
+    try:
+        plotter = LIVPlotter.from_simulation(sim)
+        for mode in ["real", "virtual"]:
+            print(f"\n  Generating LIV plot [packets_mode={mode}]...")
+            ax = plotter.generate_plot_mpl(packets_mode=mode)
+            output_path = os.path.join(output_dir, f"liv_{mode}.{fmt}")
+            ax.get_figure().savefig(output_path, dpi=150, bbox_inches="tight")
+            plt.close("all")
+            print(f"      Saved -> {output_path}")
+    except Exception as e:
+        print(f"      Warning: LIV plot failed: {e}")
+        plt.close("all")
+
+
+def main():
+    args = parse_arguments()
+    if not os.path.exists(args.config):
+        print(f"Error: YAML file not found: {args.config}")
+        return
+    os.makedirs(args.output, exist_ok=True)
+    sim = run_simulation(args.config, atom_data=args.atom_data)
+    generate_spectrum_plot(sim, args.output, fmt=args.format)
+    generate_sdec_plot(sim, args.output, fmt=args.format)
+    generate_liv_plot(sim, args.output, fmt=args.format)
+    print("\nAll plots generated successfully!")
+    print(f"Find your plots in: {args.output}/")
+
+
+if __name__ == "__main__":
+    main()
+    

--- a/docs/tardis_setups_gallery/tardis_example.yml
+++ b/docs/tardis_setups_gallery/tardis_example.yml
@@ -1,0 +1,57 @@
+# Example YAML configuration for TARDIS
+tardis_config_version: v1.0
+
+supernova:
+  luminosity_requested: 9.44 log_lsun
+  time_explosion: 13 day
+
+atom_data: kurucz_cd23_chianti_H_He_latest.h5
+
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 1.1e4 km/s
+      stop: 20000 km/s
+      num: 20
+    density:
+      type: branch85_w7
+
+  abundances:
+    type: uniform
+    O: 0.19
+    Mg: 0.03
+    Si: 0.52
+    S: 0.19
+    Ar: 0.04
+    Ca: 0.03
+
+plasma:
+  disable_electron_scattering: no
+  ionization: lte
+  excitation: lte
+  radiative_rates_type: dilute-blackbody
+  line_interaction_type: macroatom
+
+montecarlo:
+  seed: 23111963
+  no_of_packets: 4.0e+4
+  iterations: 20
+  nthreads: 1
+
+  last_no_of_packets: 1.e+5
+  no_of_virtual_packets: 10
+
+  convergence_strategy:
+    type: damped
+    damping_constant: 1.0
+    threshold: 0.05
+    fraction: 0.8
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 0.5
+
+spectrum:
+  start: 500 angstrom
+  stop: 20000 angstrom
+  num: 10000


### PR DESCRIPTION
## Description
Type: 🚀 `feature`
Mentors: @andrewfullard @jvshields

This PR addresses the First Objective of TARDIS Setups Generated Plots and Gallery Project.

It adds a standalone script `generate_plots.py` and a demo notebook `generate_plots_demo.ipynb` that generate Spectrum, SDEC, and LIV plots from a given TARDIS configuration file.

---

## 📄 `generate_plots.py`
- Takes a TARDIS YAML config file as input, runs the simulation and generates the following **5 plots**:
  - `spectrum_plot.png/pdf` — Synthetic Spectrum (real + virtual packets)
  - `sdec_real.png/pdf` — SDEC plot (real packets)
  - `sdec_virtual.png/pdf` — SDEC plot (virtual packets)
  - `liv_real.png/pdf` — LIV plot (real packets)
  - `liv_virtual.png/pdf` — LIV plot (virtual packets)
- Supports both `png` and `pdf` output formats via `--format`
- Supports both `real` and `virtual` packets mode for SDEC and LIV plots
- Takes `--atom-data` to override atomic dataset path from command line
- Saves all plots to a specified output directory via `--output`

### Arguments
| Argument | Description | Default |
|---|---|---|
| `config` | Path to TARDIS YAML config file | required |
| `--atom-data` | Path to atomic dataset (.h5) | from config |
| `--format` | Output format: `png` or `pdf` | `png` |
| `--output` | Output folder for plots | `outputs` |

### Example Usage
```bash
python generate_plots.py tardis_example.yml
python generate_plots.py tardis_example.yml --format pdf --output my_plots
python generate_plots.py tardis_example.yml --atom-data kurucz.h5 --format png
```

---

## 📓 `generate_plots_demo.ipynb`
- Demonstrates the basic usage of `generate_plots.py`
- Shows how to generate and display all 5 plots for a TARDIS simulation configuration

---

## ✅ Advantages
- Generates **Spectrum plot** (real + virtual) in addition to SDEC and LIV — unique to this PR
- Both `real` and `virtual` packets supported for all plots
- Both `png` and `pdf` formats supported
- Simple and clean CLI interface

---

## 🚦 Testing
The script was tested locally by running it on multiple TARDIS configuration files.

---

## ☑️ Checklist
- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label