### PR TITLE
Fix shell velocities used for CSVY header density profiles

### DIFF
--- a/tardis/io/model/parse_density_configuration.py
+++ b/tardis/io/model/parse_density_configuration.py
@@ -103,9 +103,7 @@ def parse_density_section_csvy(
         )
         velocity = csvy_model_config.velocity.values * velocity_unit
 
-    adjusted_velocity = velocity.insert(0, 0)
-    v_middle = adjusted_velocity[1:] * 0.5 + adjusted_velocity[:-1] * 0.5
-    no_of_shells = len(adjusted_velocity) - 1
+    v_middle = velocity[1:] * 0.5 + velocity[:-1] * 0.5
 
     if hasattr(csvy_model_config, "density"):
         density_0, time_0 = parse_density_section_config(

--- a/tardis/model/tests/test_csvy_model.py
+++ b/tardis/model/tests/test_csvy_model.py
@@ -83,6 +83,48 @@ def test_compare_models(model_config_fnames, atomic_dataset):
     )
 
 
+@pytest.mark.parametrize(
+    ("csvy_model_name", "density_profile"),
+    [
+        ("powerlaw", lambda velocity_ratio: velocity_ratio**-2),
+        ("exponential", lambda velocity_ratio: np.exp(-velocity_ratio)),
+    ],
+)
+def test_density_profile_from_csvy_header(
+    csvy_model_name, density_profile, example_csvy_file_dir
+):
+    """A density profile declared in the CSVY header has to be evaluated at
+    the middle of every shell and has to produce one density per shell.
+
+    Both models declare rho_0 = 1e-9 g/cm^3 and v_0 = 10000 km/s and no
+    time_0, so the densities are analytic and are not scaled in time.
+    """
+    csvy_config_file = example_csvy_file_dir / f"{csvy_model_name}_csvy.yml"
+    csvy_simulation_state = SimulationState.from_csvy(
+        Configuration.from_yaml(csvy_config_file)
+    )
+
+    velocity = csvy_simulation_state.velocity
+    v_middle = 0.5 * (velocity[:-1] + velocity[1:])
+    velocity_ratio = (v_middle / (10000 * u.km / u.s)).to(
+        u.dimensionless_unscaled
+    )
+    expected_density = (
+        1e-9 * u.g / u.cm**3 * density_profile(velocity_ratio.value)
+    )
+
+    assert (
+        len(csvy_simulation_state.composition.density)
+        == csvy_simulation_state.no_of_shells
+    )
+    npt.assert_allclose(
+        csvy_simulation_state.density.cgs.value,
+        expected_density.cgs.value,
+        rtol=1e-12,
+        atol=0,
+    )
+
+
 def test_dimensionality_after_update_v_inner_boundary(
     example_csvy_file_dir, atomic_dataset
 ):


### PR DESCRIPTION
`parse_density_section_csvy` inserted a fake zero velocity in front of the shell interfaces before working out the shell mid velocities. A density profile declared in the CSVY header was therefore evaluated at half the inner velocity for the first shell, and the function returned one density more than there are shells. `SimulationState` slices that array down to the active shells, so every density came out shifted by one. For `powerlaw_csvy.csvy` the first shell is 4.3 times too dense and the rest are off by about 11 percent.

The fix takes the mid velocities straight from the interfaces, matching what the config path produces after `parse_density_from_config` drops its leading value. `test_compare_models` missed this because `assert_array_almost_equal` on densities near 1e-9 has an absolute tolerance that hides it. The new test checks the power law and exponential models against analytic values with a relative tolerance, and needs no atom data or regression data.

The else branch of the same function also looks broken (`field.name`, `csvy_model_config.velocity.values`), but I left it alone to keep this small.

Fixes #3621.

I used an AI assistant on this change. I have gone through it myself and can explain it.