### PR TITLE
TARDIS "scientific attention" PR review helper skill

### DIFF
--- a/.agents/skills/tardis-pr-review/SKILL.md
+++ b/.agents/skills/tardis-pr-review/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: tardis-pr-review
+description: Analyze a numbered pull request in tardis-sn/tardis and produce a plain-language guide to changed equations, physical assumptions, scientific data, numerical methods, and supporting tests that merit close review by scientists. Use when the user supplies a TARDIS PR number and asks for scientific review priorities or areas of scientific interest. Explain the scientific importance without assuming Git or software-review expertise. Do not use for a comprehensive code review, implementation work, local-only changes, non-TARDIS repositories, or requests without a PR number.
+---
+
+# Highlight Science Questions in a TARDIS Pull Request
+
+## Establish a Read-Only Snapshot
+
+1. Require a positive integer pull-request number. Treat `tardis-sn/tardis` as
+   the canonical repository and work from a TARDIS checkout.
+
+2. Record the current branch, HEAD, remotes, and `git status --short`. Preserve
+   all user work. Do not switch branches, stash, reset, clean, pull, or use
+   `gh pr checkout`.
+
+3. Obtain the PR title, body, URL, state, author, base ref and SHA, head SHA,
+   labels, commits, and changed files. Prefer:
+
+   ```shell
+   gh pr view <number> --repo tardis-sn/tardis \
+     --json number,title,body,url,state,isDraft,author,baseRefName,baseRefOid,headRefName,headRefOid,labels,commits,files
+   ```
+
+   Read linked requirements and relevant existing discussion. When using the
+   REST API, paginate commits, files, reviews, review comments, and issue
+   comments instead of trusting first-page results. Do not install missing
+   tools.
+
+4. Fetch the base and head into review-only refs:
+
+   ```shell
+   git fetch --no-tags https://github.com/tardis-sn/tardis.git \
+     +refs/heads/<base-ref>:refs/tardis-pr-review/<number>/base \
+     +refs/pull/<number>/head:refs/tardis-pr-review/<number>/head
+   ```
+
+   Verify the fetched object IDs against the recorded SHAs. Re-query once if
+   the base moved; report an inconsistent snapshot if either SHA still differs.
+   Never execute code from the fetched PR.
+
+## Recover the Scientific Intent
+
+1. Follow the active root `AGENTS.md`. Read applicable current developer
+   documents from the fetched base tree, especially feature workflow, design
+   philosophy, and testing and regression guidance. Treat them as review policy,
+   not evidence that the proposed science is correct.
+
+2. Read the PR requirement, complete triple-dot diff, and relevant code, tests,
+   fixtures, configuration, physics documentation, cited equations, and data
+   provenance from the base and head objects. Prefer `git diff`, `git show`, and
+   `git grep` with external diff and text-conversion drivers disabled so the
+   working tree remains unchanged.
+
+3. State the claimed scientific outcome, the relevant physical regime, and the
+   explicit and implicit assumptions. Trace the changed quantities through
+   their earlier inputs and later uses—for example, from configuration, model,
+   or atomic data through plasma, opacity, transport, estimators, convergence,
+   and spectrum generation. Do not limit the trace to changed files.
+
+## Select Areas That Need Scientific Attention
+
+Include an area only when a change, or an assumption connecting calculations,
+can alter a scientific result, its interpretation, or the evidence used to
+validate it. Scan the entire diff, but do not turn the brief into a file-by-file
+software review.
+
+Use these lenses when applicable:
+
+- Physical formulation: equations, conservation laws, approximations, regimes
+  of validity, constants, dimensions, units, and normalization.
+- Frames and geometry: comoving versus observer quantities, frequency and
+  wavelength transformations, time since explosion, homologous-expansion
+  assumptions, shell boundaries, and radial or directional conventions.
+- Numerical representation: discretization, interpolation, integration,
+  tolerances, convergence, stability, floating-point behavior, array shapes,
+  masks, ordering, indexing, and boundary handling.
+- Monte Carlo transport: packet initialization and propagation, interaction
+  probabilities, random sampling and seeds, estimators, packet weights, energy
+  accounting, statistical uncertainty, and reproducibility.
+- Matter-radiation coupling: ionization and excitation populations, LTE/NLTE
+  assumptions, radiation-field updates, opacities, rates, Sobolev and macro-atom
+  treatment, continuum processes, iteration ordering, and cached state.
+- Scientific data semantics: atomic or decay-data provenance, identifiers,
+  level and transition mappings, units, missing values, filters, joins, and
+  conversions between tabular and array representations.
+- Observable construction: spectral binning, luminosity integration, virtual or
+  formal-integral spectra, escaping-packet selection, and output quantity
+  definitions.
+- Scientific validation: analytic or limiting cases, independent comparisons,
+  regression baselines, tolerances, packet counts, stochastic variance, test
+  oracle provenance, and assertions on physically meaningful quantities.
+
+Label an area `close review` when the PR changes a physical model, conservation
+or frame convention, coupled calculation, interpretation of scientific data, or
+stored reference result. Label it `check carefully` when calculation details,
+defaults, boundaries, or tests can indirectly change or conceal scientific
+behavior. These labels show where scientific attention is most useful; they do
+not mean that the change is wrong.
+
+For each area:
+
+1. Link to the relevant changed lines in the version reviewed and name important
+   later calculations when needed.
+2. Explain the changed scientific quantity or assumption and the results it can
+   affect later in the simulation.
+3. Identify the physical regime, relation that should remain true, convention,
+   or meaning of the data that a reviewer should verify.
+4. Pose concrete review questions and name useful evidence, such as a derivation,
+   dimensional check, limiting case, calculation by another method, convergence
+   study, or comparison with stored reference results.
+5. Distinguish demonstrated evidence from inference. If an error is directly
+   established, describe its scientific consequence inside the review area;
+   otherwise present the uncertainty as a review question, not a defect.
+
+Exclude style, naming, typing, general maintainability, documentation polish,
+and unrelated CI failures unless they obscure scientific meaning or validation.
+Do not assign software-bug severity labels, give an overall approval verdict, or
+imply that passing tests establish scientific correctness.
+
+## Inspect Relevant Validation Evidence
+
+1. Do not run PR code, tests, Ruff, Python imports, notebooks, documentation
+   builds, or benchmarks locally. Inspect exact-head CI and existing artifacts
+   only for evidence tied to a reported area.
+
+2. Determine whether relevant unit, integration, regression, GPU, or benchmark
+   jobs ran against the recorded head or its current synthetic merge commit.
+   Treat skipped, label-gated, stale, cancelled, or absent checks as missing
+   evidence. Inspect failed logs when they clarify a scientific validation gap.
+   Do not summarize unrelated checks.
+
+3. Never post a review or comment, approve, label, rerun, or otherwise mutate
+   GitHub state without separate user authorization.
+
+4. Re-query the PR head SHA before reporting. If it changed, fetch the new
+   snapshot and inspect the incremental diff before relying on prior analysis or
+   CI.
+
+## Write for a Scientific Reader
+
+Assume the reader understands the relevant astrophysics but may not know Git,
+GitHub Actions, or software-review terminology.
+
+1. Use precise scientific language and ordinary prose. Explain abbreviations on
+   first use unless they are standard in the immediate TARDIS context.
+
+2. Translate software terms in the report:
+
+   - Say **version reviewed**, not `head`, `SHA`, or `commit`, except when giving
+     the identifier in the final version details.
+   - Say **automated tests**, not `CI`, `check`, or `job`.
+   - Say **stored reference result** or **expected result**, not `regression
+     baseline` or `test oracle`.
+   - Name the actual later calculation or scientific output instead of saying
+     `caller`, `consumer`, or `downstream`.
+   - Describe the expected inputs, outputs, units, and meanings instead of using
+     `interface` or `data contract`.
+   - Say **area needing scientific attention**, not `hotspot`.
+   - Introduce a source link as **Where to look**, not a `line anchor`.
+
+3. When a technical software term is unavoidable, define it in one short
+   sentence at first use. Do not expect the reader to interpret branch names,
+   workflow names, test markers, or abbreviated check names.
+
+4. Focus each area on the scientific choice and its possible effect. Mention
+   code mechanics only when they help the reader understand that effect.
+
+## Report a Scientific-Review Brief
+
+Lead with: “This brief highlights science questions for specialist review; it
+does not determine whether the proposed change is correct.” Then report:
+
+1. **What the change aims to do**: explain the intended result, physical regime,
+   and assumptions in a short paragraph.
+2. **Areas needing scientific attention**: give each area a scientific title and
+   a `close review` or `check carefully` label, followed by:
+
+   - **Where to look**: link to the relevant lines.
+   - **Why it matters**: explain the possible effect on physical quantities or
+     results.
+   - **Questions to answer**: ask concrete scientific questions.
+   - **What evidence exists**: summarize useful tests, comparisons, or missing
+     evidence in plain language.
+
+3. **How the effects move through the simulation**: explain connections among
+   plasma, transport, convergence, and observables only when several review
+   areas are linked.
+4. **What has been checked**: relate automated test results to the scientific
+   questions they address. Explain absent or inconclusive evidence without
+   giving a general software-test status report.
+5. **Version reviewed**: give the PR URL and the identifiers for the starting
+   and proposed versions. State that the proposed code was inspected but not run
+   locally.
+
+If no changed area merits scientific review, say so explicitly and briefly
+explain why the change appears science-neutral. Do not fill the report with
+general software-review observations.

