### PR TITLE
Update commit hash for tardisbase dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 viz = ["lineid_plot"]
-tardisbase = ["tardisbase @ git+https://github.com/tardis-sn/tardisbase.git@bb4f0226"]
+tardisbase = ["tardisbase @ git+https://github.com/tardis-sn/tardisbase.git@f07448e"]
 
 
 [project.scripts]


### PR DESCRIPTION
Fixes build failure for tardisbase dependency

TARDIS successfully installs locally using

`pip install -e ".[tardisbase]"`
