### PR TITLE
Remove continuum matrix from workflows

### DIFF
--- a/.github/workflows/compare-regdata.yml
+++ b/.github/workflows/compare-regdata.yml
@@ -37,7 +37,7 @@ jobs:
       regression-data-repo: tardis-sn/tardis-regression-data
 
   tests:
-    name: compare-regdata ${{ matrix.continuum }} continuum ${{ matrix.os }}
+    name: compare-regdata ${{ matrix.os }}
     if: (github.repository_owner == 'tardis-sn') && contains(github.event.pull_request.labels.*.name, 'run-regression-comparison')
     needs: [test-cache]
     runs-on: ${{ matrix.os }}
@@ -45,7 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         label: [osx-arm64, linux-64]
-        continuum: ['not']
         include:
           - label: osx-arm64
             os: macos-latest
@@ -143,7 +142,7 @@ jobs:
           pip install GitPython
 
       - name: Regression Data Generation tests
-        run: pytest tardis ${{ env.PYTEST_FLAGS }} --generate-reference -m "${{ matrix.continuum }} continuum"
+        run: pytest tardis ${{ env.PYTEST_FLAGS }} --generate-reference
       
       - name: Commit regression data
         id: commit
@@ -173,7 +172,7 @@ jobs:
         run: |
           jupyter nbconvert --execute ${{ github.workspace }}/tardisbase/tardisbase/testing/regression_comparison/compare_regression_data.ipynb \
             --to html \
-            --output=compare_regression_data_${{ github.event.pull_request.head.sha || github.sha }}_${{ matrix.continuum }}_${{ matrix.os }}.html \
+            --output=compare_regression_data_${{ github.event.pull_request.head.sha || github.sha }}_${{ matrix.os }}.html \
         working-directory: ${{ github.workspace }}/tardis-regression-data
         env:
           REGRESSION_DATA_REPO: ${{ github.workspace }}/tardis-regression-data
@@ -182,8 +181,8 @@ jobs:
         if: steps.commit.outputs.has_changes == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: compare_regression_data_${{ github.event.pull_request.head.sha || github.sha }}_${{ matrix.continuum }}_${{ matrix.os }}.html
+          name: compare_regression_data_${{ github.event.pull_request.head.sha || github.sha }}_${{ matrix.os }}.html
           include-hidden-files: true
           path: |
-            ${{ github.workspace }}/tardisbase/tardisbase/testing/regression_comparison/compare_regression_data_${{ github.event.pull_request.head.sha || github.sha }}_${{ matrix.continuum }}_${{ matrix.os }}.html
+            ${{ github.workspace }}/tardisbase/tardisbase/testing/regression_comparison/compare_regression_data_${{ github.event.pull_request.head.sha || github.sha }}_${{ matrix.os }}.html
             ${{ github.workspace }}/tardisbase/tardisbase/testing/regression_comparison/comparison_plots*

--- a/.github/workflows/publish-regdata-comparison.yml
+++ b/.github/workflows/publish-regdata-comparison.yml
@@ -46,13 +46,11 @@ jobs:
         id: get_paths
         run: |
           for os in "macos-latest" "ubuntu-latest"; do
-            for cont in "" "not_"; do
-              dir=$(find comparison-artifacts -type d -name "comparison_plots*" -path "*${cont}${os}*" | head -n1)
-              if [ -n "$dir" ]; then
-                clean_dir=$(echo "$dir" | sed 's|^comparison-artifacts/||')
-                echo "${cont}${os}_path=${clean_dir}" >> "$GITHUB_OUTPUT"
-              fi
-            done
+            dir=$(find comparison-artifacts -type d -name "comparison_plots*" -path "*${os}*" | head -n1)
+            if [ -n "$dir" ]; then
+              clean_dir=$(echo "$dir" | sed 's|^comparison-artifacts/||')
+              echo "${os}_path=${clean_dir}" >> "$GITHUB_OUTPUT"
+            fi
           done
 
       - name: Deploy to GitHub Pages
@@ -89,30 +87,16 @@ jobs:
 
             The comparison results have been generated and can be viewed here:
 