--- a/.agents/skills/tardis-pr-review/SKILL.md
+++ b/.agents/skills/tardis-pr-review/SKILL.md
@@ -100,12 +100,33 @@ actual changes; never turn them into a generic checklist:
   regression baselines, tolerances, packet counts, stochastic variance, test
   oracle provenance, and assertions on physically meaningful quantities.
 
-Label an area `close review` when the PR changes a physical model, conservation
-or frame convention, coupled calculation, interpretation of scientific data, or
-stored reference result. Label it `check carefully` when calculation details,
-defaults, boundaries, or tests can indirectly change or conceal scientific
-behavior. These labels show where scientific attention is most useful; they do
-not mean that the change is wrong.
+Assign each area exactly one of these labels, choosing the most specific label
+supported by the changed lines:
+
+- `Physical model change`: equations, physical assumptions, conservation laws,
+  approximations, or regimes of validity change.
+- `Convention change`: a frame, geometry, sign, normalization, unit, indexing,
+  or other scientific convention changes.
+- `Coupled calculation with downstream effects`: a change in one calculation
+  changes inputs, state, or iteration behavior in later coupled calculations.
+- `Change in interpretation of scientific data`: the meaning, provenance,
+  mapping, filtering, units, or conversion of scientific data changes.
+- `Change in stored reference result`: an expected or regression result changes,
+  whether because the calculation or the stored comparison changes.
+- `Calculation details changed`: discretization, interpolation, tolerances,
+  ordering, floating-point handling, or other numerical details change without
+  a more specific close-review classification above.
+- `Defaults changed`: a default parameter, option, packet count, seed, or other
+  implicit user input changes.
+- `Boundary values changed`: shell, grid, mask, cutoff, range, or other
+  boundary handling changes.
+- `Tests changed`: tests, fixtures, assertions, tolerances, or test data change
+  in a way that can alter or conceal scientific validation.
+
+Use the first five labels for changes needing close review and the last four
+for changes to check carefully. If a change genuinely covers multiple distinct
+labels, split it into separate areas. These labels show where scientific
+attention is most useful; they do not mean that the change is wrong.
 
 For each area:
 
