### PR TITLE
[GSOC]Add ASV benchmarks for RadiativeRatesSolver

### DIFF
--- a/benchmarks/plasma/benchmark_radiative_rates_solver.py
+++ b/benchmarks/plasma/benchmark_radiative_rates_solver.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+
+from tardis.plasma.equilibrium.rates.radiative_rates import (
+    RadiativeRatesSolver,
+)
+
+
+class DummyRadiationField:
+    def calculate_mean_intensity(self, nu):
+        return np.ones_like(nu)
+
+
+def make_einstein_coeff_df(n_lines):
+    index = pd.MultiIndex.from_tuples(
+        [
+            (1, 0, i, i + 1)
+            for i in range(n_lines)
+        ],
+        names=[
+            "atomic_number",
+            "ion_number",
+            "level_number_lower",
+            "level_number_upper",
+        ],
+    )
+
+    return pd.DataFrame(
+        {
+            "A_ul": np.ones(n_lines),
+            "B_ul": np.ones(n_lines),
+            "B_lu": np.ones(n_lines),
+            "nu": np.linspace(1e14, 5e14, n_lines),
+        },
+        index=index,
+    )
+
+
+class BenchmarkRadiativeRatesSolver:
+    """
+    ASV benchmark for RadiativeRatesSolver.solve()
+
+    Measures runtime performance as number of transitions increases.
+    """
+
+    params = [50, 100, 200]
+    param_names = ["n_lines"]
+
+    def setup(self, n_lines):
+        self.df = make_einstein_coeff_df(n_lines)
+        self.solver = RadiativeRatesSolver(self.df)
+        self.rad_field = DummyRadiationField()
+
+    def time_solve(self, n_lines):
+        self.solver.solve(self.rad_field)


### PR DESCRIPTION
#### :pencil: Description

**Type:** : | :vertical_traffic_light: `testing` | 

This PR adds an ASV benchmark for the RadiativeRatesSolver class in the plasma module.
The benchmark measures the runtime of the solve method using controlled input data with a configurable number of transitions. A dummy radiation field is used to isolate the solver’s performance and ensure reproducibility.
This benchmark contributes to improving performance monitoring of key plasma components and aligns with the project goal of expanding benchmark coverage for the plasma module.
Future work may include adding scaling benchmarks and extending coverage to other plasma solvers.


### :vertical_traffic_light: Testing

How did you test these changes?

- [x] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

AI Usage:
- I used ChatGPT to understand benchmark infrastructure and to optimise my code.
- I've run the background checks
- I take full responsibility of the code

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
