### PR TITLE
Adding adaptive damping method for convergence

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -70,6 +70,8 @@ Christian Vogl <cvogl@mpa-garching.mpg.de> chvogl <cvogl@mpa-garching.mpg.de>
 
 Debajyoti Dasgupta <debajyotidasgupta6@gmail.com>
 
+Deeksha Mohanty <mohant11@msu.edu>
+
 Dhruv Sondhi <dhruvsondhi05@gmail.com>
 Dhruv Sondhi <dhruvsondhi05@gmail.com> Dhruv <dhruvsondhi05@gmail.com>
 Dhruv Sondhi <dhruvsondhi05@gmail.com> Dhruv Sondhi <66117751+DhruvSondhi@users.noreply.github.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -26,6 +26,7 @@ swayamshah66@gmail.com,0009-0005-8092-547X
 hmlperkins@gmail.com,0009-0000-5561-9116
 erin.visser1@gmail.com,0009-0001-8470-275X
 lujingeve158@gmail.com,0000-0002-3900-1452
+mohant11@msu.edu,0000-0003-1197-6693
 b.connor.mcc@gmail.com,0000-0002-6040-8281
 aaryandadu5157@gmail.com,0009-0005-3670-8777
 abhayraj916146@gmail.com,0009-0003-8477-2963

--- a/docs/analyzing_tardis/index.rst
+++ b/docs/analyzing_tardis/index.rst
@@ -1,5 +1,5 @@
 ************************************
-Analyszing TARDIS Simulation Outputs
+Analyzing TARDIS Simulation Outputs
 ************************************
 
 This section provides practical solutions for common analysis tasks. These guides assume you have completed simulations and want to extract scientific insights from the results.

--- a/docs/how_to_adaptive_damping.ipynb
+++ b/docs/how_to_adaptive_damping.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Adaptive Damped Convergence Example"
+    "# How to use Adaptive Damping for Convergence in TARDIS"
    ]
   },
   {
@@ -30,13 +30,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat tardis_example.yml"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Running the Simulation\n",
     "\n",
-    "To run the simulation, import the `run_tardis` function and create the `sim` object. "
+    "To run the simulation, import the `run_tardis` function and create the `sim_damped` object. "
    ]
   },
   {
@@ -54,10 +63,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_example.yml\", \n",
+    "sim_damped = run_tardis(\"tardis_example.yml\", \n",
     "                 virtual_packet_logging=True,\n",
     "                 show_convergence_plots=True,\n",
-    "                 export_convergence_plots=False,\n",
+    "                 export_convergence_plots=True,\n",
     "                 log_level=\"INFO\") "
    ]
   },
@@ -76,10 +85,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = run_tardis(\"tardis_adaptive_damped_example.yml\", \n",
+    "!cat tardis_adaptive_damped_example.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running the Simulation\n",
+    "\n",
+    "To run the simulation, import the `run_tardis` function and create the `sim_adaptive` object. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim_adaptive = run_tardis(\"tardis_adaptive_damped_example.yml\", \n",
     "                 virtual_packet_logging=True,\n",
     "                 show_convergence_plots=True,\n",
-    "                 export_convergence_plots=False,\n",
+    "                 export_convergence_plots=True,\n",
     "                 log_level=\"INFO\") "
    ]
   },

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ Mission Statement
     :hidden:
 
     how_to/index
+    how_to_adaptive_damping
     workflows
     analyzing_tardis/index
     io/configuration/tutorial_read_configuration