@@ -193,8 +214,8 @@ does not determine whether the proposed change is correct.” Follow it with at
 most one sentence describing what the PR aims to change.
 
 Apart from that opening and the final version line, report only **Areas needing
-scientific attention**. Give each area a scientific title and a `close review`
-or `check carefully` label, followed by:
+scientific attention**. Give each area a scientific title and exactly one of the
+specific labels above, followed by:
 
 - **Where to look**: link to the relevant lines.
 - **Why it matters**: explain the possible scientific effect in one or two

--- a/.agents/skills/tardis-pr-review/SKILL.md
+++ b/.agents/skills/tardis-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tardis-pr-review
-description: Analyze a numbered pull request in tardis-sn/tardis and produce a plain-language guide to changed equations, physical assumptions, scientific data, numerical methods, and supporting tests that merit close review by scientists. Use when the user supplies a TARDIS PR number and asks for scientific review priorities or areas of scientific interest. Explain the scientific importance without assuming Git or software-review expertise. Do not use for a comprehensive code review, implementation work, local-only changes, non-TARDIS repositories, or requests without a PR number.
+description: Analyze a numbered pull request in tardis-sn/tardis and produce a concise, plain-language guide to changed equations, physical assumptions, scientific data, numerical methods, and supporting tests that merit close review by scientists. Use when the user supplies a TARDIS PR number and asks for scientific review priorities or areas of scientific interest. Ask only questions directly motivated by changed code or its immediate scientific effects, and explain their importance without assuming Git or software-review expertise. Do not use for a comprehensive code review, implementation work, local-only changes, non-TARDIS repositories, or requests without a PR number.
 ---
 
 # Highlight Science Questions in a TARDIS Pull Request
