### PR TITLE
[GSoC] refactor: Upgrade raw print() statements to standard logging in visualization module

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -309,4 +309,4 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
-Aditya Raut <araut7798@gmail.com>
+Aditya Raut <araut7798@gmail.com>s7g4 <shauryagaur07@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -309,4 +309,7 @@ Riddhi Gangbhoj <riddhigangbhoj76@gmail.com>
 Riddhi Gangbhoj <riddhigangbhoj76@gmail.com> riddhigangbhoj <riddhigangbhoj76@gmail.com>
 
 Connor McClellan <b.connor.mcc@gmail.com>
-Aditya Raut <araut7798@gmail.com>s7g4 <shauryagaur07@gmail.com>
+Aditya Raut <araut7798@gmail.com>
+
+Shaurya Gaur <shauryagaur07@gmail.com>
+Shaurya Gaur <shauryagaur07@gmail.com> s7g4 <shauryagaur07@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -29,3 +29,4 @@ lujingeve158@gmail.com,0000-0002-3900-1452
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
 araut7798@gmail.com ,0009-0009-4508-2218
+shauryagaur07@gmail.com,0009-0007-3297-9152

--- a/tardis/visualization/__init__.py
+++ b/tardis/visualization/__init__.py
@@ -1,5 +1,9 @@
 """Visualization tools and widgets for TARDIS."""
 
+import logging
+
+import panel as pn
+
 from tardis.visualization.tools.convergence_plot import ConvergencePlots
 from tardis.visualization.tools.liv_plot import LIVPlotter
 from tardis.visualization.tools.rpacket_plot import RPacketPlotter
@@ -12,9 +16,19 @@ from tardis.visualization.widgets.shell_info import (
     shell_info_from_simulation,
 )
 
-import logging
+__all__ = [
+    "ConvergencePlots",
+    "LIVPlotter",
+    "RPacketPlotter",
+    "SDECPlotter",
+    "CustomAbundanceWidget",
+    "GrotrianWidget",
+    "LineInfoWidget",
+    "shell_info_from_hdf",
+    "shell_info_from_simulation",
+]
 
 logger = logging.getLogger(__name__)
 logger.info("Initializing tabulator and plotly panel extensions for widgets to work")
-import panel as pn
+
 pn.extension("tabulator", "plotly")

--- a/tardis/visualization/__init__.py
+++ b/tardis/visualization/__init__.py
@@ -12,7 +12,9 @@ from tardis.visualization.widgets.shell_info import (
     shell_info_from_simulation,
 )
 
+import logging
 
-print("Initializing tabulator and plotly panel extensions for widgets to work")
+logger = logging.getLogger(__name__)
+logger.info("Initializing tabulator and plotly panel extensions for widgets to work")
 import panel as pn
 pn.extension("tabulator", "plotly")

