### PR TITLE
Remove git LFS pull blocker from all workflows in TARDIS

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ on:
       - ready_for_review
   workflow_dispatch:
 
-env: 
+env:
   DEPLOY_BRANCH: main
 
 concurrency:
@@ -34,7 +34,6 @@ jobs:
     with:
       atom-data-sparse: false
       regression-data-repo: tardis-sn/tardis-regression-data
-      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   build:
     if: github.repository_owner == 'tardis-sn' &&
@@ -88,7 +87,7 @@ jobs:
 
       - name: Accept all asv questions
         run: asv machine --yes
-      
+
       - name: Download environment file for benchmarks
         run: wget -q https://raw.githubusercontent.com/tardis-sn/tardisbase/refs/heads/master/env-benchmark-linux.yml
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -41,7 +41,6 @@ jobs:
     with:
       atom-data-sparse: true
       regression-data-repo: tardis-sn/tardis-regression-data
-      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   check-for-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/compare-regdata.yml
+++ b/.github/workflows/compare-regdata.yml
@@ -36,7 +36,6 @@ jobs:
     with:
       atom-data-sparse: false
       regression-data-repo: tardis-sn/tardis-regression-data
-      allow_lfs_pull: ${{ contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   tests:
     name: compare-regdata ${{ matrix.continuum }} continuum ${{ matrix.os }}

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -37,7 +37,6 @@ jobs:
     with:
       atom-data-sparse: false
       regression-data-repo: tardis-sn/tardis-regression-data
-      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   run-tests:
     if: github.repository_owner == 'tardis-sn' && contains(github.event.pull_request.labels.*.name, 'full-tests')

--- a/.github/workflows/lfs-cache.yml
+++ b/.github/workflows/lfs-cache.yml
@@ -13,11 +13,6 @@ on:
         required: false
         default: "tardis-sn/tardis-regression-data"
         type: string
-      allow_lfs_pull:
-        description: "If true, allows LFS pull operations"
-        required: false
-        default: false
-        type: boolean
   workflow_call:
     inputs:
       atom-data-sparse:
@@ -30,11 +25,6 @@ on:
         required: false
         default: "tardis-sn/tardis-regression-data"
         type: string
-      allow_lfs_pull:
-        description: "If true, allows LFS pull operations"
-        required: false
-        default: false
-        type: boolean
 
 defaults:
   run:
@@ -76,22 +66,14 @@ jobs:
           path: tardis-regression-data/.git/lfs
           key: tardis-regression-${{ inputs.atom-data-sparse == true && 'atom-data-sparse' || 'full-data' }}-${{ hashFiles('tardis-regression-data/.lfs-files-list') }}-${{ inputs.regression-data-repo }}-v1
           lookup-only: true
-  
-      - name: Fail if LFS pull is needed but not allowed
-        if: |
-          steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && 
-          inputs.allow_lfs_pull != true
-        run: |
-          echo "Error: LFS pull is required but not allowed (allow_lfs_pull is false)"
-          exit 1
       
       - name: Git LFS Pull Atom Data
-        if: ${{ inputs.atom-data-sparse && steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && inputs.allow_lfs_pull }}
+        if: ${{ inputs.atom-data-sparse && steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' }}
         run: git lfs pull --include=atom_data/kurucz_cd23_chianti_H_He_latest.h5
         working-directory: tardis-regression-data
       
       - name: Git LFS Pull Full Data
-        if: ${{ !inputs.atom-data-sparse && steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' && inputs.allow_lfs_pull }}
+        if: ${{ !inputs.atom-data-sparse && steps.test-lfs-cache-regression-data.outputs.cache-hit != 'true' }}
         run: git lfs pull
         working-directory: tardis-regression-data
       

--- a/.github/workflows/stardis-tests.yml
+++ b/.github/workflows/stardis-tests.yml
@@ -27,7 +27,6 @@ jobs:
     with:
       atom-data-sparse: true
       regression-data-repo: tardis-sn/tardis-regression-data
-      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   build:
     needs: [test-cache]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,6 @@ jobs:
     with:
       atom-data-sparse: false
       regression-data-repo: tardis-sn/tardis-regression-data
-      allow_lfs_pull: ${{ github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'git-lfs-pull') }}
 
   tests:
     name: tests ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ matrix.pip_git && 'pip tests enabled' || 'pip tests disabled' }}

--- a/.github/workflows/util.yml
+++ b/.github/workflows/util.yml
@@ -6,25 +6,6 @@ on:
       - master
 
 jobs:
-  git-lfs-pull-label:
-    if: contains(github.event.pull_request.labels.*.name, 'git-lfs-pull')
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
-      contents: read
-
-    steps:
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body: |
-            Warning - LFS bandwidth usage
-            ⚠️ **Warning**: The label you applied triggers workflows that consume LFS bandwidth and should be used carefully. For safety, this label will be automatically removed once the checks have run.
-
   add-gsoc-label:
     if: contains(github.event.pull_request.title, 'GSoC')
     runs-on: ubuntu-latest

--- a/docs/contributing/development/continuous_integration.rst
+++ b/docs/contributing/development/continuous_integration.rst
@@ -51,8 +51,6 @@ TARDIS uses specific cache key formats to efficiently store and retrieve data du
 
 .. warning::
    - The version suffix (-v1) allows for future cache invalidation if needed.
-   - The `lfs-cache` workflow will fail if the cache is not available and will not pull LFS data by default. 
-   - However, if the `allow_lfs_pull` label is added to the PR, the workflow will pull LFS data. Please note that this is to be used sparingly and only with caution.
 
 Streamlined Steps for TARDIS Pipelines
 ========================================


### PR DESCRIPTION
### :pencil: Description

**Type:**  :roller_coaster: `infrastructure`

The git-lfs-pull label causes more problems than it solves. This should smooth out updating the LFS cache after regression data changes.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
