### PR TITLE
Small fix for pandas 3.x compatibility

### DIFF
--- a/tardis/plasma/tests/test_complete_plasmas.py
+++ b/tardis/plasma/tests/test_complete_plasmas.py
@@ -189,7 +189,8 @@ class TestPlasma:
             if attr == "lines":
                 expected.columns.name = "N."
             if attr == "selected_atoms":
-                npt.assert_allclose(actual.values, expected.values)
+                actual = actual.to_frame(index=False)
+                pdt.assert_frame_equal(actual, expected)
             elif actual.ndim == 1:
                 actual = pd.Series(actual)
                 pdt.assert_series_equal(actual, expected)
@@ -200,7 +201,7 @@ class TestPlasma:
             warnings.warn(f'Property "{attr}" not found')
 
     def test_levels(self, plasma):
-        actual = pd.DataFrame(plasma.levels)
+        actual = plasma.levels.to_frame(index=False)
         key = "plasma/levels"
         expected = pd.read_hdf(self.regression_data.fpath, key)
         pdt.assert_frame_equal(actual, expected)


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :vertical_traffic_light: `testing` 

Pandas 3.x compatibility added in #3601 caused regression data generation tests to fail due to expanding indexes into columns. This fixes that comparison and requires https://github.com/tardis-sn/tardis-regression-data/pull/100

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
