### PR TITLE
[GSOC] fix first-time committer workflow

### DIFF
--- a/.github/workflows/util.yml
+++ b/.github/workflows/util.yml
@@ -58,7 +58,7 @@ jobs:
 
             Please mark the pull request as draft if you are not ready for review yet or if there are things you will be adding.
           issue_message: |
-            👋 Welcome @${{ github.event.issue.user.login }}! Thank you for opening your first issue in this repository!
+            👋 Welcome! Thank you for opening your first issue in this repository!
 
   check-orcid:
     runs-on: ubuntu-latest

--- a/.github/workflows/util.yml
+++ b/.github/workflows/util.yml
@@ -57,6 +57,8 @@ jobs:
             **If you are applying to GSoC, please read our [AI Usage Policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy/) and our [PR checklist](https://tardis-sn.github.io/summer_of_code/pr_checklist/).**
 
             Please mark the pull request as draft if you are not ready for review yet or if there are things you will be adding.
+          issue_message: |
+            👋 Welcome @${{ github.event.issue.user.login }}! Thank you for opening your first issue in this repository!
 
   check-orcid:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`


- `actions/first-interaction@v3` made `issue_message` a required input alongside `pr_message`. The workflow only supplied `pr_message`, so the action crashed at startup for every PR.

Closes #3553 

### :pushpin: Resources

https://github.com/marketplace/actions/first-interaction


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)

Tested the changes in a PR in my fork https://github.com/Aaryan-Dadu/tardis/pull/3, corresponding [results](https://github.com/Aaryan-Dadu/tardis/actions/runs/24903128374/job/72925665442?pr=3)
I made the changes in my fix-workflow-trial branch and made PR from fix-workflow-test branch, the changes which differ from there to here are unrelated to the fix and were made to be able to test the wokflow in my fork without the need to setup secrets or anything else.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.

### AI Usage:

No use of LLMs have been made.
I have read the checklist and the [AI usage policy](https://tardis-sn.github.io/summer_of_code/ai_usage_policy)