### PR TITLE
Fix failing publish workflow

### DIFF
--- a/.github/workflows/publish-benchmark-comparison.yml
+++ b/.github/workflows/publish-benchmark-comparison.yml
@@ -32,12 +32,13 @@ jobs:
             -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
           if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::No unique open pull request matches this source run."
-            exit 1
+            echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+            pr_number=
           fi
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Download benchmark artifacts
+        if: steps.pr.outputs.number != ''
         uses: actions/download-artifact@v8
         with:
           github-token: ${{ github.token }}
@@ -47,6 +48,7 @@ jobs:
           path: comparison-artifacts
 
       - name: Check for generated benchmark HTML
+        if: steps.pr.outputs.number != ''
         id: html
         run: |
           if [[ -d comparison-artifacts/.asv/html ]]; then

--- a/.github/workflows/publish-codestyle.yml
+++ b/.github/workflows/publish-codestyle.yml
@@ -31,17 +31,17 @@ jobs:
             -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
           if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::No unique open pull request matches this source run."
-            exit 1
+            echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+            pr_number=
           fi
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Explain skipped comment
-        if: github.event.workflow_run.conclusion != 'success'
+        if: steps.pr.outputs.number != '' && github.event.workflow_run.conclusion != 'success'
         run: echo "::notice::The codestyle workflow concluded ${{ github.event.workflow_run.conclusion }}; no codestyle comment was posted."
 
       - name: Download Ruff results
-        if: github.event.workflow_run.conclusion == 'success'
+        if: steps.pr.outputs.number != '' && github.event.workflow_run.conclusion == 'success'
         uses: actions/download-artifact@v8
         with:
           github-token: ${{ github.token }}
@@ -51,21 +51,21 @@ jobs:
           path: ruff-results
 
       - name: Read statistics output
-        if: github.event.workflow_run.conclusion == 'success'
+        if: steps.pr.outputs.number != '' && github.event.workflow_run.conclusion == 'success'
         id: ruff_stats
         uses: juliangruber/read-file-action@v1.1.8
         with:
           path: ruff-results/ruff_stats.txt
 
       - name: Read complete output
-        if: github.event.workflow_run.conclusion == 'success'
+        if: steps.pr.outputs.number != '' && github.event.workflow_run.conclusion == 'success'
         id: ruff_complete
         uses: juliangruber/read-file-action@v1.1.8
         with:
           path: ruff-results/ruff_truncated.txt
 
       - name: Find comment
-        if: github.event.workflow_run.conclusion == 'success'
+        if: steps.pr.outputs.number != '' && github.event.workflow_run.conclusion == 'success'
         uses: peter-evans/find-comment@v4
         id: fc
         with:
@@ -73,7 +73,7 @@ jobs:
           body-includes: I ran ruff on the latest commit
 
       - name: Post comment
-        if: github.event.workflow_run.conclusion == 'success'
+        if: steps.pr.outputs.number != '' && github.event.workflow_run.conclusion == 'success'
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -31,12 +31,13 @@ jobs:
             -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
           if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::No unique open pull request matches this source run."
-            exit 1
+            echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+            pr_number=
           fi
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Check whether documentation publishing was requested
+        if: steps.pr.outputs.number != ''
         id: policy
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/publish-mailmap.yml
+++ b/.github/workflows/publish-mailmap.yml
@@ -28,12 +28,13 @@ jobs:
             -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
           if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::No unique open pull request matches this source run."
-            exit 1
+            echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+            pr_number=
           fi
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Create comment
+        if: steps.pr.outputs.number != ''
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/publish-orcid.yml
+++ b/.github/workflows/publish-orcid.yml
@@ -31,12 +31,13 @@ jobs:
             -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
           if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::No unique open pull request matches this source run."
-            exit 1
+            echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+            pr_number=
           fi
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Download ORCID check result
+        if: steps.pr.outputs.number != ''
         uses: actions/download-artifact@v8
         with:
           github-token: ${{ github.token }}
@@ -46,6 +47,7 @@ jobs:
           path: orcid-results
 
       - name: Check result
+        if: steps.pr.outputs.number != ''
         id: result
         run: echo "failed=$(grep -Fxq failure orcid-results/orcid-status.txt && echo true || echo false)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-regdata-comparison.yml
+++ b/.github/workflows/publish-regdata-comparison.yml
@@ -32,12 +32,13 @@ jobs:
             -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
             --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
           if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-            echo "::error::No unique open pull request matches this source run."
-            exit 1
+            echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+            pr_number=
           fi
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
       - name: Check regression comparison label
+        if: steps.pr.outputs.number != ''
         id: label
         run: |
           if gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" --paginate --jq '.[].name' | grep -Fxq run-regression-comparison; then

--- a/docs/current_developers/continuous_integration.rst
+++ b/docs/current_developers/continuous_integration.rst
@@ -91,8 +91,8 @@ fail-closed ``Get PR number`` step:
          -f "head=${HEAD_OWNER}:${HEAD_BRANCH}" \
          --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number")
        if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
-         echo "::error::No unique open pull request matches this source run."
-         exit 1
+         echo "::notice::No unique open pull request matches this source run; publishing was skipped."
+         pr_number=
        fi
        echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
 
@@ -123,12 +123,11 @@ The script then performs these operations:
    regular expression ``^[0-9]+$`` accepts exactly one numeric result. No match
    produces an empty value, while multiple matches produce multiple lines; both
    cases fail this check.
-4. When the check fails, the script emits an error in the workflow log and exits
-   with status 1. The publisher job therefore fails before any artifact download,
-   deployment, or comment can use an empty pull-request number.
+4. When the check fails, the script emits a notice and empties ``pr_number``.
+   The lookup step succeeds, but guarded publishing steps do not run.
 5. The final line writes ``number=<value>`` to ``GITHUB_OUTPUT``. Later steps
-   read it as ``steps.pr.outputs.number``. This line is reached only after the
-   value has passed the numeric-result check.
+   read it as ``steps.pr.outputs.number`` and use
+   ``if: steps.pr.outputs.number != ''`` to run only when it is present.
 
 If the API request itself fails, for example because the token lacks permission,
 the ``Get PR number`` step fails instead of silently skipping publication. The
@@ -212,9 +211,8 @@ After the change reaches the default branch:
 4. Confirm that the bot comment links both workflow runs and that any preview
    URL uses the correct pull-request number.
 5. Push another commit while an older producer is finishing. The old publisher
-   should fail with the error that no unique open pull request matches the source
-   run and publish nothing; the publisher for the newest SHA should publish
-   normally.
+   should report that no unique open pull request matches the source run and
+   publish nothing; the publisher for the newest SHA should publish normally.
 
 When troubleshooting:
 


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

The workflows that publish artifacts are crashing instead of skipping if they can't find a PR.