### PR TITLE
Changed Dataset.dims to Dataset.size

### DIFF
--- a/tardis/io/model/snec/tests/test_xg_files.py
+++ b/tardis/io/model/snec/tests/test_xg_files.py
@@ -46,7 +46,7 @@ def test_xgdata_to_xr_dataset(regression_test_mass_xg_file):
     )
     xarray_data = xg_data.to_xr_dataset()
 
-    assert list(xarray_data.dims.keys()) == ['time', 'cell_id']
+    assert list(xarray_data.sizes.keys()) == ['time', 'cell_id']
     assert 'time' in xarray_data.coords
     assert 'cell_id' in xarray_data.coords
     assert 'enclosed_mass' in xarray_data.coords


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

xarray's Dataset.dims will be changed to return a set of dimension names instead of a mapping of dimension names to lengths in the future. We can use Dataset.sizes instead.

### :pushpin: Resources

https://docs.xarray.dev/en/stable/whats-new.html#id481

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
