### PR TITLE
Fix outdated tardis-refdata URLs to tardis-regression-data in documentation

### DIFF
--- a/docs/io/configuration/components/atomic/current_public_table.rst
+++ b/docs/io/configuration/components/atomic/current_public_table.rst
@@ -12,7 +12,7 @@ Current Public Atomic Data Table
       - zeta
       - synpp references
       - database version
-    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
+    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
       - 6f7b09e887a311e7a06b246e96350010
       - | **kurucz:**
         | Li I-II, Be I-IV, C I-IV, N I-VI

--- a/docs/io/configuration/components/atomic/current_public_table.rst
+++ b/docs/io/configuration/components/atomic/current_public_table.rst
@@ -12,7 +12,7 @@ Current Public Atomic Data Table
       - zeta
       - synpp references
       - database version
-    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
+    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-regression-data/raw/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
       - 6f7b09e887a311e7a06b246e96350010
       - | **kurucz:**
         | Li I-II, Be I-IV, C I-IV, N I-VI

--- a/docs/io/configuration/components/models/example_data.inc
+++ b/docs/io/configuration/components/models/example_data.inc
@@ -1,2 +1,2 @@
 .. _example_yml: https://github.com/tardis-sn/tardis-setups/blob/master/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
-.. _example_atomic_database: https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5
+.. _example_atomic_database: https://github.com/tardis-sn/tardis-regression-data/raw/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5

--- a/docs/io/configuration/components/models/example_data.inc
+++ b/docs/io/configuration/components/models/example_data.inc
@@ -1,2 +1,2 @@
 .. _example_yml: https://github.com/tardis-sn/tardis-setups/blob/master/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
-.. _example_atomic_database: https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5
+.. _example_atomic_database: https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5


### PR DESCRIPTION
### :pencil: Description

**Type:** :memo: `documentation`

Updates outdated URLs in two documentation files:
- Changed repository from `tardis-refdata` to `tardis-regression-data`
- Changed branch from `master` to `main`

Part of #3576


### :pushpin: Resources: N/A

### :vertical_traffic_light: Testing

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested - These are documentation URL fixes, no code changes were made.


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

@tardis-sn/tardis could someone please review this?