@@ -65,7 +65,16 @@ can alter a scientific result, its interpretation, or the evidence used to
 validate it. Scan the entire diff, but do not turn the brief into a file-by-file
 software review.
 
-Use these lenses when applicable:
+Require this evidence chain for every reported area:
+
+1. An exact changed line.
+2. The scientific quantity, assumption, or test affected by that line.
+3. A plausible effect on a calculation or result.
+4. A specific unanswered question that would help a scientific reviewer assess
+   that effect, or a directly established scientific consequence.
+
+Omit the area if any link is missing. Use the following lenses only to interpret
+actual changes; never turn them into a generic checklist:
 
 - Physical formulation: equations, conservation laws, approximations, regimes
   of validity, constants, dimensions, units, and normalization.
@@ -106,12 +115,19 @@ For each area:
    affect later in the simulation.
 3. Identify the physical regime, relation that should remain true, convention,
    or meaning of the data that a reviewer should verify.
-4. Pose concrete review questions and name useful evidence, such as a derivation,
-   dimensional check, limiting case, calculation by another method, convergence
-   study, or comparison with stored reference results.
+4. Ask only questions caused by the changed lines or their immediate effects.
+   Make each question identify the changed choice and the scientific uncertainty
+   it creates. Do not ask broad questions such as whether units, conservation,
+   tests, or documentation are generally adequate.
 5. Distinguish demonstrated evidence from inference. If an error is directly
-   established, describe its scientific consequence inside the review area;
-   otherwise present the uncertainty as a review question, not a defect.
+   established, describe its scientific consequence without inventing a
+   question; otherwise present the uncertainty as a review question, not a
+   defect.
+6. Prefer one question and never include more than three questions for one area.
+   Combine overlapping areas and remove duplicate questions.
+7. Do not ask a question already answered by the changed code, tests, PR
+   description, or review discussion. State the answer briefly only when it
+   materially affects the remaining scientific question.
 
 Exclude style, naming, typing, general maintainability, documentation polish,
 and unrelated CI failures unless they obscure scientific meaning or validation.
@@ -166,33 +182,38 @@ GitHub Actions, or software-review terminology.
 4. Focus each area on the scientific choice and its possible effect. Mention
    code mechanics only when they help the reader understand that effect.
 
+5. Keep the brief short. Do not repeat the PR description, explain familiar
+   TARDIS physics, narrate the inspection process, list unaffected files, or
+   restate the same consequence under several headings.
+
 ## Report a Scientific-Review Brief
 
 Lead with: “This brief highlights science questions for specialist review; it
-does not determine whether the proposed change is correct.” Then report:
+does not determine whether the proposed change is correct.” Follow it with at
+most one sentence describing what the PR aims to change.
 
-1. **What the change aims to do**: explain the intended result, physical regime,
-   and assumptions in a short paragraph.
-2. **Areas needing scientific attention**: give each area a scientific title and
-   a `close review` or `check carefully` label, followed by:
+Apart from that opening and the final version line, report only **Areas needing
+scientific attention**. Give each area a scientific title and a `close review`
+or `check carefully` label, followed by:
 
-   - **Where to look**: link to the relevant lines.
-   - **Why it matters**: explain the possible effect on physical quantities or
-     results.
-   - **Questions to answer**: ask concrete scientific questions.
-   - **What evidence exists**: summarize useful tests, comparisons, or missing
-     evidence in plain language.
+- **Where to look**: link to the relevant lines.
+- **Why it matters**: explain the possible scientific effect in one or two
+  sentences.
+- **Question for the reviewer**: include this only for an unresolved question.
+  Ask one concise question directly tied to the changed lines. Add a second or
+  third only when each addresses a distinct scientific uncertainty created by
+  those changes. Do not invent a question for an established consequence.
+- **Evidence**: include at most one sentence when an automated test, comparison,
+  or missing result changes how the reviewer should approach the question.
 
-3. **How the effects move through the simulation**: explain connections among
-   plasma, transport, convergence, and observables only when several review
-   areas are linked.
-4. **What has been checked**: relate automated test results to the scientific
-   questions they address. Explain absent or inconclusive evidence without
-   giving a general software-test status report.
-5. **Version reviewed**: give the PR URL and the identifiers for the starting
-   and proposed versions. State that the proposed code was inspected but not run
-   locally.
+Add one short paragraph about how effects move through the simulation only when
+it is necessary to connect several reported areas. Do not include a separate
+general test summary.
+
+End with one **Version reviewed** line containing the PR URL and identifiers for
+the starting and proposed versions, followed by a note that the proposed code
+was inspected but not run locally.
 
 If no changed area merits scientific review, say so explicitly and briefly
