### PR TITLE
Converted lists passed to njit functions to typed lists

### DIFF
--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Optional
 
+from numba.typed import List
+
 import astropy.units as u
 import numpy as np
 import pandas as pd
@@ -318,6 +320,11 @@ def run_gamma_ray_loop(
     logger.info("Total CMF energy is %s", total_cmf_energy)
     logger.info("Total RF energy is %s", total_rf_energy)
 
+    # nopython mode of numba requires typed lists
+    # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
+    packets_typed_list = List()
+    [packets_typed_list.append(p) for p in packets]
+
     (
         energy_out,
         energy_out_cosi,
@@ -325,7 +332,7 @@ def run_gamma_ray_loop(
         energy_deposited_gamma,
         total_energy,
     ) = gamma_packet_loop(
-        packets,
+        packets_typed_list,
         grey_opacity,
         photoabsorption_opacity,
         pair_creation_opacity,

--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from numba.typed import List
+from numba import typed
 
 import astropy.units as u
 import numpy as np
@@ -322,8 +322,9 @@ def run_gamma_ray_loop(
 
     # nopython mode of numba requires typed lists
     # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
-    packets_typed_list = List()
-    [packets_typed_list.append(p) for p in packets]
+    packets_typed_list = typed.List()
+    for p in packets:
+        packets_typed_list.append(p)
 
     (
         energy_out,

--- a/tardis/transport/montecarlo/modes/classic/solver.py
+++ b/tardis/transport/montecarlo/modes/classic/solver.py
@@ -2,6 +2,7 @@ import logging
 
 from astropy import units as u
 from numba import cuda, set_num_threads
+from numba.typed import List
 
 import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
@@ -211,6 +212,11 @@ class MCTransportSolverClassic(HDFWriterMixin):
         if show_progress_bars:
             reset_packet_pbar(number_of_rpackets)
 
+        # nopython mode of numba requires typed lists
+        # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
+        trackers_list_typed = List()
+        [trackers_list_typed.append(tracker) for tracker in trackers_list]
+
         # Classic mode: returns 4 values (no continuum estimators)
         (
             v_packets_energy_hist,
@@ -224,7 +230,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
             transport_state.opacity_state,
             self.montecarlo_configuration,
             self.spectrum_frequency_grid.value,
-            trackers_list,
+            trackers_list_typed,
             number_of_vpackets,
             show_progress_bars=show_progress_bars,
         )

--- a/tardis/transport/montecarlo/modes/classic/solver.py
+++ b/tardis/transport/montecarlo/modes/classic/solver.py
@@ -1,8 +1,7 @@
 import logging
 
 from astropy import units as u
-from numba import cuda, set_num_threads
-from numba.typed import List
+from numba import cuda, set_num_threads, typed
 
 import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
@@ -214,8 +213,9 @@ class MCTransportSolverClassic(HDFWriterMixin):
 
         # nopython mode of numba requires typed lists
         # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
-        trackers_list_typed = List()
-        [trackers_list_typed.append(tracker) for tracker in trackers_list]
+        trackers_typed_list = typed.List()
+        for tracker in trackers_list:
+            trackers_typed_list.append(tracker)
 
         # Classic mode: returns 4 values (no continuum estimators)
         (
@@ -230,7 +230,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
             transport_state.opacity_state,
             self.montecarlo_configuration,
             self.spectrum_frequency_grid.value,
-            trackers_list_typed,
+            trackers_typed_list,
             number_of_vpackets,
             show_progress_bars=show_progress_bars,
         )

--- a/tardis/transport/montecarlo/modes/iip/solver.py
+++ b/tardis/transport/montecarlo/modes/iip/solver.py
@@ -2,6 +2,7 @@ import logging
 
 from astropy import units as u
 from numba import cuda, set_num_threads
+from numba.typed import List
 
 import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
@@ -184,6 +185,11 @@ class MCTransportSolverIIP(HDFWriterMixin):
                 number_of_rpackets
             )
 
+        # nopython mode of numba requires typed lists
+        # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
+        trackers_typed_list = List()
+        [trackers_typed_list.append(trackers) for trackers in trackers_list]
+
         # Reset packet progress bar for this iteration
         if show_progress_bars:
             reset_packet_pbar(number_of_rpackets)
@@ -200,7 +206,7 @@ class MCTransportSolverIIP(HDFWriterMixin):
             transport_state.opacity_state,
             self.montecarlo_configuration,
             transport_state.n_levels_bf_species_by_n_cells_tuple,
-            trackers_list,
+            trackers_typed_list,
             show_progress_bars=show_progress_bars,
         )
 

--- a/tardis/transport/montecarlo/modes/iip/solver.py
+++ b/tardis/transport/montecarlo/modes/iip/solver.py
@@ -1,8 +1,7 @@
 import logging
 
 from astropy import units as u
-from numba import cuda, set_num_threads
-from numba.typed import List
+from numba import cuda, set_num_threads, typed
 
 import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
@@ -187,8 +186,9 @@ class MCTransportSolverIIP(HDFWriterMixin):
 
         # nopython mode of numba requires typed lists
         # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
-        trackers_typed_list = List()
-        [trackers_typed_list.append(trackers) for trackers in trackers_list]
+        trackers_typed_list = typed.List()
+        for trackers in trackers_list:
+            trackers_typed_list.append(trackers)
 
         # Reset packet progress bar for this iteration
         if show_progress_bars:

--- a/tardis/transport/montecarlo/packets/trackers/tracker_full_util.py
+++ b/tardis/transport/montecarlo/packets/trackers/tracker_full_util.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from numba import njit
+from numba.typed import List
 from pandas.api.types import CategoricalDtype
 
 from tardis.transport.montecarlo.packets.radiative_packet import (
@@ -124,6 +125,12 @@ def trackers_full_to_df(trackers_full_list) -> pd.DataFrame:
         indexed by packet_id and event_id. Line interaction columns have default
         values (-1 for IDs, NaN for physical quantities) for non-interaction events.
     """
+
+    # nopython mode of numba requires typed lists
+    # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
+    trackers_typed_list = List()
+    [trackers_typed_list.append(tracker) for tracker in trackers_full_list]
+
     # Use the fast array extraction function
     (
         packet_id,
@@ -141,7 +148,7 @@ def trackers_full_to_df(trackers_full_list) -> pd.DataFrame:
         after_energy,
         line_absorb_id,
         line_emit_id,
-    ) = trackers_full_list_to_arrays(trackers_full_list)
+    ) = trackers_full_list_to_arrays(trackers_typed_list)
 
     # Create categorical data types
     interaction_type_dtype = CategoricalDtype(

--- a/tardis/transport/montecarlo/packets/trackers/tracker_full_util.py
+++ b/tardis/transport/montecarlo/packets/trackers/tracker_full_util.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
-from numba import njit
-from numba.typed import List
+from numba import njit, typed
 from pandas.api.types import CategoricalDtype
 
 from tardis.transport.montecarlo.packets.radiative_packet import (
@@ -128,8 +127,9 @@ def trackers_full_to_df(trackers_full_list) -> pd.DataFrame:
 
     # nopython mode of numba requires typed lists
     # https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types
-    trackers_typed_list = List()
-    [trackers_typed_list.append(tracker) for tracker in trackers_full_list]
+    trackers_typed_list = typed.List()
+    for tracker in trackers_full_list:
+        trackers_typed_list.append(tracker)
 
     # Use the fast array extraction function
     (


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Reflection for lists and sets in numba will soon be deprecated. This essentially means that they cannot be used in  `nopython` mode(such as `@njit` functions). The lists passed to these functions need to be converted to numba typed lists.


### :pushpin: Resources
https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-reflection-for-list-and-set-types

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
