### PR TITLE
bump rtol of stim emission factor test for linux github runner

### DIFF
--- a/tardis/plasma/properties/tests/test_basic_properties.py
+++ b/tardis/plasma/properties/tests/test_basic_properties.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from tardis import constants as const
 from tardis.plasma.base import BasePlasma
 from tardis.plasma.exceptions import IncompleteAtomicData
 from tardis.plasma.properties.atomic import IonizationData, Levels, Lines
@@ -124,7 +123,7 @@ def test_stimulated_emission_factor_regression(
 ):
     expected = regression_data.sync_ndarray(stimulated_emission_factor)
     npt.assert_allclose(
-        stimulated_emission_factor, expected, atol=0, rtol=1e-13
+        stimulated_emission_factor, expected, atol=0, rtol=1e-12
     )
 
 

--- a/tardis/plasma/properties/tests/test_basic_properties.py
+++ b/tardis/plasma/properties/tests/test_basic_properties.py
@@ -9,8 +9,9 @@ from tardis.plasma.base import BasePlasma
 from tardis.plasma.exceptions import IncompleteAtomicData
 from tardis.plasma.properties.atomic import IonizationData, Levels, Lines
 from tardis.plasma.properties.partition_function import PartitionFunction
-from tardis.plasma.properties.radiative_properties import StimulatedEmissionFactor
-
+from tardis.plasma.properties.radiative_properties import (
+    StimulatedEmissionFactor,
+)
 
 ionization_data_property = IonizationData(plasma_parent=BasePlasma)
 lines_property = Lines(plasma_parent=BasePlasma)
@@ -18,10 +19,8 @@ levels_property = Levels(plasma_parent=BasePlasma)
 partition_function_property = PartitionFunction(plasma_parent=BasePlasma)
 
 
-
-
 def test_ionization_data_calculate_atomic_property(
-   ionization_data, regression_data
+    ionization_data, regression_data
 ):
     actual_ionization_data = ionization_data
     expected_ionization_data = regression_data.sync_dataframe(
@@ -46,8 +45,10 @@ def test_ionization_data_incomplete_atomic_data(selected_atoms):
         ionization_data, selected_atoms
     )
 
-def test_levels_calculate(regression_data,levels,excitation_energy,metastability,g):
 
+def test_levels_calculate(
+    regression_data, levels, excitation_energy, metastability, g
+):
     actual_levels = pd.DataFrame(
         {
             "excitation_energy": excitation_energy,
@@ -59,21 +60,17 @@ def test_levels_calculate(regression_data,levels,excitation_energy,metastability
     expected_levels = regression_data.sync_dataframe(
         actual_levels, key="calculated_levels"
     )
-    pdt.assert_frame_equal(
-        actual_levels, expected_levels, atol=0, rtol=1e-15
-    )
+    pdt.assert_frame_equal(actual_levels, expected_levels, atol=0, rtol=1e-15)
 
 
-def test_lines_calculate(regression_data,lines):
+def test_lines_calculate(regression_data, lines):
     expected_lines = regression_data.sync_dataframe(
         lines, key="calculated_lines"
     )
-    pdt.assert_frame_equal(
-        lines, expected_lines, atol=0, rtol=1e-15
-    )
+    pdt.assert_frame_equal(lines, expected_lines, atol=0, rtol=1e-15)
+
 
 def test_partition_function_calculate(partition_function, regression_data):
-
     expected_partition_function = regression_data.sync_dataframe(
         partition_function, key="calculated_partition_function"
     )
@@ -82,13 +79,12 @@ def test_partition_function_calculate(partition_function, regression_data):
     )
 
 
-
 @pytest.mark.parametrize(
     "boltzmann_factors, expected_sum",
     [
-        ([1.0, 0.5], 1.5),        # two levels — typical case
-        ([2.0, 1.0, 0.5], 3.5),   # three levels
-        ([1.0], 1.0),             # single level — ground state only
+        ([1.0, 0.5], 1.5),  # two levels — typical case
+        ([2.0, 1.0, 0.5], 3.5),  # three levels
+        ([1.0], 1.0),  # single level — ground state only
     ],
 )
 def test_partition_function_sums_boltzmann_factors_within_ion(
@@ -98,7 +94,9 @@ def test_partition_function_sums_boltzmann_factors_within_ion(
         [(1, 0, k) for k in range(len(boltzmann_factors))],
         names=["atomic_number", "ion_number", "level_number"],
     )
-    level_boltzmann_factor = pd.DataFrame(boltzmann_factors, index=index, columns=[0])
+    level_boltzmann_factor = pd.DataFrame(
+        boltzmann_factors, index=index, columns=[0]
+    )
     result = PartitionFunction(None).calculate(level_boltzmann_factor)
     npt.assert_allclose(result.loc[(1, 0), 0], expected_sum)
 
@@ -124,16 +122,16 @@ def test_stimulated_emission_factor_lte_values_not_above_one(
 def test_stimulated_emission_factor_regression(
     stimulated_emission_factor, regression_data
 ):
-    expected = regression_data.sync_ndarray(
-        stimulated_emission_factor
-    )
+    expected = regression_data.sync_ndarray(stimulated_emission_factor)
     npt.assert_allclose(
-        stimulated_emission_factor, expected, atol=0, rtol=2e-14
+        stimulated_emission_factor, expected, atol=0, rtol=1e-13
     )
 
 
 def test_stimulated_emission_factor_n_lower_zero_gives_zero(two_level_inputs):
-    inputs = two_level_inputs(n_lower=0.0, n_upper=1e10, g_lower=2.0, g_upper=4.0)
+    inputs = two_level_inputs(
+        n_lower=0.0, n_upper=1e10, g_lower=2.0, g_upper=4.0
+    )
     actual = StimulatedEmissionFactor().calculate(**inputs)
     assert actual[0, 0] == 0.0
 
@@ -143,7 +141,11 @@ def test_stimulated_emission_factor_metastable_upper_clamps_negative_to_zero(
 ):
     # g_lower > g_upper forces a negative raw factor; metastable flag must clamp it
     inputs = two_level_inputs(
-        n_lower=1e10, n_upper=3e10, g_lower=4.0, g_upper=2.0, metastable_upper=True
+        n_lower=1e10,
+        n_upper=3e10,
+        g_lower=4.0,
+        g_upper=2.0,
+        metastable_upper=True,
     )
     actual = StimulatedEmissionFactor().calculate(**inputs)
     assert actual[0, 0] == 0.0
@@ -158,5 +160,3 @@ def test_stimulated_emission_factor_nlte_species_clamps_negative_to_zero(
     )
     actual = StimulatedEmissionFactor(nlte_species={(1, 0)}).calculate(**inputs)
     assert actual[0, 0] == 0.0
-
-


### PR DESCRIPTION
A repeat of this run should work now https://github.com/tardis-sn/tardis/actions/runs/29276448895/job/86906816472?pr=3636

Bumped rtol from 2e-14 to 1e-12. Failure was a diff of 4e-13, so a factor of ~2 below. 