### PR TITLE
Fix docs publish workflow bugs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -102,15 +102,11 @@ jobs:
           edit-mode: replace
           body: |
             <!-- tardis:docs-preview -->
-            *\*beep\* \*bop\**
-
-            Hi, human.
 
             The **docs** workflow has completed with these results:
 
             - Build: **${{ github.event.workflow_run.conclusion }}**
-            - Deployment: **${{ steps.deploy.outcome }}**
 
-            ${{ steps.deploy.outcome == 'success' && format('[View the documentation preview](https://{0}.github.io/{1}/pull/{2}/index.html).', github.repository_owner, github.event.repository.name, steps.pr.outputs.number) || 'The latest documentation preview was not deployed. See the publisher run for details.' }}
+            [View the documentation preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pull/${{ steps.pr.outputs.number }}/index.html).
 
             Runs: [build and test](${{ github.event.workflow_run.html_url }}) · [publish](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEPLOY_BRANCH: gh-pages
+      PR_SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
       - name: Get PR number
         id: pr
@@ -70,6 +71,7 @@ jobs:
           path: ${{ runner.temp }}/docs-artifact
 
       - name: Deploy documentation
+        id: deploy
         if: github.event.workflow_run.conclusion == 'success' && steps.policy.outputs.should-publish == 'true'
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -83,15 +85,15 @@ jobs:
           user_email: "tardis.sn.bot@gmail.com"
 
       - name: Find documentation preview comment
-        if: steps.policy.outputs.should-publish == 'true'
+        if: always() && steps.policy.outputs.should-publish == 'true'
         uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ steps.pr.outputs.number }}
           body-includes: The **docs** workflow has
 
-      - name: Post comment (success)
-        if: github.event.workflow_run.conclusion == 'success' && steps.policy.outputs.should-publish == 'true'
+      - name: Post documentation preview status
+        if: always() && steps.policy.outputs.should-publish == 'true'
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.BOT_TOKEN }}
@@ -104,26 +106,11 @@ jobs:
 
             Hi, human.
 
-            The **docs** workflow has **succeeded** :heavy_check_mark:
+            The **docs** workflow has completed with these results:
 
-            [View the documentation preview](https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pull/${{ steps.pr.outputs.number }}/index.html).
+            - Build: **${{ github.event.workflow_run.conclusion }}**
+            - Deployment: **${{ steps.deploy.outcome }}**
 
-            Runs: [build and test](${{ github.event.workflow_run.html_url }}) · [publish](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-      - name: Post comment (failure)
-        if: github.event.workflow_run.conclusion != 'success' && steps.policy.outputs.should-publish == 'true'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          token: ${{ secrets.BOT_TOKEN }}
-          issue-number: ${{ steps.pr.outputs.number }}
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            <!-- tardis:docs-preview -->
-            *\*beep\* \*bop\**
-
-            Hi, human.
-
-            The **docs** workflow has **failed** :x:
+            ${{ steps.deploy.outcome == 'success' && format('[View the documentation preview](https://{0}.github.io/{1}/pull/{2}/index.html).', github.repository_owner, github.event.repository.name, steps.pr.outputs.number) || 'The latest documentation preview was not deployed. See the publisher run for details.' }}
 
             Runs: [build and test](${{ github.event.workflow_run.html_url }}) · [publish](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/docs/current_developers/continuous_integration.rst
+++ b/docs/current_developers/continuous_integration.rst
@@ -165,10 +165,12 @@ The following pairs use this setup:
 
 GitHub displays the producer and publisher as separate workflow runs. Each
 publisher's run name includes the pull request title from
-``workflow_run.display_title``, and successful bot comments link the source and
-publisher runs. GitHub does not provide a token setting that turns a
-``workflow_run`` run into a child job of the producer or natively attaches it to
-the pull request.
+``workflow_run.display_title``. The documentation publisher's bot comment
+reports the producer build conclusion and deployment-step outcome separately.
+It links the preview after the deployment step succeeds. The comment uses
+``always()`` so deployment failures are reported as well as producer failures.
+GitHub does not provide a token setting that turns a ``workflow_run`` run into
+a child job of the producer or natively attaches it to the pull request.
 
 Testing a producer/publisher change
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/current_developers/continuous_integration.rst
+++ b/docs/current_developers/continuous_integration.rst
@@ -166,9 +166,9 @@ The following pairs use this setup:
 GitHub displays the producer and publisher as separate workflow runs. Each
 publisher's run name includes the pull request title from
 ``workflow_run.display_title``. The documentation publisher's bot comment
-reports the producer build conclusion and deployment-step outcome separately.
-It links the preview after the deployment step succeeds. The comment uses
-``always()`` so deployment failures are reported as well as producer failures.
+reports the producer build conclusion and includes the preview link regardless
+of the deployment result. The comment uses ``always()`` so deployment failures
+are reported as well as producer failures.
 GitHub does not provide a token setting that turns a ``workflow_run`` run into
 a child job of the producer or natively attaches it to the pull request.
 

--- a/docs/current_developers/documentation.rst
+++ b/docs/current_developers/documentation.rst
@@ -201,7 +201,8 @@ The built documentation is available at:
    https://tardis-sn.github.io/tardis/pull/<pull request number>/index.html
 
 
-It is also linked automatically in pull request comments.
+The pull request comment reports the documentation build and deployment
+outcomes separately. It links the preview after the deployment step succeeds.
 
 To view build logs, go to the Actions tab in the TARDIS repository and select
 the ``docs`` workflow. Search documentation builds by branch to find the relevant


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :roller_coaster: `infrastructure`

There are still a couple of bugs with the docs publishing workflow (which handles PR-specific docs builds and comments)