--- a/docs/quickstart_adaptive_damped.ipynb
+++ b/docs/quickstart_adaptive_damped.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Adaptive Damped Convergence Example"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates how to run the TARDIS example configuration with\n",
+    "the existing `damped` convergence strategy and the new `adaptive_damped`\n",
+    "strategy, and illustrates their convergence behavior across iterations."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Damped Convergence Strategy\n",
+    "\n",
+    "This example uses the standard TARDIS damped convergence strategy specified in the configuration file `tardis_example.yml` with the\n",
+    "damping constant set to 0.5 (or another user-specified value between 0.1 and 1.0)."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running the Simulation\n",
+    "\n",
+    "To run the simulation, import the `run_tardis` function and create the `sim` object. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tardis import run_tardis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = run_tardis(\"tardis_example.yml\", \n",
+    "                 virtual_packet_logging=True,\n",
+    "                 show_convergence_plots=True,\n",
+    "                 export_convergence_plots=False,\n",
+    "                 log_level=\"INFO\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adaptive Damped Convergence Strategy\n",
+    "\n",
+    "This example uses the `adaptive_damped` convergence strategy specified in the configuration file `tardis_adaptive_damped_example.yml`, where the damping factor is adjusted dynamically during the simulation, removing the need for manual tuning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sim = run_tardis(\"tardis_adaptive_damped_example.yml\", \n",
+    "                 virtual_packet_logging=True,\n",
+    "                 show_convergence_plots=True,\n",
+    "                 export_convergence_plots=False,\n",
+    "                 log_level=\"INFO\") "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tardis-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tardis_adaptive_damped_example.yml
+++ b/docs/tardis_adaptive_damped_example.yml
@@ -1,0 +1,54 @@
+# Example YAML configuration for the adaptive damped convergence strategy in TARDIS
+tardis_config_version: v1.0
+
+supernova:
+  luminosity_requested: 9.44 log_lsun
+  time_explosion: 13 day
+
+atom_data: kurucz_cd23_chianti_H_He_latest.h5
+
+model:
+  structure:
+    type: specific
+    velocity:
+      start: 1.1e4 km/s
+      stop: 20000 km/s
+      num: 20
+    density:
+      type: branch85_w7
+
+  abundances:
+    type: uniform
+    O: 0.19
+    Mg: 0.03
+    Si: 0.52
+    S: 0.19
+    Ar: 0.04
+    Ca: 0.03
+
+plasma:
+  disable_electron_scattering: no
+  ionization: lte
+  excitation: lte
+  radiative_rates_type: dilute-blackbody
+  line_interaction_type: macroatom
+
+montecarlo:
+  seed: 23111963
+  no_of_packets: 4.0e+4
+  iterations: 20
+  nthreads: 1
+  last_no_of_packets: 1.e+5
+  no_of_virtual_packets: 10
+
+  convergence_strategy:
+    type: adaptive_damped
+    threshold: 0.05
+    fraction: 0.8
+    hold_iterations: 3
+    stop_if_converged: no
+
+spectrum:
+  start: 500 angstrom
+  stop: 20000 angstrom
+  num: 10000

--- a/tardis/io/configuration/config_reader.py
+++ b/tardis/io/configuration/config_reader.py
@@ -413,13 +413,21 @@ class Configuration(ConfigurationNameSpace, ConfigWriterMixin):
             ] = Configuration.parse_convergence_section(
                 montecarlo_section["convergence_strategy"]
             )
+        
+        elif montecarlo_section["convergence_strategy"]["type"] == "adaptive_damped":
+            montecarlo_section[
+                "convergence_strategy"
+            ] = Configuration.parse_convergence_section(
+                montecarlo_section["convergence_strategy"]
+            )
+
         elif montecarlo_section["convergence_strategy"]["type"] == "custom":
             raise NotImplementedError(
                 'convergence_strategy is set to "custom"; '
                 "you need to implement your specific convergence treatment"
             )
         else:
-            raise ValueError('convergence_strategy is not "damped" or "custom"')
+            raise ValueError('convergence_strategy is not "damped", "adaptive_damped" or "custom"')
 
     @staticmethod
     def parse_convergence_section(convergence_section_dict):

