### PR TITLE
fix naming collision rate name inversion

### DIFF
--- a/tardis/plasma/equilibrium/rates/collisional_rates.py
+++ b/tardis/plasma/equilibrium/rates/collisional_rates.py
@@ -3,12 +3,12 @@ import pandas as pd
 from astropy import units as u
 
 from tardis import constants as const
+from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 from tardis.plasma.equilibrium.rates.collision_strengths import (
     UpsilonChiantiSolver,
     UpsilonCMFGENSolver,
     UpsilonRegemorterSolver,
 )
-from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 
 BETA_COLL = (
     (const.h**4 / (8 * const.k_B * const.m_e**3 * np.pi**3)) ** 0.5
@@ -65,11 +65,11 @@ class ThermalCollisionalRateSolver:
             ].energy.values
         ) * u.erg
 
-        self.g_l = self.levels.loc[
+        self.g_upper = self.levels.loc[
             self.all_collisional_strengths_index.droplevel("level_number_lower")
         ].g.values
 
-        self.g_u = self.levels.loc[
+        self.g_lower = self.levels.loc[
             self.all_collisional_strengths_index.droplevel("level_number_upper")
         ].g.values
 
@@ -101,7 +101,7 @@ class ThermalCollisionalRateSolver:
         )  # see formula A2 in Przybilla, Butler 2004 - Apj 609, 1181
 
         collision_rates_coeff_ul = (
-            (self.g_u / self.g_l)[np.newaxis].T
+            (self.g_lower / self.g_upper)[np.newaxis].T
             / boltzmann_factor
             * collision_rates_coeff_lu
         )


### PR DESCRIPTION
The equation in the rate solver seems correct, but the names are inverted because the class defined degeneracies are dropping the wrong ones. This small patch is just a rename. 