--- a/tardis/visualization/__init__.py
+++ b/tardis/visualization/__init__.py
@@ -18,12 +18,12 @@ from tardis.visualization.widgets.shell_info import (
 
 __all__ = [
     "ConvergencePlots",
-    "LIVPlotter",
-    "RPacketPlotter",
-    "SDECPlotter",
     "CustomAbundanceWidget",
     "GrotrianWidget",
+    "LIVPlotter",
     "LineInfoWidget",
+    "RPacketPlotter",
+    "SDECPlotter",
     "shell_info_from_hdf",
     "shell_info_from_simulation",
 ]
@@ -31,4 +31,4 @@ __all__ = [
 logger = logging.getLogger(__name__)
 logger.info("Initializing tabulator and plotly panel extensions for widgets to work")
 
-pn.extension("tabulator", "plotly")
+pn.extension("tabulator", "plotly")

--- a/tardis/visualization/conftest.py
+++ b/tardis/visualization/conftest.py
@@ -1,8 +1,10 @@
-from tardis.base import run_tardis
-import pytest
 from copy import deepcopy
+
+import pytest
+
 from tardis.base import run_tardis
 from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow
+
 
 @pytest.fixture(scope="module")
 def simulation_simple_tracked(config_verysimple, atomic_dataset):
@@ -50,7 +52,7 @@ def workflow_simple_tracked(config_verysimple, atomic_data_fname):
     config.montecarlo.no_of_virtual_packets = 1
     config.spectrum.num = 2000
     config_verysimple.montecarlo.tracking.track_rpacket = True
-    
+
     workflow = StandardTARDISWorkflow(config, enable_virtual_packet_logging=True)
     workflow.run()
     return workflow

--- a/tardis/visualization/plot_util.py
+++ b/tardis/visualization/plot_util.py
@@ -8,8 +8,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-from tardis.transport.montecarlo.packets.radiative_packet import InteractionType
-
 from tardis.util.base import (
     element_symbol2atomic_number,
     int_to_roman,
@@ -53,8 +51,7 @@ def axis_label_in_latex(label_text, unit, only_text=True):
 
     if only_text:
         return f"$\\text{{{label_text}}}\\,[{unit_in_latex}]$"
-    else:
-        return f"${label_text}\\,[{unit_in_latex}]$"
+    return f"${label_text}\\,[{unit_in_latex}]$"
 
 
 def get_mid_point_idx(arr):

--- a/tardis/visualization/sdec/util.py
+++ b/tardis/visualization/sdec/util.py
@@ -114,8 +114,7 @@ def calculate_absorption_luminosities(
                 "to plot luminosities instead of flux, set distance=None "
                 "or don't specify distance parameter in the function call."
             )
-        else:
-            lum_to_flux = 4.0 * np.pi * (distance.to("cm")) ** 2
+        lum_to_flux = 4.0 * np.pi * (distance.to("cm")) ** 2
     # Group packets_df by atomic number of elements with which packets
     # had their last absorption (interaction in)
     # or if species_list is requested then group by species id
@@ -272,8 +271,7 @@ def calculate_emission_luminosities(sim, packets_mode, packet_wvl_range, species
                 "to plot luminosities instead of flux, set distance=None "
                 "or don't specify distance parameter in the function call."
             )
-        else:
-            lum_to_flux = 4.0 * np.pi * (distance.to("cm")) ** 2
+        lum_to_flux = 4.0 * np.pi * (distance.to("cm")) ** 2
 
 
     # Histogram weights are packet luminosities or flux
@@ -309,7 +307,7 @@ def calculate_emission_luminosities(sim, packets_mode, packet_wvl_range, species
 
     # Contribution of packets which only experienced electron scattering
     mask_escatter = (
-        (packets_df["last_interaction_type"][packet_nu_range_mask] == InteractionType.ESCATTERING)
+        packets_df["last_interaction_type"][packet_nu_range_mask] == InteractionType.ESCATTERING
     ) & (
         packets_df["last_line_interaction_in_id"][packet_nu_range_mask]
         == InteractionType.NO_INTERACTION

--- a/tardis/visualization/tests/test_plot_util.py
+++ b/tardis/visualization/tests/test_plot_util.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tardis.transport.montecarlo.packets.radiative_packet import InteractionType
 from tardis.visualization.plot_util import (
     axis_label_in_latex,
     create_wavelength_mask,
@@ -14,7 +13,6 @@ from tardis.visualization.plot_util import (
     parse_species_list_util,
     to_rgb255_string,
 )
-from tardisbase.testing.regression_data.regression_data import PlotDataHDF
 
 
 class TestPlotUtil:

--- a/tardis/visualization/tools/convergence_plot.py
+++ b/tardis/visualization/tools/convergence_plot.py
@@ -1,17 +1,16 @@
 """Convergence Plots to see the convergence of the simulation in real time."""
 
 from collections import defaultdict
-import warnings
 
 import ipywidgets as widgets
 import numpy as np
-from astropy import units as u
-from IPython.display import HTML, display
 
 # Added the below as a (temporary) workaround to the latex
 # labels on the convergence plots not rendering correctly.
 import plotly
 import plotly.graph_objects as go
+from astropy import units as u
+from IPython.display import HTML, display
 
 import tardis.visualization.plot_util as pu
 

--- a/tardis/visualization/tools/lineid_plotter.py
+++ b/tardis/visualization/tools/lineid_plotter.py
@@ -46,7 +46,6 @@ def lineid_plotter(
     ax: matplotlib.axes._subplots.AxesSubplot
         the original ax with the line markers plotted
     """
-
     if plotter_kwargs is None:
         plotter_kwargs = {}
 

--- a/tardis/visualization/tools/lineid_plotter.py
+++ b/tardis/visualization/tools/lineid_plotter.py
@@ -3,7 +3,9 @@ try:
     from lineid_plot import get_line_flux
 
 except ImportError:
-    print("Please pip install lineid_plot to use the lineid_plotter function")
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.warning("Please pip install lineid_plot to use the lineid_plotter function")
     raise
 
 

--- a/tardis/visualization/tools/liv_plot.py
+++ b/tardis/visualization/tools/liv_plot.py
@@ -320,8 +320,7 @@ class LIVPlotter:
                     "No line interactions found in the packet data. "
                     "The LIV plot requires packets that underwent line interactions."
                 )
-            else:
-                raise ValueError("No species provided for plotting.")
+            raise ValueError("No species provided for plotting.")
         self.species = list(set(self._species_list) & set(species_in_model))
 
         if len(self.species) == 0:

--- a/tardis/visualization/tools/rpacket_plot.py
+++ b/tardis/visualization/tools/rpacket_plot.py
@@ -1,12 +1,9 @@
 import logging
-from typing import Dict, List, Optional, Tuple
 
 import astropy.units as u
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
-
-from tardis.transport.montecarlo.packets.radiative_packet import InteractionType
 
 
 class RPacketPlotter:
@@ -454,7 +451,7 @@ class RPacketPlotter:
         time: float,
         last_interaction_type: pd.Series,
         theta_initial: float = 0,
-    ) -> Tuple[np.ndarray, np.ndarray, List[int]]:
+    ) -> tuple[np.ndarray, np.ndarray, list[int]]:
         """
         Generate 2D coordinates for a single packet trajectory.
 
@@ -492,7 +489,7 @@ class RPacketPlotter:
 
         # getting thetas at different steps of the packet movement
 
-        for step_no in range(0, len(r_track)):
+        for step_no in range(len(r_track)):
             # for the first step the packet is at photosphere, so theta will be equal to the intial angle we are launching the packet from
             if step_no == 0:
                 theta.append(theta_initial)
@@ -533,7 +530,7 @@ class RPacketPlotter:
 
     def get_coordinates_multiple_packets(
         self, r_packet_tracker: pd.DataFrame
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         Generate coordinates for multiple packet trajectories.
 
@@ -561,7 +558,7 @@ class RPacketPlotter:
         """
         # Remove rows with any NaN values
         r_packet_tracker = r_packet_tracker.dropna()
-        
+
         # for plotting packets at equal intervals throught the circle, we choose thetas distributed uniformly
         thetas = np.linspace(0, 2 * np.pi, self.no_of_packets + 1)
         all_rpackets_x_coords = []
@@ -573,7 +570,7 @@ class RPacketPlotter:
             packet_data = r_packet_tracker.loc[packet_no]
             interaction_types = packet_data["interaction_type"]
             mu_data = packet_data["after_mu"]
-            
+
             (
                 rpacket_x,
                 rpacket_y,
@@ -599,7 +596,7 @@ class RPacketPlotter:
         rpacket_x: np.ndarray,
         rpacket_y: np.ndarray,
         interactions: np.ndarray,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
         """
         Normalize coordinate arrays to equal size for animation frames.
 
@@ -663,7 +660,7 @@ class RPacketPlotter:
         rpacket_y: np.ndarray,
         interactions: np.ndarray,
         theme: str,
-    ) -> List[go.Scatter]:
+    ) -> list[go.Scatter]:
         """
         Create individual animation frames with scatter plot objects.
 
@@ -707,7 +704,7 @@ class RPacketPlotter:
         rpacket_y: np.ndarray,
         interactions: np.ndarray,
         theme: str,
-        frame: Optional[int] = None,
+        frame: int | None = None,
     ) -> go.Scatter:
         """
         Create a scatter plot object for a single packet trajectory.
@@ -782,7 +779,7 @@ class RPacketPlotter:
             ),
         )
 
-    def get_slider_steps(self, rpacket_max_array_size: int) -> List[Dict]:
+    def get_slider_steps(self, rpacket_max_array_size: int) -> list[dict]:
         """
         Generate timeline slider steps for animated plot frames.
 

--- a/tardis/visualization/tools/sdec_plot.py
+++ b/tardis/visualization/tools/sdec_plot.py
@@ -16,13 +16,12 @@ import pandas as pd
 import plotly.graph_objects as go
 from astropy.modeling.models import BlackBody
 
-from tardis.transport.montecarlo.packets.radiative_packet import InteractionType
+from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 from tardis.util.base import (
     atomic_number2element_symbol,
     int_to_roman,
 )
 from tardis.visualization import plot_util as pu
-from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 
 logger = logging.getLogger(__name__)
 
@@ -997,7 +996,7 @@ class SDECPlotter:
         """Show matplotlib colorbar with labels of elements mapped to colors."""
         if len(self._species_name) == 0:
             return
-            
+
         color_values = [
             self.cmap(species_counter / len(self._species_name))
             for species_counter in range(len(self._species_name))
@@ -1273,7 +1272,7 @@ class SDECPlotter:
         """Show plotly colorbar with labels of elements mapped to colors."""
         if len(self._species_name) == 0:
             return
-            
+
         # Interpolate [0, 1] range to create bins equal to number of elements
         colorscale_bins = np.linspace(0, 1, num=len(self._species_name) + 1)
 

--- a/tardis/visualization/tools/tests/test_convergence_plot.py
+++ b/tardis/visualization/tools/tests/test_convergence_plot.py
@@ -7,14 +7,9 @@ import plotly.graph_objects as go
 import pytest
 from astropy import units as u
 
-from tardis import run_tardis
-from tardis.visualization.tools.convergence_plot import (
-    ConvergencePlots
-)
-from collections import defaultdict
-import plotly.graph_objects as go
-from astropy import units as u
 import tardis.visualization.plot_util as pu
+from tardis import run_tardis
+from tardis.visualization.tools.convergence_plot import ConvergencePlots
 
 
 @pytest.fixture(scope="module", params=[0, 1, 2])

--- a/tardis/visualization/tools/tests/test_lineid_plotter.py
+++ b/tardis/visualization/tools/tests/test_lineid_plotter.py
@@ -1,10 +1,12 @@
 import pytest
-from tardis.visualization.tools.sdec_plot import SDECPlotter
 from matplotlib.testing.compare import compare_images
+
+from tardis.visualization.tools.sdec_plot import SDECPlotter
 
 # check if lineid_plot is installed
 lineid_plot = pytest.importorskip("lineid_plot", reason="lineid_plot is not installed")
 from tardis.visualization.tools.lineid_plotter import lineid_plotter
+
 
 @pytest.fixture(scope="module")
 def plotter(simulation_simple_tracked):

--- a/tardis/visualization/tools/tests/test_liv_plot.py
+++ b/tardis/visualization/tools/tests/test_liv_plot.py
@@ -1,18 +1,15 @@
 from itertools import product
-from copy import deepcopy
 
 import astropy.units as u
 import numpy as np
+import pandas as pd
 import pytest
 from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 from matplotlib.testing.compare import compare_images
-
-import pandas as pd
+from tardisbase.testing.regression_data.regression_data import PlotDataHDF
 
 from tardis.visualization.tools.liv_plot import LIVPlotter
-from tardis.workflows.standard_tardis_workflow import StandardTARDISWorkflow
-from tardisbase.testing.regression_data.regression_data import PlotDataHDF
 
 RELATIVE_TOLERANCE_LIV=1e-12
 
@@ -304,8 +301,8 @@ class TestLIVPlotter:
                         path.vertices,
                         expected.get(
                             "plot_data_hdf/"
-                            + "polypath"
-                            + "ind_"
+                             "polypath"
+                             "ind_"
                             + str(index1)
                             + "ind_"
                             + str(index2)
@@ -512,25 +509,25 @@ class TestLIVPlotter:
         self, plotter_prepare_plot_data_from_workflow, liv_regression_data
     ):
         param_idx = plotter_prepare_plot_data_from_workflow._param_idx
-        
+
         for attribute in ["plot_data", "plot_colors", "new_bin_edges"]:
             if attribute == "plot_data" or attribute == "plot_colors":
                 regression_file = liv_regression_data / f"test_prepare_plot_data__plotter_prepare_plot_data{param_idx}-{attribute}__.npy"
                 expected = np.load(regression_file)
-                
+
                 plot_object = getattr(plotter_prepare_plot_data_from_workflow, attribute)
                 plot_object = [item for sublist in plot_object for item in sublist]
                 if all(isinstance(item, u.Quantity) for item in plot_object):
                     plot_object = [item.value for item in plot_object]
-                    
+
                 np.testing.assert_allclose(plot_object, expected, atol=0, rtol=RELATIVE_TOLERANCE_LIV)
             else:
                 regression_file = liv_regression_data / f"test_prepare_plot_data__plotter_prepare_plot_data{param_idx}-{attribute}__.npy"
                 expected = np.load(regression_file)
-                
+
                 plot_object = getattr(plotter_prepare_plot_data_from_workflow, attribute)
                 plot_object = plot_object.value
-                
+
                 np.testing.assert_allclose(plot_object, expected, atol=0, rtol=RELATIVE_TOLERANCE_LIV)
 
     @pytest.fixture(scope="class", params=list(enumerate(combinations)))
@@ -566,18 +563,18 @@ class TestLIVPlotter:
         _, plotter = plotter_generate_plot_mpl_from_workflow
         param_idx = plotter._param_idx
         regression_file = liv_regression_data / f"test_generate_plot_mpl__plotter_generate_plot_mpl{param_idx}__.h5"
-        
+
         # Compare species names and color lists
         expected_species = pd.read_hdf(regression_file, key="plot_data_hdf/_species_name")
         expected_colors = pd.read_hdf(regression_file, key="plot_data_hdf/_color_list")
         expected_step_x = pd.read_hdf(regression_file, key="plot_data_hdf/step_x")
         expected_step_y = pd.read_hdf(regression_file, key="plot_data_hdf/step_y")
-        
+
         np.testing.assert_array_equal(plotter._species_name, expected_species.values.flatten())
-        
+
         color_list = [item for subitem in plotter._color_list for item in subitem]
         np.testing.assert_allclose(color_list, expected_colors.values.flatten(), atol=0, rtol=RELATIVE_TOLERANCE_LIV)
-        
+
         np.testing.assert_allclose(plotter.step_x.value, expected_step_x.values.flatten(), atol=0, rtol=RELATIVE_TOLERANCE_LIV)
         np.testing.assert_allclose(plotter.step_y, expected_step_y.values.flatten(), atol=0, rtol=RELATIVE_TOLERANCE_LIV)
 
@@ -596,7 +593,7 @@ class TestLIVPlotter:
 
         plotter._prepare_plot_data(**params)
         plotter_from_workflow._prepare_plot_data(**params)
-        
+
         # Test that plot data arrays are identical
         for i, (sim_data, workflow_data) in enumerate(zip(plotter.plot_data, plotter_from_workflow.plot_data)):
             np.testing.assert_allclose(
@@ -608,13 +605,13 @@ class TestLIVPlotter:
     def test_mpl_image_workflow(self, plotter_generate_plot_mpl_from_workflow, tmp_path, liv_regression_data):
         fig, plotter = plotter_generate_plot_mpl_from_workflow
         param_idx = plotter._param_idx
-        
+
         # Save actual image
         actual_image_path = tmp_path / f"test_mpl_image_workflow_{param_idx}.png"
         fig.figure.savefig(actual_image_path)
-        
+
         # Path to expected image
         expected_image_path = liv_regression_data / f"test_mpl_image__plotter_generate_plot_mpl{param_idx}__.png"
-        
+
         # Compare images
         compare_images(str(expected_image_path), str(actual_image_path), tol=1e-3)

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -1,5 +1,6 @@
 """Class to create and display Custom Abundance Widget."""
 
+import logging
 from pathlib import Path
 
 import ipywidgets as ipw
@@ -7,8 +8,8 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import yaml
-from IPython.display import display
 from astropy import units as u
+from IPython.display import display
 from radioactivedecay import Nuclide
 from radioactivedecay.utils import Z_DICT, elem_to_Z
 
@@ -34,6 +35,8 @@ from tardis.util.base import (
 )
 from tardis.util.environment import Environment
 from tardis.visualization.widgets.util import debounce
+
+logger = logging.getLogger(__name__)
 
 BASE_DIR = tardis.__path__[0]
 YAML_DELIMITER = "---"
@@ -1287,8 +1290,6 @@ class CustomAbundanceWidget:
             A box that contains all the widgets in the GUI.
         """
         if not Environment.allows_widget_display():
-            import logging
-            logger = logging.getLogger(__name__)
             logger.warning("Please use a notebook to display the widget")
         else:
             # --------------Combine widget components--------------
@@ -1448,8 +1449,6 @@ class CustomAbundanceWidget:
 
             f.write(yaml_output)
 
-        import logging
-        logger = logging.getLogger(__name__)
         logger.info("Saved Successfully!")
 
     def write_csv_portion(self, path):

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -1286,7 +1286,9 @@ class CustomAbundanceWidget:
             A box that contains all the widgets in the GUI.
         """
         if not Environment.allows_widget_display():
-            print("Please use a notebook to display the widget")
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning("Please use a notebook to display the widget")
         else:
             # --------------Combine widget components--------------
             self.box_editor = ipw.HBox(
@@ -1445,7 +1447,9 @@ class CustomAbundanceWidget:
 
             f.write(yaml_output)
 
-        print("Saved Successfully!")
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.info("Saved Successfully!")
 
     def write_csv_portion(self, path):
         """Write the CSV portion of the output file.

--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import yaml
+from IPython.display import display
 from astropy import units as u
 from radioactivedecay import Nuclide
 from radioactivedecay.utils import Z_DICT, elem_to_Z
@@ -1718,16 +1719,6 @@ class DensityEditor:
         new_value = obj.new
         self.data.density_t_0 = new_value * self.data.density_t_0.unit
 
-    def input_d_time_0_eventhandler(self, obj):
-        """Update density time 0 data when the widget gets new input.
-
-        Parameters
-        ----------
-        obj : traitlets.utils.bunch.Bunch
-            A dictionary holding the information about the change.
-        """
-        new_value = obj.new
-        self.data.density_t_0 = new_value * self.data.density_t_0.unit
 
     dtype_out = ipw.Output()
 

--- a/tardis/visualization/widgets/grotrian.py
+++ b/tardis/visualization/widgets/grotrian.py
@@ -610,8 +610,8 @@ class GrotrianPlot:
                     y=level_info.y_coord * np.ones(10),
                     mode="lines",
                     hovertemplate=f"Energy: {level_info.energy:.2e} eV<br>"
-                    + f"Population: {level_info.population:.2e}"
-                    + "<extra></extra>",
+                     f"Population: {level_info.population:.2e}"
+                     "<extra></extra>",
                     line=dict(
                         color="black",
                         width=level_info.level_width_coefficient
@@ -755,8 +755,8 @@ class GrotrianPlot:
                     if is_excitation
                     else [y_upper, y_lower],
                     hovertemplate=f"Count: {int(line_info.num_electrons)}<br>"
-                    + f"Wavelength: {wavelength:.2e} {ANGSTROM_SYMBOL}"
-                    + "<extra></extra>",
+                     f"Wavelength: {wavelength:.2e} {ANGSTROM_SYMBOL}"
+                     "<extra></extra>",
                     marker=dict(
                         size=self.arrowhead_size,
                         color=color,
@@ -1177,7 +1177,7 @@ class GrotrianWidget:
             self.wavelength_range_selector.layout.visibility = "hidden"
             return
 
-        elif min_wavelength == max_wavelength:
+        if min_wavelength == max_wavelength:
             self.wavelength_range_selector.layout.visibility = "visible"
             self.wavelength_range_selector.disabled = True
         else:

--- a/tardis/visualization/widgets/line_info.py
+++ b/tardis/visualization/widgets/line_info.py
@@ -1,24 +1,27 @@
 """Class to create and display Line Info Widget."""
 
+import logging
+
 import numpy as np
 import pandas as pd
 import panel as pn
 from astropy import units as u
-
-from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource
+from bokeh.plotting import figure
+
 from tardis.analysis import LastLineInteraction
+from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 from tardis.util.base import (
     species_string_to_tuple,
     species_tuple_to_string,
 )
-
+from tardis.util.environment import Environment
 from tardis.visualization.widgets.util import (
     TableSummaryLabel,
     create_table_widget,
 )
-from tardis.util.environment import Environment
-from tardis.configuration.sorting_globals import SORTING_ALGORITHM
+
+logger = logging.getLogger(__name__)
 
 
 class LineInfoWidget:
@@ -693,8 +696,6 @@ class LineInfoWidget:
             Line info widget containing all component widgets
         """
         if not Environment.allows_widget_display():
-            import logging
-            logger = logging.getLogger(__name__)
             logger.warning("Please use a notebook to display the widget")
         else:
             # Panel tables handle their own sizing

--- a/tardis/visualization/widgets/line_info.py
+++ b/tardis/visualization/widgets/line_info.py
@@ -693,7 +693,9 @@ class LineInfoWidget:
             Line info widget containing all component widgets
         """
         if not Environment.allows_widget_display():
-            print("Please use a notebook to display the widget")
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning("Please use a notebook to display the widget")
         else:
             # Panel tables handle their own sizing
             self.total_packets_label.update_and_resize(0)

--- a/tardis/visualization/widgets/shell_info.py
+++ b/tardis/visualization/widgets/shell_info.py
@@ -377,7 +377,9 @@ class ShellInfoWidget:
             Shell info widget containing all component widgets
         """
         if not Environment.allows_widget_display():
-            print("Please use a notebook to display the widget")
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning("Please use a notebook to display the widget")
         else:
             # Panel tables handle their own sizing automatically
 

--- a/tardis/visualization/widgets/shell_info.py
+++ b/tardis/visualization/widgets/shell_info.py
@@ -1,3 +1,5 @@
+import logging
+
 import pandas as pd
 import panel as pn
 
@@ -7,6 +9,8 @@ from tardis.util.base import (
 )
 from tardis.util.environment import Environment
 from tardis.visualization.widgets.util import create_table_widget
+
+logger = logging.getLogger(__name__)
 
 
 class BaseShellInfo:
@@ -377,8 +381,6 @@ class ShellInfoWidget:
             Shell info widget containing all component widgets
         """
         if not Environment.allows_widget_display():
-            import logging
-            logger = logging.getLogger(__name__)
             logger.warning("Please use a notebook to display the widget")
         else:
             # Panel tables handle their own sizing automatically

--- a/tardis/visualization/widgets/tests/test_line_info.py
+++ b/tardis/visualization/widgets/tests/test_line_info.py
@@ -3,7 +3,6 @@ import pandas as pd
 import pytest
 
 from tardis.util.base import species_string_to_tuple
-
 from tardis.visualization.widgets.line_info import LineInfoWidget
 
 

--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -106,7 +106,7 @@ class PanelTableWidget:
                 self.table.selection = [row_position]  # Panel expects a list even for single selection
                 self._selected_rows = [row_position]
             except (KeyError, TypeError) as e:
-                logger.error(f"Error selecting index {idx_val}: {e}")
+                logger.exception("Error selecting index %s", idx_val)
                 self.table.selection = []
                 self._selected_rows = []
 

--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import re
+
 import panel as pn
 
 logger = logging.getLogger(__name__)

--- a/tardis/visualization/widgets/util.py
+++ b/tardis/visualization/widgets/util.py
@@ -106,7 +106,7 @@ class PanelTableWidget:
                 self.table.selection = [row_position]  # Panel expects a list even for single selection
                 self._selected_rows = [row_position]
             except (KeyError, TypeError) as e:
-                print(f"Error selecting index {idx_val}: {e}")
+                logger.error(f"Error selecting index {idx_val}: {e}")
                 self.table.selection = []
                 self._selected_rows = []
 


### PR DESCRIPTION
## Description
**Type:** refactor

**Mentors:** @connor-mcclellan @andrewfullard @jvshields

This PR addresses code quality by refactoring the visualization module. It upgrades raw `print()` statements and inline logging to use standard, module-level Python logging conventions. 

### Changes Included:
- **Ruff Linting Fixes:** Resolved `I001` (Unsorted Imports), `RUF022` (Unsorted `__all__`), and `W292` (Missing Newline) across the `tardis/visualization/` tree.
- **Author Attribution:** Fixed the [.mailmap](cci:7://file:///c:/Users/Shaurya/OneDrive/Desktop/projects/tardis-core/.mailmap:0:0-0:0) formatting to correctly map the local `Shaurya Gaur` alias to my name so the TARDIS bot properly verifies the commits.
## Testing

- Other method: Ran `ruff check tardis/visualization` locally to verify that all formatting, syntax, and import sorting errors are fully resolved. 

## Checklist

- [x] I requested two reviewers for this pull request

*Note: If you are not allowed to perform any of these actions, ping (@) a contributor.*

## AI Usage Statement

- **Name the tool(s):** Google Gemini
- It is used as a coding assistant to run ruff locally, helping to identify and resolve formatting and import sorting errors
- I confirm that I fully understand and can explain all AI-assisted contributions for this refactor.