-explain why the change appears science-neutral. Do not fill the report with
-general software-review observations.
+explain why the change appears science-neutral, then give the version reviewed.
+Do not fill the report with general software-review observations.

--- a/.agents/skills/tardis-pr-review/agents/openai.yaml
+++ b/.agents/skills/tardis-pr-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TARDIS Science Review Guide"
+  short_description: "Highlight science questions in TARDIS PRs"
+  default_prompt: "Use $tardis-pr-review to explain in plain language which scientific questions in TARDIS pull request #123 need close review."

--- a/.agents/skills/tardis-pr-review/agents/openai.yaml
+++ b/.agents/skills/tardis-pr-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TARDIS Science Review Guide"
-  short_description: "Highlight science questions in TARDIS PRs"
-  default_prompt: "Use $tardis-pr-review to explain in plain language which scientific questions in TARDIS pull request #123 need close review."
+  short_description: "Brief, code-driven science questions"
+  default_prompt: "Use $tardis-pr-review to briefly identify only the science questions directly raised by code changes in TARDIS pull request #123."


### PR DESCRIPTION
### :pencil: Description

**Type:**  :roller_coaster: `infrastructure`

This PR adds a skill that provides review support for TARDIS developers. It is intended to point them at relevant areas where scientific attention is most valuable. It is not likely to be fully comprehensive, and does not look closely at code style, bugs etc.

### :pushpin: Example review of #3365 

This brief highlights science questions for specialist review; it does not determine whether the proposed change is correct.

### What the change aims to do

