### PR TITLE
Fix stardis-tests action

### DIFF
--- a/.github/workflows/stardis-tests.yml
+++ b/.github/workflows/stardis-tests.yml
@@ -22,7 +22,15 @@ env:
   CACHE_NUMBER: 0  # increase to reset cache manually
 
 jobs:
+  test-cache:
+    uses: ./.github/workflows/lfs-cache.yml
+    with:
+      atom-data-sparse: true
+      regression-data-repo: tardis-sn/tardis-regression-data
+      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
+
   build:
+    needs: [test-cache]
     strategy:
       matrix:
         label: [linux-64]
@@ -38,6 +46,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: tardis-sn/stardis
+
+      - name: Checkout TARDIS workflow helpers
+        uses: actions/checkout@v6
+        with:
+          path: tardis-source
 
       - name: Download Lock File
         run:  wget -q https://raw.githubusercontent.com/tardis-sn/stardis/main/conda-${{ matrix.label }}.lock
@@ -68,6 +81,17 @@ jobs:
         id: install-stardis
         run: |
           pip install -e .[test]
+
+      - name: Setup atom data
+        uses: ./tardis-source/.github/actions/setup_lfs
+        with:
+          atom-data-sparse: true
+          regression-data-repo: tardis-sn/tardis-regression-data
+
+      - name: Copy atom data
+        run: |
+          mkdir -p ~/Downloads/tardis-data
+          cp ./tardis-regression-data/atom_data/kurucz_cd23_chianti_H_He_latest.h5 ~/Downloads/tardis-data/
 
       - name: Run stardis tests  
         run: pytest


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`| :vertical_traffic_light: `testing`

Fixes #3381.

When https://github.com/tardis-sn/stardis/pull/288 is merged into STARDIS, this action will again function as a check to make sure a TARDIS PR doesn't break STARDIS.

The specific change in this PR to acquire atom data from the LFS cache (like TARDIS does) instead of trying to download the atom data from a URL. The previous `download_from_url` function no longer works since we use LFS storage now.

### :vertical_traffic_light: Testing

How did you test these changes?

- [X] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)