### PR TITLE
[GSoC]fix: reduce photosphere size in RPacketPlotter

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -310,3 +310,5 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gm
 
 Connor McClellan <b.connor.mcc@gmail.com>
 Aditya Raut <araut7798@gmail.com>
+
+Kona Nagadevi <nagadevikona20@gmail.com> nagadevikona20-max <nagadevikona20@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -29,3 +29,4 @@ lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
 araut7798@gmail.com ,0009-0009-4508-2218
+nagadevikona20@gmail.com,0009-0005-2784-6895

--- a/tardis/visualization/tools/rpacket_plot.py
+++ b/tardis/visualization/tools/rpacket_plot.py
@@ -307,9 +307,17 @@ class RPacketPlotter:
                 y1=v_shells[shell_no],
             )
             if shell_no == 0:
-                # photosphere
+                # photosphere - drawn at half the inner shell radius so it is
+                # visually smaller than (and distinct from) the innermost shell
+                photo_r = v_shells[shell_no] * 0.5
                 self.fig.add_shape(
-                    **shape_props,
+                    type="circle",
+                    xref="x",
+                    yref="y",
+                    x0=-photo_r,
+                    y0=-photo_r,
+                    x1=photo_r,
+                    y1=photo_r,
                     line_color=self.theme_colors[theme][
                         "photosphere_line_color"
                     ],


### PR DESCRIPTION
📝 Description
Type: 🪲 bugfix

The photosphere circle in `RPacketPlotter.generate_plot()` was drawn at
the full inner shell boundary radius (`v_shells[0]`), making it
visually the same size as the innermost shell. This caused overlap and
reduced plot readability.

Changes made:
- Computed `photo_r = 0.5 * v_shells[0]` to scale the photosphere down
- Used explicit `x0, y0, x1, y1` coordinates for the photosphere
  instead of unpacking `shape_props`, giving it an independent radius

fixes #2116

📌 Resources
- Issue #2116

🚦 Testing
How did you test these changes?

- [ ] Testing pipeline
- [x] Other method verified visually that the photosphere circle is
  now clearly smaller and distinct from the first shell boundary
- [ ] My changes can't be tested (explain why)

☑️ Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [x] I built the documentation by applying the `build_docs` label

AI Usage Statement:
I used an AI tool only to help improve the clarity and structure of the PR description. All technical work including identifying the issue, reasoning about the fix, and implementing the scaling of the photosphere radius was done independently by me.
Tool Used: 
Gemini 3

> Note: If you are not allowed to perform any of these actions, ping (@) a contributor.