--- a/tardis/io/configuration/config_reader.py
+++ b/tardis/io/configuration/config_reader.py
@@ -407,20 +407,12 @@ class Configuration(ConfigurationNameSpace, ConfigWriterMixin):
         ----------
         montecarlo_section : dict
         """
-        if montecarlo_section["convergence_strategy"]["type"] == "damped":
+        if montecarlo_section["convergence_strategy"]["type"] in ["damped", "adaptive_damped"]:
             montecarlo_section[
                 "convergence_strategy"
             ] = Configuration.parse_convergence_section(
                 montecarlo_section["convergence_strategy"]
             )
-        
-        elif montecarlo_section["convergence_strategy"]["type"] == "adaptive_damped":
-            montecarlo_section[
-                "convergence_strategy"
-            ] = Configuration.parse_convergence_section(
-                montecarlo_section["convergence_strategy"]
-            )
-
         elif montecarlo_section["convergence_strategy"]["type"] == "custom":
             raise NotImplementedError(
                 'convergence_strategy is set to "custom"; '

--- a/tardis/io/configuration/schemas/montecarlo.yml
+++ b/tardis/io/configuration/schemas/montecarlo.yml
@@ -48,6 +48,7 @@ properties:
   convergence_strategy:
     oneOf:
     - $ref: 'montecarlo_definitions.yml#/definitions/convergence_strategy/damped'
+    - $ref: 'montecarlo_definitions.yml#/definitions/convergence_strategy/adaptive_damped'
     - $ref: 'montecarlo_definitions.yml#/definitions/convergence_strategy/custom'
     default:
       type: 'damped'

--- a/tardis/io/configuration/schemas/montecarlo_definitions.yml
+++ b/tardis/io/configuration/schemas/montecarlo_definitions.yml
@@ -131,6 +131,115 @@ definitions:
           type: number
           default: -0.5
           description: L=4*pi*r**2*T^y
+    adaptive_damped:
+      $$target: 'montecarlo_definitions.yml#/definitions/convergence_strategy/adaptive_damped'
+      title: 'Adaptive Damped Convergence Strategy'
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          enum:
+          - adaptive_damped
+        default: adaptive_damped
+        stop_if_converged:
+          type: boolean
+          default: false
+          description: stop plasma iterations before number of specified
+            iterations are reached if the simulation is plasma and inner
+            boundary state is converged
+        fraction:
+          type: number
+          default: 0.8
+          description: the fraction of shells that have to converge to the given  convergence
+            threshold. For example, 0.8 means that 80% of shells have to converge
+            to the threshold that convergence is established
+          minimum: 0
+        hold_iterations:
+          type: number
+          multipleOf: 1.0
+          default: 3
+          description: the number of iterations that the convergence criteria need
+            to be fulfilled before TARDIS accepts the simulation as converged
+        damping_constant:
+          type: number
+          default: 1.0
+          description: damping constant
+          minimum: 0
+        threshold:
+          type: number
+          default: 0.05
+          description: specifies the threshold that is taken as convergence  (i.e.
+            0.05 means that the value does not change more than 5%)
+          minimum: 0
+        t_inner:
+          type: object
+          additionalProperties: false
+          properties:
+            damping_constant:
+              type: number
+              default: 0.5
+              description: damping constant
+              minimum: 0
+            threshold:
+              type: number
+              description: specifies the threshold that is taken as convergence  (i.e.
+                0.05 means that the value does not change more than 5%)
+              minimum: 0
+            type:
+              type: string
+              default: 'damped'
+              description: THIS IS A DUMMY VARIABLE DO NOT USE
+        t_rad:
+          type: object
+          additionalProperties: false
+          properties:
+            damping_constant:
+              type: number
+              default: 0.5
+              description: damping constant
+              minimum: 0
+            threshold:
+              type: number
+              description: specifies the threshold that is taken as convergence  (i.e.
+                0.05 means that the value does not change more than 5%)
+              minimum: 0
+            type:
+              type: string
+              default: 'damped'
+              description: THIS IS A DUMMY VARIABLE DO NOT USE
+          required:
+          - threshold
+        w:
+          type: object
+          additionalProperties: false
+          properties:
+            damping_constant:
+              type: number
+              default: 0.5
+              description: damping constant
+              minimum: 0
+            threshold:
+              type: number
+              description: specifies the threshold that is taken as convergence  (i.e.
+                0.05 means that the value does not change more than 5%)
+              minimum: 0
+            type:
+              type: string
+              default: 'damped'
+              description: THIS IS A DUMMY VARIABLE DO NOT USE
+          required:
+          - threshold
+        lock_t_inner_cycles:
+          type: number
+          multipleOf: 1.0
+          default: 1
+          description: The number of cycles to lock the update of the inner boundary
+            temperature. This process helps with convergence. The default is to switch
+            it off (1 cycle)
+        t_inner_update_exponent:
+          type: number
+          default: -0.5
+          description: L=4*pi*r**2*T^y
     custom:
       $$target: 'montecarlo_definitions.yml#/definitions/convergence_strategy/custom'
       title: 'Custom Convergence Strategy'

--- a/tardis/simulation/convergence.py
+++ b/tardis/simulation/convergence.py
@@ -24,6 +24,13 @@ class ConvergenceSolver:
 
         if self.convergence_strategy.type in ("damped"):
             self.converge = self.damped_converge
+        elif self.convergence_strategy.type in ("adaptive_damped"):
+            self.lambda_min = 0.1
+            self.lambda_max = 1.0
+            self.lambda_step = 0.05
+            self.residual_old = None 
+            self.damping_factor = 0.5  
+            self.converge = self.adaptive_damped
         elif self.convergence_strategy.type in ("custom"):
             raise NotImplementedError(
                 "Convergence strategy type is custom; "
@@ -52,6 +59,50 @@ class ConvergenceSolver:
             The converged value
         """
         return value + self.damping_factor * (estimated_value - value)
