### PR TITLE
Track packets only for final mc

### DIFF
--- a/tardis/transport/montecarlo/modes/classic/solver.py
+++ b/tardis/transport/montecarlo/modes/classic/solver.py
@@ -152,6 +152,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
         self,
         transport_state,
         show_progress_bars=True,
+        enable_rpacket_tracking=False,
     ):
         """
         Run the montecarlo calculation.
@@ -162,18 +163,21 @@ class MCTransportSolverClassic(HDFWriterMixin):
             Transport state containing all the data needed for the Monte Carlo simulation
         show_progress_bars : bool
             Show progress bars
+        enable_rpacket_tracking : bool
+            Write packet data to tracker.
 
         Returns
         -------
         v_packets_energy_hist : ndarray
             Histogram of energy from virtual packets
         """
-        return self.run_classic(transport_state, show_progress_bars)
+        return self.run_classic(transport_state, show_progress_bars, enable_rpacket_tracking)
 
     def run_classic(
         self,
         transport_state,
         show_progress_bars=True,
+        enable_rpacket_tracking=False,
     ):
         """
         Run the montecarlo calculation using classic mode (no continuum).
@@ -184,6 +188,8 @@ class MCTransportSolverClassic(HDFWriterMixin):
             Transport state containing all the data needed for the Monte Carlo simulation
         show_progress_bars : bool
             Show progress bars
+        enable_rpacket_tracking : bool
+            Write packet data to tracker
 
         Returns
         -------
@@ -196,7 +202,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
         number_of_vpackets = self.montecarlo_configuration.NUMBER_OF_VPACKETS
         number_of_rpackets = len(transport_state.packet_collection.initial_nus)
 
-        if self.enable_rpacket_tracking:
+        if enable_rpacket_tracking:
             trackers_list = generate_tracker_full_list(
                 number_of_rpackets,
                 self.montecarlo_configuration.INITIAL_TRACKING_ARRAY_LENGTH,
@@ -247,7 +253,7 @@ class MCTransportSolverClassic(HDFWriterMixin):
         # Need to change the implementation of rpacket_trackers_to_dataframe
         # Such that it also takes of the case of
         # RPacketLastInteractionTracker
-        if self.enable_rpacket_tracking:
+        if enable_rpacket_tracking:
             self.transport_state.tracker_full_df = trackers_full_to_df(
                 trackers_list
             )

--- a/tardis/transport/montecarlo/modes/iip/solver.py
+++ b/tardis/transport/montecarlo/modes/iip/solver.py
@@ -161,6 +161,7 @@ class MCTransportSolverIIP(HDFWriterMixin):
         self,
         transport_state,
         show_progress_bars=True,
+        enable_rpacket_tracking=False,
     ):
         """
         Run the Monte Carlo calculation using IIP mode (continuum always enabled).
@@ -171,6 +172,8 @@ class MCTransportSolverIIP(HDFWriterMixin):
             Transport state containing all the data needed for the Monte Carlo simulation
         show_progress_bars : bool
             Show progress bars
+        enable_rpacket_tracking : bool
+            Write packet data to tracker.
 
         Returns
         -------
@@ -183,7 +186,7 @@ class MCTransportSolverIIP(HDFWriterMixin):
         number_of_vpackets = self.montecarlo_configuration.NUMBER_OF_VPACKETS
         number_of_rpackets = len(transport_state.packet_collection.initial_nus)
 
-        if self.enable_rpacket_tracking:
+        if enable_rpacket_tracking:
             trackers_list = generate_tracker_full_list(
                 number_of_rpackets,
                 self.montecarlo_configuration.INITIAL_TRACKING_ARRAY_LENGTH,
@@ -230,7 +233,7 @@ class MCTransportSolverIIP(HDFWriterMixin):
         # Need to change the implementation of rpacket_trackers_to_dataframe
         # Such that it also takes of the case of
         # RPacketLastInteractionTracker
-        if self.enable_rpacket_tracking:
+        if enable_rpacket_tracking:
             self.transport_state.tracker_full_df = trackers_full_to_df(
                 trackers_list
             )

--- a/tardis/transport/montecarlo/modes/nonhomologous/solver.py
+++ b/tardis/transport/montecarlo/modes/nonhomologous/solver.py
@@ -148,6 +148,7 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
         self,
         transport_state,
         show_progress_bars=True,
+        enable_rpacket_tracking=False,
     ):
         """
         Run the montecarlo calculation.
@@ -158,18 +159,21 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
             Transport state containing all the data needed for the Monte Carlo simulation
         show_progress_bars : bool
             Show progress bars
+        enable_rpacket_tracking : bool or None
+            Write packet data to tracker.
 
         Returns
         -------
         v_packets_energy_hist : ndarray
             Histogram of energy from virtual packets
         """
-        return self.run_nonhomologous(transport_state, show_progress_bars)
+        return self.run_nonhomologous(transport_state, show_progress_bars, enable_rpacket_tracking)
 
     def run_nonhomologous(
         self,
         transport_state,
         show_progress_bars=True,
+        enable_rpacket_tracking=False,
     ):
         """
         Run the montecarlo calculation using nonhomologous mode (no continuum).
@@ -180,6 +184,8 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
             Transport state containing all the data needed for the Monte Carlo simulation
         show_progress_bars : bool
             Show progress bars
+        enable_rpacket_tracking : bool
+            Write packet data to tracker
 
         Returns
         -------
@@ -192,7 +198,7 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
         number_of_vpackets = self.montecarlo_configuration.NUMBER_OF_VPACKETS
         number_of_rpackets = len(transport_state.packet_collection.initial_nus)
 
-        if self.enable_rpacket_tracking:
+        if enable_rpacket_tracking:
             trackers_list = generate_tracker_full_list(
                 number_of_rpackets,
                 self.montecarlo_configuration.INITIAL_TRACKING_ARRAY_LENGTH,
@@ -242,7 +248,7 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
         # Need to change the implementation of rpacket_trackers_to_dataframe
         # Such that it also takes of the case of
         # RPacketLastInteractionTracker
-        if self.enable_rpacket_tracking:
+        if enable_rpacket_tracking:
             self.transport_state.tracker_full_df = trackers_full_to_df(
                 trackers_list
             )

--- a/tardis/transport/montecarlo/modes/nonhomologous/solver.py
+++ b/tardis/transport/montecarlo/modes/nonhomologous/solver.py
@@ -159,7 +159,7 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
             Transport state containing all the data needed for the Monte Carlo simulation
         show_progress_bars : bool
             Show progress bars
-        enable_rpacket_tracking : bool or None
+        enable_rpacket_tracking : bool
             Write packet data to tracker.
 
         Returns

--- a/tardis/workflows/simple_tardis_workflow.py
+++ b/tardis/workflows/simple_tardis_workflow.py
@@ -441,6 +441,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
         opacity_states: dict,
         no_of_real_packets: int,
         no_of_virtual_packets: int = 0,
+        enable_rpacket_tracking: bool = False,
     ) -> np.ndarray:
         """Solve the MonteCarlo process
 
@@ -452,6 +453,8 @@ class SimpleTARDISWorkflow(WorkflowLogging):
             Number of real packets to simulate.
         no_of_virtual_packets
             Number of virtual packets to simulate per interaction.
+        enable_rpacket_tracking
+            Whether to save packet data to the full tracker for this MC step
 
         Returns
         -------
@@ -474,6 +477,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
         virtual_packet_energies = self.transport_solver.run(
             self.transport_state,
             show_progress_bars=self.show_progress_bars,
+            enable_rpacket_tracking=enable_rpacket_tracking,
         )
 
         output_energy = self.transport_state.packet_collection.output_energies
@@ -541,7 +545,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
             self.opacity_states = self.solve_opacity()
 
             virtual_packet_energies = self.solve_montecarlo(
-                self.opacity_states, self.real_packet_count
+                self.opacity_states, self.real_packet_count, enable_rpacket_tracking=False,
             )
 
             (
@@ -570,6 +574,7 @@ class SimpleTARDISWorkflow(WorkflowLogging):
             self.opacity_states,
             self.final_iteration_packet_count,
             self.virtual_packet_count,
+            enable_rpacket_tracking=self.transport_solver.enable_rpacket_tracking,
         )
 
         self.initialize_spectrum_solver(

--- a/tardis/workflows/standard_tardis_workflow.py
+++ b/tardis/workflows/standard_tardis_workflow.py
@@ -221,7 +221,7 @@ class StandardTARDISWorkflow(
             self.opacity_states = self.solve_opacity()
 
             virtual_packet_energies = self.solve_montecarlo(
-                self.opacity_states, self.real_packet_count
+                self.opacity_states, self.real_packet_count, enable_rpacket_tracking=False,
             )
 
             (
@@ -253,6 +253,7 @@ class StandardTARDISWorkflow(
             self.opacity_states,
             self.final_iteration_packet_count,
             self.virtual_packet_count,
+            enable_rpacket_tracking=self.transport_solver.enable_rpacket_tracking,
         )
         self.store_plasma_state(
             self.completed_iterations,

--- a/tardis/workflows/type_iip_workflow.py
+++ b/tardis/workflows/type_iip_workflow.py
@@ -875,7 +875,11 @@ class TypeIIPWorkflow(WorkflowLogging):
         }
 
     def solve_montecarlo(
-        self, opacity_states, no_of_real_packets, no_of_virtual_packets=0
+        self,
+        opacity_states,
+        no_of_real_packets,
+        no_of_virtual_packets=0,
+        enable_rpacket_tracking: bool = False,
     ):
         """Solve the MonteCarlo process
 
@@ -887,7 +891,8 @@ class TypeIIPWorkflow(WorkflowLogging):
             Number of real packets to simulate
         no_of_virtual_packets : int, optional
             Number of virtual packets to simulate per interaction, by default 0
-
+        enable_rpacket_tracking
+            Whether to save packet data to the full tracker for this MC step
         """
         opacity_state = opacity_states["opacity_state"]
         macro_atom_state = opacity_states["macro_atom_state"]
@@ -905,6 +910,7 @@ class TypeIIPWorkflow(WorkflowLogging):
         self.transport_solver.run(
             self.transport_state,
             show_progress_bars=self.show_progress_bars,
+            enable_rpacket_tracking=enable_rpacket_tracking,
         )
 
         output_energy = self.transport_state.packet_collection.output_energies
@@ -933,7 +939,11 @@ class TypeIIPWorkflow(WorkflowLogging):
 
             self.opacity_states = self.solve_opacity()
 
-            self.solve_montecarlo(self.opacity_states, self.real_packet_count)
+            self.solve_montecarlo(
+                self.opacity_states,
+                self.real_packet_count,
+                enable_rpacket_tracking=False,
+            )
 
             (
                 estimated_values,
@@ -971,6 +981,7 @@ class TypeIIPWorkflow(WorkflowLogging):
             self.opacity_states,
             self.final_iteration_packet_count,
             self.virtual_packet_count,
+            enable_rpacket_tracking=self.transport_solver.enable_rpacket_tracking,
         )
 
         self.initialize_spectrum_solver()


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Splits the `enable_rpacket_tracking` flag off into the `run` function arguments instead of just being a global toggle set in the config.

In each workflow, the value of the global toggle `transport_state.enable_rpacket_tracking` is passed _only_ to the final MC run, rather than being used for every MC step in the convergence iteration. These were all writing to the same dataframe anyway, so it was just doing a bunch of work to write out a tracker full df that was overwritten on the next iteration.

Fixes #3593.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