[[PR #3365](https://github.com/tardis-sn/tardis/pull/3365)](https://github.com/tardis-sn/tardis/pull/3365) introduces one-dimensional homologous mesh objects and density solvers for uniform, power-law, exponential, and Branch85 W7 profiles. It assumes density is evaluated at shell-center velocity, \(r=vt\), and W7 follows

\[
\rho(v,t)=\rho_0\left(\frac{v}{v_0}\right)^{-7}\left(\frac{t_0}{t}\right)^3.
\]

The starting version already implements the \(v^{-7}\) profile followed by one \(t^{-3}\) scaling, so a reviewer should clarify what scientific error relative to that version the PR intends to correct.

### Areas needing scientific attention

#### 1. Homologous time dilution is applied twice — `close review`

**Where to look:** The [[W7 solver scales density to the explosion time](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/parse_density.py#L226-L250)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/parse_density.py#L226-L250), but the [[transition parser returns that result with the original reference time](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/parse_density_configuration.py#L60-L70)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/parse_density_configuration.py#L60-L70), after which [[model construction applies the same \(t^{-3}\) transformation again](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/parse_composition_configuration.py#L46-L54)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/parse_composition_configuration.py#L46-L54).

**Why it matters:** This code path directly produces an overall \(t^{-6}\), rather than \(t^{-3}\), dependence for configured W7 models. For the standard 13-day configuration with \(t_0=0.000231481\) day, the second scaling introduces an additional factor of \(5.65\times10^{-15}\). This would strongly suppress ejecta mass density, elemental and electron number densities, level populations, and optical depths.

**Questions to answer:**

- Should every solver return density at \(t_0\), leaving time evolution to model construction, or should it return density at \(t_\mathrm{explosion}\)? Only one layer should own the transformation.
- Does \(\rho(t_2)/\rho(t_1)=(t_1/t_2)^3\) and does \(\rho V\) remain constant for fixed velocity shells?
- Can the authors show a derivation or Branch85 reference establishing the intended formula? The schema calls it a “seventh-order polynomial fit,” while the implementation is a \(v^{-7}\) power law.

**What evidence exists:** The [[new isolated-solver test](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/tests/test_density_from_config.py#L17-L59)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/tests/test_density_from_config.py#L17-L59) contains useful first- and last-shell expected values, but bypasses the parser and therefore cannot detect the second scaling. The existing full-model test contains the same expected values, but did not run for this version.

#### 2. Shell-center velocities are reinterpreted as interfaces — `close review`

**Where to look:** Model construction first calculates shell centers, then the [[changed adapter prepends another zero and labels those centers as mesh interfaces](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/parse_density_configuration.py#L47-L62)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/parse_density_configuration.py#L47-L62). The [[solvers average adjacent values again](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/parse_density.py#L105-L124)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/parse_density.py#L105-L124).

**Why it matters:** This shifts the velocity at which every non-uniform analytic density is evaluated. In the paper configuration, the first retained shell changes from 11,225 to 8,362.5 km s\(^{-1}\). For a \(v^{-7}\) profile, that alone raises its density by a factor of about 7.85 before the time-scaling effect is included. Power-law and exponential configurations, including configured CSVY models, follow the same adapter.

The new mesh description also calls cell zero a central volume, although the new configuration parser begins at the positive configured inner velocity. That convention needs resolution before any later calculation masks or specially treats cell zero.

**Questions to answer:**

- Should the adapter receive the original \(N+1\) interfaces, or should solvers accept the already-computed \(N\) centers?
- Does each retained shell use exactly \((v_\mathrm{inner}+v_\mathrm{outer})/2\), including nonuniform grids and configured inner/outer boundaries?
- Are shell indexing and the synthetic central point identical between classic configuration, CSVY, and file-based models?

**What evidence exists:** Solver tests confirm midpoint evaluation when supplied genuine interfaces. The configuration tests construct genuine interfaces directly and therefore bypass the problematic center-to-interface conversion. There is no test of the complete adapter path on an irregular grid or with boundary cuts.

#### 3. Scientific validation did not execute — `check carefully`

**Where to look:** The [[W7 unit tests omit the now-required reference velocity](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/tests/test_density_solvers.py#L175-L214)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/tests/test_density_solvers.py#L175-L214), while the [[parser test expects the obsolete solver type](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/tests/test_density_parser.py#L60-L75)](https://github.com/tardis-sn/tardis/blob/5a420c540f44bed66c98d3561258b298a47228a7/tardis/io/model/classic/tests/test_density_parser.py#L60-L75).

**Why it matters:** These inconsistencies obstruct the evidence intended to validate the W7 formulation, even before the scientific assertions are reached.

**Questions to answer:**

- After repairing the tests, does the full configuration-to-composition path reproduce the existing W7 expected densities?
- Is there a two-epoch \(t^{-3}\) test, a shell-mass conservation test, and a comparison of resulting number densities or optical depths?
- Should stored reference spectra be compared after the density path is corrected?

**What evidence exists:** The exact-version [[unit-test run](https://github.com/tardis-sn/tardis/actions/runs/20195212322)](https://github.com/tardis-sn/tardis/actions/runs/20195212322) never started its tests because the data-cache prerequisite failed. [[Full tests](https://github.com/tardis-sn/tardis/actions/runs/20435912673)](https://github.com/tardis-sn/tardis/actions/runs/20435912673) and [[stored-reference comparisons](https://github.com/tardis-sn/tardis/actions/runs/29265627863)](https://github.com/tardis-sn/tardis/actions/runs/29265627863) were skipped. [[Benchmarks succeeded](https://github.com/tardis-sn/tardis/actions/runs/29265627885)](https://github.com/tardis-sn/tardis/actions/runs/29265627885), but measured execution time rather than densities, conservation, or spectra.

### How the effects move through the simulation

The two demonstrated transformations multiply together in the initial density field. Density is combined with mass fractions to form elemental and isotopic number densities; these set ion, electron, and level populations. Those populations determine electron-scattering and Sobolev optical depths, interaction probabilities, and ultimately plasma convergence and the emergent spectrum. No output-level comparison currently constrains these consequences.

### What has been checked

The complete three-dot change set, configuration defaults, density equations, mesh conventions, model-construction path, relevant tests, discussion, and exact-version automated records were inspected. No proposed code, tests, notebooks, or benchmarks were run locally.

### Version reviewed

- PR: [[#3365 — Fixes W7 density solver implementation and reorganizes tests](https://github.com/tardis-sn/tardis/pull/3365)](https://github.com/tardis-sn/tardis/pull/3365)
- Starting identifier reported by GitHub: `a1a284343ed3cba7acf5cd6606c0ec0e166b8e0c`
- Proposed identifier: `5a420c540f44bed66c98d3561258b298a47228a7`

The proposed identifier remained unchanged at final recheck. The starting snapshot is formally inconsistent: a fresh fetch of `master` produced `3caeb850d4421605c263e1de29aae392aca09fc3`, while GitHub continued to report `a1a2843…` after the required re-query. Both have the same common ancestor with the proposed version, so the complete PR-owned change set reviewed is unchanged.