+    
+    def adaptive_damped(self, value, estimated_value):
+        """Adaptive damped convergence solver
+
+        Dynamically updates the damping factor by locally searching around the current value and selecting the step that minimizes the residual
+
+        Parameters
+        ----------
+        value : np.float64
+            The current value of the physical property
+        estimated_value : np.float64
+           The estimated value of the physical property
+
+        Returns
+        -------
+        np.float64
+            Updated value after applying adaptive damping
+
+        Notes
+        -----
+        The damping factor is updated in-place and constrained in the interval [lambda_min, lambda_max]
+        """
+        delta = self.lambda_step 
+        base = self.damping_factor 
+
+        candidates = [base]
+        if base - delta >= self.lambda_min:
+            candidates.append(base - delta)
+        if base + delta <= self.lambda_max:
+            candidates.append(base + delta)
+
+        best_lambda = base
+        best_residual = None
+
+        for lam in candidates:
+            x_new = value + lam * (estimated_value - value)
+            res = np.mean(np.abs((estimated_value - x_new) / (estimated_value)))
+            if best_residual is None or res < best_residual:
+                best_residual = res
+                best_lambda = lam
+
+        self.damping_factor = best_lambda
+
+        return value + best_lambda * (estimated_value - value)
 
     def get_convergence_status(self, value, estimated_value, no_of_cells):
         """Get the status of convergence for the physical property

--- a/tardis/simulation/convergence.py
+++ b/tardis/simulation/convergence.py
@@ -92,6 +92,7 @@ class ConvergenceSolver:
 
         best_lambda = base
         best_residual = None
+        best_x_new = None
 
         for lam in candidates:
             x_new = value + lam * (estimated_value - value)
@@ -99,10 +100,11 @@ class ConvergenceSolver:
             if best_residual is None or res < best_residual:
                 best_residual = res
                 best_lambda = lam
+                best_x_new = x_new
 
         self.damping_factor = best_lambda
 
-        return value + best_lambda * (estimated_value - value)
+        return best_x_new
 
     def get_convergence_status(self, value, estimated_value, no_of_cells):
         """Get the status of convergence for the physical property

--- a/tardis/simulation/convergence.py
+++ b/tardis/simulation/convergence.py
@@ -79,7 +79,7 @@ class ConvergenceSolver:
 
         Notes
         -----
-        The damping factor is updated in-place and constrained in the interval [lambda_min, lambda_max]
+        The damping factor is updated in place and constrained in the interval [lambda_min, lambda_max]
         """
         delta = self.lambda_step 
         base = self.damping_factor 

--- a/tardis/simulation/tests/test_convergence.py
+++ b/tardis/simulation/tests/test_convergence.py
@@ -27,6 +27,15 @@ def test_convergence_solver_init_damped(strategy):
     assert solver.converge == solver.damped_converge
 
 
+def test_convergence_solver_init_adaptive(strategy):
+    strategy.type = "adaptive_damped"
+    solver = ConvergenceSolver(strategy)
+    assert solver.damping_factor == 0.5
+    assert solver.lambda_min == 0.1
+    assert solver.lambda_max == 1.0
+    assert solver.converge == solver.adaptive_damped
+
+
 def test_convergence_solver_init_custom(strategy):
     strategy.type = "custom"
     with pytest.raises(NotImplementedError):
@@ -45,6 +54,27 @@ def test_damped_converge(strategy):
     estimated_value = np.float64(20.0)
     converged_value = solver.damped_converge(value, estimated_value)
     npt.assert_almost_equal(converged_value, 15.0)
+
+
+def test_adaptive_damped_basic(strategy):
+    strategy.type = "adaptive_damped"
+    solver = ConvergenceSolver(strategy)
+    value = np.float64(10.0)
+    estimated_value = np.float64(20.0)
+    new_value = solver.adaptive_damped(value, estimated_value)
+    assert new_value > value
+    assert new_value <= estimated_value
+
+
+def test_adaptive_damped_updates(strategy):
+    strategy.type = "adaptive_damped"
+    solver = ConvergenceSolver(strategy)
+    value = np.float64(10.0)
+    estimated_value = np.float64(20.0)
+    solver.adaptive_damped(value, estimated_value)
+
+    # check that lambda remains within the bounds
+    assert solver.lambda_min <= solver.damping_factor <= solver.lambda_max
 
 
 def test_get_convergence_status(strategy):


### PR DESCRIPTION
### :pencil: Description

**Type:** :rocket: `feature` 

This PR introduces the `adaptive_damped` convergence strategy in TARDIS.

It includes:
- the implementation in `convergence.py`
- tests in `test_convergence.py`
- a quickstart notebook `quickstart_adaptive_damped.ipynb` demonstrating usage and comparison with the standard `damped` method
- an example configuration `tardis_adaptive_damped_example.yml` for running simulations with the adaptive strategy

The approach is based on adaptive damping developed during this associated [master's thesis](https://d.lib.msu.edu/etd/52612?q=Mentor).

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline