### PR TITLE
Make the bot only post in PRs if benchmarks change

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -146,6 +146,18 @@ jobs:
       - name: Compare Master and PR head but only show changed results
         run: asv compare origin/master HEAD --only-changed --factor 1.1 --split --sort ratio | tee asv-compare-changed-output.log
 
+      - name: Check for significantly changed benchmarks
+        id: significant_benchmarks
+        if: github.event_name == 'pull_request_target'
+        run: |
+          if grep -Eq '^\| [-+!] +\|' asv-compare-changed-output.log; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Significantly changed benchmarks found."
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No significantly changed benchmarks found."
+          fi
+
       - name: Benchmarks compare output
         id: asv_pr_vs_master
         uses: juliangruber/read-file-action@v1.1.8
@@ -159,16 +171,16 @@ jobs:
           path: asv-compare-changed-output.log
 
       - name: Generate Graphs and HTML of PR
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         run: |
           asv publish
 
       - name: Delete env files of PR
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         run: rm -r .asv/env
 
       - name: Set destination directory
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         run: |
           BRANCH=$(echo ${GITHUB_REF#refs/heads/})
           if [[ $EVENT == push ]] || [[ $EVENT == workflow_dispatch ]]; then
@@ -195,7 +207,7 @@ jobs:
           PR: ${{ github.event.number }}
 
       - name: Set clean branch option
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         run: |
           if [[ $EVENT == workflow_dispatch ]]; then
             echo "CLEAN_BRANCH=true" >> $GITHUB_ENV
@@ -210,7 +222,7 @@ jobs:
           EVENT: ${{ github.event_name }}
 
       - name: Deploy ${{ env.DEST_DIR }}
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ secrets.BOT_TOKEN }}
@@ -234,7 +246,7 @@ jobs:
             Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Find Comment
-        if: always() && github.event_name == 'pull_request_target'
+        if: always() && github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         uses: peter-evans/find-comment@v4
         id: fc
         with:
@@ -242,7 +254,7 @@ jobs:
           body-includes: I ran benchmarks as you asked
 
       - name: Post comment
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target' && steps.significant_benchmarks.outputs.changed == 'true'
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.BOT_TOKEN }}
@@ -281,7 +293,7 @@ jobs:
 
       - name: Save results artifact
         uses: actions/upload-artifact@v7
-        if: always()
+        if: always() && (github.event_name != 'pull_request_target' || steps.significant_benchmarks.outputs.changed == 'true')
         with:
           name: asv-benchmark-results-${{ runner.os }}
           path: |


### PR DESCRIPTION
### :pencil: Description

**Type:**  :roller_coaster: `infrastructure`

The benchmark bot comments are effectively background noise. Now they should only post to a PR if the benchmarks have changed, so they are worth looking at.

### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