-            - [macOS (not continuum)](https://tardis-sn.github.io/reg-data-comp/pull/${{ env.PR_NUMBER }}/compare_regression_data_${{ env.PR_SHA }}_not_macos-latest.html/compare_regression_data_${{ env.PR_SHA }}_not_macos-latest.html)
-            - [macOS (continuum)](https://tardis-sn.github.io/reg-data-comp/pull/${{ env.PR_NUMBER }}/compare_regression_data_${{ env.PR_SHA }}__macos-latest.html/compare_regression_data_${{ env.PR_SHA }}__macos-latest.html)
-            - [Ubuntu (not continuum)](https://tardis-sn.github.io/reg-data-comp/pull/${{ env.PR_NUMBER }}/compare_regression_data_${{ env.PR_SHA }}_not_ubuntu-latest.html/compare_regression_data_${{ env.PR_SHA }}_not_ubuntu-latest.html)
-            - [Ubuntu (continuum)](https://tardis-sn.github.io/reg-data-comp/pull/${{ env.PR_NUMBER }}/compare_regression_data_${{ env.PR_SHA }}__ubuntu-latest.html/compare_regression_data_${{ env.PR_SHA }}__ubuntu-latest.html)
+            - [macOS](https://tardis-sn.github.io/reg-data-comp/pull/${{ env.PR_NUMBER }}/compare_regression_data_${{ env.PR_SHA }}_macos-latest.html/compare_regression_data_${{ env.PR_SHA }}_macos-latest.html)
+            - [Ubuntu](https://tardis-sn.github.io/reg-data-comp/pull/${{ env.PR_NUMBER }}/compare_regression_data_${{ env.PR_SHA }}_ubuntu-latest.html/compare_regression_data_${{ env.PR_SHA }}_ubuntu-latest.html)
 
             <details>
             <summary>📊 View Comparison Plots</summary>
 
-            ### macOS (not continuum)
-            ![Spectrum Comparison](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.not_macos-latest_path }}/spectrum.png?raw=true)
-            ![Same Name Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.not_macos-latest_path }}/same_name_diff.png?raw=true)
-            ![Key Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.not_macos-latest_path }}/diff_keys.png?raw=true)
-
-            ### macOS (continuum)
             ![Spectrum Comparison](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.macos-latest_path }}/spectrum.png?raw=true)
             ![Same Name Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.macos-latest_path }}/same_name_diff.png?raw=true)
             ![Key Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.macos-latest_path }}/diff_keys.png?raw=true)
 
-            ### Ubuntu (not continuum)
-            ![Spectrum Comparison](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.not_ubuntu-latest_path }}/spectrum.png?raw=true)
-            ![Same Name Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.not_ubuntu-latest_path }}/same_name_diff.png?raw=true)
-            ![Key Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.not_ubuntu-latest_path }}/diff_keys.png?raw=true)
-
-            ### Ubuntu (continuum)
             ![Spectrum Comparison](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.ubuntu-latest_path }}/spectrum.png?raw=true)
             ![Same Name Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.ubuntu-latest_path }}/same_name_diff.png?raw=true)
             ![Key Differences](https://github.com/tardis-sn/reg-data-comp/blob/main/pull/${{ env.PR_NUMBER }}/${{ steps.get_paths.outputs.ubuntu-latest_path }}/diff_keys.png?raw=true)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
       regression-data-repo: tardis-sn/tardis-regression-data
 
   tests:
-    name: tests ${{ matrix.continuum }} continuum ${{ matrix.os }} ${{ matrix.pip_git && 'pip tests enabled' || 'pip tests disabled' }}
+    name: tests ${{ matrix.os }} ${{ matrix.pip_git && 'pip tests enabled' || 'pip tests disabled' }}
     if: github.repository_owner == 'tardis-sn'
     needs: [test-cache]
     runs-on: ${{ matrix.os }}
@@ -52,7 +52,6 @@ jobs:
       fail-fast: false
       matrix:
         label: [osx-arm64, linux-64]
-        continuum: ["not"]
         pip_git: ${{ contains(github.event.pull_request.labels.*.name, 'pip-git-tests') && fromJSON('[true, false]') || fromJSON('[false]') }}
         include:
           - label: osx-arm64
@@ -145,7 +144,7 @@ jobs:
           pip install --no-deps lineid_plot
 
       - name: Run tests
-        run: pytest tardis ${{ env.PYTEST_FLAGS }} -m "${{ matrix.continuum }} continuum"
+        run: pytest tardis ${{ env.PYTEST_FLAGS }}
 
       - name: Run JIT-disabled tests
         env:
@@ -153,14 +152,14 @@ jobs:
         run: pytest tardis/transport/montecarlo/tests/test_single_packet_loop.py tardis/energy_input/transport/tests/test_gamma_transport.py -k numba_disabled ${{ env.PYTEST_FLAGS }}
 
       - name: Regression Data Generation tests
-        run: pytest tardis ${{ env.PYTEST_FLAGS }} --generate-reference -m "${{ matrix.continuum }} continuum"
+        run: pytest tardis ${{ env.PYTEST_FLAGS }} --generate-reference
         if: contains(github.event.pull_request.labels.*.name, 'run-generation-tests') || github.ref == 'refs/heads/master'
 
       - run: mv .coverage .coverage.${{ strategy.job-index }}
 
       - uses: actions/upload-artifact@v7
         with:
-          name: coverage-${{ matrix.continuum }}-continuum-${{ matrix.pip_git && 'pip-git-' || '' }}${{ matrix.os }}
+          name: coverage-${{ matrix.pip_git && 'pip-git-' || '' }}${{ matrix.os }}
           include-hidden-files: true
           path: |
             .coverage*


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

We don't use the continuum marker for tests any more (and definitely not when #3654 is merged.
