### PR TITLE
New Plasma Module Documentation 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -54,6 +54,9 @@ Atul Kumar <kr.atul.atk@gmail.com>
 Anirban Dutta <anirbaniamdutta@gmail.com>
 Anirban Dutta <duttaan2@msu.edu>
 
+Angel Gupta <anglegupta037@gmail.com> Angel-Gupta037 <anglegupta037@gmail.com>
+Angel-Gupta037 <anglegupta037@gmail.com>
+
 Barnabás Barna <bbarna@titan.physx.u-szeged.hu>
 
 Caroline Sofiatti <c.sofiatti@gmail.com>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -34,3 +34,4 @@ araut7798@gmail.com ,0009-0009-4508-2218
 rishmita.rao12@gmail.com,0009-0003-3964-2107
 nagadevikona20@gmail.com,0009-0005-2784-6895
 abhayraj916146@gmail.com,0009-0003-8477-2963
+anglegupta037@gmail.com,0009-0007-6690-938X

--- a/docs/how_to/output/how_to_plasma_graph.ipynb
+++ b/docs/how_to/output/how_to_plasma_graph.ipynb
@@ -13,7 +13,7 @@
    "id": "0329e9f4",
    "metadata": {},
    "source": [
-    "After running a simulation, TARDIS has the ability to create a [graph](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)) showcasing how each variable used to compute the plasma state is connected and calculated (see the [Plasma Documentation](../../physics/setup/plasma/index.rst) for more information). To do so, one needs to utilize the `write_to_tex` command to generate a .tex file that displays the graph. This how-to aims to showcase how the .tex file can be generated and what options can be inputted to display the graph in a preferred method. To start, TARDIS needs to perform a simulation. Here the `tardis_example.yml` configuration file is used as in the [quickstart guide](../../quickstart.ipynb)."
+    "After running a simulation, TARDIS has the ability to create a [graph](https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)) showcasing how each variable used to compute the plasma state is connected and calculated (see the [Plasma Documentation](../../physics_walkthrough/setup/plasma/plasma_module) for more information). To do so, one needs to utilize the `write_to_tex` command to generate a .tex file that displays the graph. This how-to aims to showcase how the .tex file can be generated and what options can be inputted to display the graph in a preferred method. To start, TARDIS needs to perform a simulation. Here the `tardis_example.yml` configuration file is used as in the [quickstart guide](../../quickstart.ipynb)."
    ]
   },
   {

--- a/docs/io/configuration/components/atomic/current_public_table.rst
+++ b/docs/io/configuration/components/atomic/current_public_table.rst
@@ -12,7 +12,7 @@ Current Public Atomic Data Table
       - zeta
       - synpp references
       - database version
-    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
+    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
       - 6f7b09e887a311e7a06b246e96350010
       - | **kurucz:**
         | Li I-II, Be I-IV, C I-IV, N I-VI

--- a/docs/io/configuration/components/atomic/current_public_table.rst
+++ b/docs/io/configuration/components/atomic/current_public_table.rst
@@ -12,7 +12,7 @@ Current Public Atomic Data Table
       - zeta
       - synpp references
       - database version
-    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
+    * - `kurucz_cd23_chianti_H_He_latest.h5 <https://github.com/tardis-sn/tardis-regression-data/raw/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5>`_
       - 6f7b09e887a311e7a06b246e96350010
       - | **kurucz:**
         | Li I-II, Be I-IV, C I-IV, N I-VI

--- a/docs/io/configuration/components/models/example_data.inc
+++ b/docs/io/configuration/components/models/example_data.inc
@@ -1,2 +1,2 @@
 .. _example_yml: https://github.com/tardis-sn/tardis-setups/blob/master/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
-.. _example_atomic_database: https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5
+.. _example_atomic_database: https://github.com/tardis-sn/tardis-regression-data/raw/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5

--- a/docs/io/configuration/components/models/example_data.inc
+++ b/docs/io/configuration/components/models/example_data.inc
@@ -1,2 +1,2 @@
 .. _example_yml: https://github.com/tardis-sn/tardis-setups/blob/master/2014/2014_kerzendorf_sim/appendix_A1/tardis_example.yml
-.. _example_atomic_database: https://github.com/tardis-sn/tardis-refdata/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5
+.. _example_atomic_database: https://github.com/tardis-sn/tardis-regression-data/raw/master/atom_data/kurucz_cd23_chianti_H_He_latest.h5

--- a/docs/physics_walkthrough/setup/plasma/index.rst
+++ b/docs/physics_walkthrough/setup/plasma/index.rst
@@ -67,7 +67,8 @@ The next more complex class is `LTEPlasma` which will calculate the ionization b
 
 .. toctree::
     :maxdepth: 2
-
+    
+    plasma_module
     lte_plasma
     nebular_plasma
 

--- a/docs/physics_walkthrough/setup/plasma/plasma_module.rst
+++ b/docs/physics_walkthrough/setup/plasma/plasma_module.rst
@@ -93,18 +93,8 @@ Property Categories
 ~~~~~~~~~~~~~~~~~~~
 
 The following describes the property categories defined in
-``legacy_property_collections.py`` and the integration test coverage
-status of each class:
-
-.. note::
-
-   * **Green** — Covered in integration tests, with unit tests written
-     where deemed useful.
-   * **Yellow** — Referenced in the TARDIS codebase but not exercised
-     by integration tests. These classes are not built during standard
-     TARDIS runs.
-   * **Red** — Not referenced outside their class definition.
-   * **Unhighlighted** — See inline notes for explanation.
+``legacy_property_collections.py``. Properties that are inactive,
+uncovered, or not exercised by integration tests are noted inline.
 
 Adiabatic Cooling Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -113,13 +103,6 @@ Adiabatic Cooling Properties
 
 Basic Inputs
 ^^^^^^^^^^^^
-
-.. note::
-
-   For Basic Inputs, green indicates the input is used by plasma
-   configurations that are active in standard TARDIS runs. Red indicates
-   the input is not activated by any current simulation configuration.
-   Input classes do not require unit tests.
 
 * ``DilutePlanckianRadField``
 * ``NumberDensity``

--- a/docs/physics_walkthrough/setup/plasma/plasma_module.rst
+++ b/docs/physics_walkthrough/setup/plasma/plasma_module.rst
@@ -1,0 +1,396 @@
+.. _plasma_module:
+
+*********************
+TARDIS Plasma Module
+*********************
+
+Plasma Structure
+================
+
+NetworkX - Plasma Graphs
+-------------------------
+
+The plasma is structured as a network of calculations. Each quantity
+(temperature, ionization, optical depth, etc.) is a "property." Properties
+depend on one another, and TARDIS connects them into a graph so that when
+one value changes, only the downstream values get recalculated in the
+correct order.
+
+The plasma lives in the class ``BasePlasma``, defined in ``plasma/base.py``.
+
+There are two types of properties:
+
+* **Input properties** — values fed in from the model or config. They have
+  outputs but no inputs, so they are the starting points of the graph.
+
+* **Processing properties** — values that get calculated. TARDIS reads the
+  argument names of their ``calculate`` function to learn what inputs
+  they need.
+
+For example, ``PhiSahaLTE`` (defined in
+``plasma/properties/ion_population.py``) has the function::
+
+   calculate(g_electron, beta_rad, partition_function, ionization_data)
+
+Its inputs are those four names and its output is ``phi``. Connections are
+made by matching names — an output called ``phi`` automatically links to
+any calculation that has an argument called ``phi``.
+
+Building the Graph
+~~~~~~~~~~~~~~~~~~
+
+TARDIS builds the graph inside ``_build_graph`` in three steps:
+
+1. Add one node for every property.
+2. Mark the input properties as starting points (they have no inputs).
+3. For each calculated property, find what it needs, locate the property
+   that produces each name, and draw an arrow from producer to consumer.
+   If a property needs something that nothing produces, TARDIS raises an
+   error immediately, catching broken or incomplete setups.
+
+When an input changes (for example, the temperature), TARDIS finds
+everything downstream of that change and recalculates in topological
+order, so each property is updated only after the values it depends
+on are fresh.
+
+For a guide on how to display a plasma graph, see
+:doc:`../../../how_to/output/how_to_plasma_graph`.
+
+Plasma Solver Factory
+---------------------
+
+The ``PlasmaSolverFactory`` class, defined in ``plasma/assembly/base.py``,
+initializes, configures, and assembles the plasma used in TARDIS runs. It
+has two key methods:
+
+* ``prepare_factory`` — accepts specific property collections, which are
+  collections of classes that define plasma properties.
+* ``assemble`` — returns an instance of the ``BasePlasma`` class.
+
+There is also an ``assemble_plasma`` function defined in two locations:
+
+* ``plasma/assembly/legacy_assembly.py``
+* ``plasma/standard_plasmas.py``
+
+The ``assemble_plasma`` function used by the simulation class is the one
+defined in ``plasma/assembly``. It returns an assembled plasma by:
+
+1. Defining a ``PlasmaSolverFactory`` instance.
+2. Calling the ``prepare_factory`` method.
+3. Calling the ``assemble`` method.
+
+Plasma Properties
+-----------------
+
+The plasma properties used throughout the plasma module are defined in
+``legacy_property_collections.py``. There is also a
+``property_collections.py`` file which contains fewer classes. The plasma
+built throughout the TARDIS codebase imports from
+``legacy_property_collections.py``. The ``property_collections.py`` file
+is not referenced elsewhere in the TARDIS codebase for plasma that gets
+built during actual runs.
+
+Property Categories
+~~~~~~~~~~~~~~~~~~~
+
+The following describes the property categories defined in
+``legacy_property_collections.py`` and whether each class is built or
+referenced outside its definition:
+
+.. note::
+
+   * **Green** — Covered in integration tests, with unit tests written
+     where deemed useful.
+   * **Yellow** — Referenced in the TARDIS codebase but never run in
+     integration tests. These classes are not usually built during
+     real TARDIS runs.
+   * **Red** — Never referenced outside their class definition.
+   * **Unhighlighted** — See inline notes for explanation.
+
+Adiabatic Cooling Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``AdiabaticCoolingRate``
+
+Basic Inputs
+^^^^^^^^^^^^
+
+.. note::
+
+   For Basic Inputs, green indicates the input is used for classes built
+   by plasma that TARDIS users actually use. Red indicates the input is
+   usually never used. No unit tests are needed for Inputs.
+
+* ``DilutePlanckianRadField``
+* ``NumberDensity``
+* ``TimeExplosion``
+* ``AtomicData``
+* ``JBlues``
+* ``LinkTRadTElectron``
+* ``HeliumTreatment``
+* ``ContinuumInteractionSpecies`` — Never used as an input in any
+  integration test. Many associated properties seem to be part of an
+  unfinished refactor attempt.
+* ``NLTEIonizationSpecies``
+* ``NLTEExcitationSpecies``
+
+Basic Properties
+^^^^^^^^^^^^^^^^
+
+* ``BetaRadiation``
+* ``DilutionFactor``
+* ``ElectronTemperature``
+* ``GElectron``
+* ``IonizationData``
+* ``Levels``
+* ``Lines``
+* ``LinesLowerLevelIndex``
+* ``LinesUpperLevelIndex``
+* ``PartitionFunction``
+* ``SelectedAtoms``
+* ``StimulatedEmission``
+* ``TRadiative``
+* ``TauSobolev``
+
+Continuum Interaction Inputs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PhotoIonRateCoeff``
+* ``StimRecombRateFactor``
+* ``BfHeatingRateCoeffEstimator``
+* ``StimRecombCoolingRateCoeffEstimator``
+* ``YgData`` — Referenced in
+  ``plasma/equilibrium/tests/test_collisional_transitions.py`` and
+  ``plasma/tests/test_plasma_continuum.py`` but not referenced in the
+  plasma solver factory.
+
+Continuum Interaction Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``BoundFreeOpacity``
+* ``CollDeexcRateCoeff`` — Imported into ``collision_strengths.py``.
+  Defined in two files: ``plasma/equilibrium/rates/collision_strengths.py``
+  and ``plasma/properties/continuum_processes/rates.py``. The class
+  defined in ``collision_strengths.py`` is fully uncovered.
+* ``CollExcRateCoeff`` — Same as above.
+* ``CollIonRateCoeffSeaton``
+* ``CollRecombRateCoeff``
+* ``ContinuumInteractionHandler``
+* ``CorrPhotoIonRateCoeff``
+* ``FreeBoundCoolingRate``
+* ``FreeBoundEmissionCDF``
+* ``FreeFreeCoolingRate``
+* ``LevelIdxs2LineIdx``
+* ``LevelIdxs2TransitionIdx``
+* ``LevelNumberDensityLTE``
+* ``MarkovChainIndex``
+* ``MarkovChainTransProbs``
+* ``MarkovChainTransProbsCollector``
+* ``MonteCarloTransProbs``
+* ``NonContinuumTransProbsMask``
+* ``NonMarkovChainTransitionProbabilities``
+* ``PhotoIonBoltzmannFactor``
+* ``PhotoIonizationData`` — Referenced in the main plasma solver factory
+  but never run.
+* ``RawCollIonTransProbs``
+* ``RawCollisionTransProbs``
+* ``RawPhotoIonTransProbs``
+* ``RawRadBoundBoundTransProbs``
+* ``RawRecombTransProbs``
+* ``SahaFactor``
+* ``SpontRecombCoolingRateCoeff``
+* ``SpontRecombRateCoeff`` — Only defined in the class and put into
+  property collections but never referenced in the main plasma solver
+  factory.
+* ``StimRecombRateCoeff``
+* ``ThermalGElectron``
+* ``ThermalLTEPartitionFunction``
+* ``ThermalLevelBoltzmannFactorLTE``
+* ``ThermalPhiSahaLTE``
+* ``YgInterpolator``
+
+Dilute LTE Excitation Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``LevelBoltzmannFactorDiluteLTE``
+
+Helium LTE Properties
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``LevelNumberDensity``
+* ``IonNumberDensity``
+
+Helium NLTE Properties
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``HeliumNLTE``
+* ``RadiationFieldCorrection``
+* ``ZetaData``
+* ``BetaElectron``
+* ``LevelNumberDensityHeNLTE``
+* ``IonNumberDensityHeNLTE``
+
+Helium Numerical NLTE Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``HeliumNumericalNLTE`` — Requires a specific numerical NLTE solver and
+  a specific atomic dataset, neither of which are distributed with TARDIS.
+
+LTE Excitation Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``LevelBoltzmannFactorLTE``
+
+LTE Ionization Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PhiSahaLTE``
+
+Nebular Ionization Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``PhiSahaNebular``
+* ``ZetaData``
+* ``BetaElectron``
+* ``RadiationFieldCorrection``
+
+NLTE LU Solver Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``NLTEIndexHelper``
+* ``NLTEPopulationSolverLU`` — Referenced in ``test_nlte_solver`` but
+  never run in a full integration test.
+
+NLTE Properties
+^^^^^^^^^^^^^^^^
+
+* ``LevelBoltzmannFactorNLTE``
+* ``NLTEData``
+* ``PreviousElectronDensities``
+* ``PreviousBetaSobolev``
+* ``BetaSobolev``
+
+NLTE Root Solver Properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``NLTEIndexHelper``
+* ``NLTEPopulationSolverRoot`` — Referenced in ``test_nlte_solver`` but
+  never run in a full integration test.
+
+Non NLTE Properties
+^^^^^^^^^^^^^^^^^^^^
+
+* ``LevelBoltzmannFactorNoNLTE``
+
+Two Photon Properties
+^^^^^^^^^^^^^^^^^^^^^^
+
+* ``RawTwoPhotonTransProbs``
+* ``TwoPhotonData``
+* ``TwoPhotonEmissionCDF``
+* ``TwoPhotonFrequencySampler``
+
+Equilibrium
+-----------
+
+In ``tardis/plasma/equilibrium`` there are files under a ``rates/`` folder
+that represent another attempt at a plasma module refactor using
+``RateSolver`` classes. These are not used in the actual implemented plasma
+module but do have direct tests.
+
+Uncovered Plasma Module Files
+==============================
+
+The following files in the plasma module are either fully uncovered or have
+very little coverage, beyond what was already noted in the property
+sections above.
+
+``tardis/plasma/standard_plasmas.py``
+   Zero percent coverage. Appears to be an attempt at refactoring how
+   ``assemble_plasma`` is used by ``PlasmaSolverFactory``. Referenced
+   only in ``grotarian_mockup.ipynb``.
+
+``tardis/plasma/properties/property_collections.py``
+   Property collection for a plasma module refactor that was never
+   completed. Appears to be imported into
+   ``tardis/plasma/standard_plasmas.py``.
+
+``tardis/plasma/properties/nlte_excitation_data.py``
+   Defines ``NLTEExcitationData``, which is not used anywhere else in
+   the codebase.
+
+``tardis/plasma/properties/hydrogen_continuum.py``
+   Zero percent coverage by plasma tests.
+
+``tardis/plasma/properties/continuum_processes/fast_array_util.py``
+   Defines two numba functions:
+
+   * ``numba_cumulative_trapezoid`` — Used in the uncovered class
+     ``TwoPhotonEmissionCDF`` in
+     ``tardis/plasma/properties/continuum_processes/rates.py``.
+   * ``cumulative_integrate_array_by_blocks`` — Same as above.
+
+Tools to Understand the Plasma Module
+======================================
+
+Test Coverage Reports
+---------------------
+
+Generating coverage reports of the plasma module test cases is a useful
+way to understand what parts of the plasma module are actually used by
+researchers running TARDIS. Running exclusively the tests in the plasma
+module and examining coverage results can reveal, for example:
+
+* ``plasma/standard_plasmas.py`` is fully uncovered. The
+  ``assemble_plasma`` function defined there is never used in the actual
+  TARDIS simulation. The ``assemble_plasma`` that TARDIS actually uses is
+  in ``plasma/assembly/legacy_assembly.py``.
+* The continuum interactions setup in ``PlasmaSolverFactory``
+  (``plasma/assembly/base.py``) is never triggered because none of the
+  tested plasma configs set up continuum interactions.
+
+.. TODO: Add screenshot of PlasmaSolverFactory continuum interactions code here
+
+* ``hydrogen_continuum.py`` is not used anywhere and has zero percent
+  coverage.
+
+The best way to find which classes are actually being called is to go
+through ``legacy_property_collections.py``, click on each class, and
+check whether the code inside the ``calculate`` function is covered.
+
+For example, ``LinesLowerLevelIndex`` is in legacy properties and has
+full coverage, meaning it is actually being calculated when
+``test_full_plasmas`` builds its plasma configurations.
+
+.. TODO: Add screenshot of LinesLowerLevelIndex coverage here
+
+On the other hand, ``SpontRecombRateCoeff`` is in
+``continuum_interactions_properties`` and its ``calculate`` method is
+never run by any config in ``test_complete_plasmas``.
+
+.. TODO: Add screenshot of SpontRecombRateCoeff coverage here
+
+Going through coverage results for ``test_complete_plasma`` is a good
+way to:
+
+* Guide what is worth writing unit tests for.
+* Identify features unused by the plasma module that should be migrated
+  to Type II plasma exclusively.
+* Find features that should be removed completely.
+* Find features that need to be fleshed out further.
+
+Plasma Graph Generation
+-----------------------
+
+As described in the :ref:`NetworkX - Plasma Graphs <plasma_module>`
+section above, TARDIS can generate diagrams showing how plasma graph
+properties connect to one another. Generating diagrams across multiple
+configs is a good way to understand which plasma properties are relevant
+to general TARDIS users.
+
+Useful resources:
+
+* TARDIS configs repository:
+  `tardis-sn/tardis-configs <https://github.com/tardis-sn/tardis-configs>`_
+* How to draw plasma graphs:
+  :doc:`../../../how_to/output/how_to_plasma_graph`

--- a/docs/physics_walkthrough/setup/plasma/plasma_module.rst
+++ b/docs/physics_walkthrough/setup/plasma/plasma_module.rst
@@ -72,8 +72,9 @@ There is also an ``assemble_plasma`` function defined in two locations:
 * ``plasma/assembly/legacy_assembly.py``
 * ``plasma/standard_plasmas.py``
 
-The ``assemble_plasma`` function used by the simulation class is the one
-defined in ``plasma/assembly``. It returns an assembled plasma by:
+The active ``assemble_plasma`` function used by the TARDIS simulation
+class is the one defined in ``plasma/assembly/legacy_assembly.py``. It
+returns an assembled plasma by:
 
 1. Defining a ``PlasmaSolverFactory`` instance.
 2. Calling the ``prepare_factory`` method.
@@ -83,28 +84,26 @@ Plasma Properties
 -----------------
 
 The plasma properties used throughout the plasma module are defined in
-``legacy_property_collections.py``. There is also a
-``property_collections.py`` file which contains fewer classes. The plasma
-built throughout the TARDIS codebase imports from
-``legacy_property_collections.py``. The ``property_collections.py`` file
-is not referenced elsewhere in the TARDIS codebase for plasma that gets
-built during actual runs.
+``legacy_property_collections.py``. A separate ``property_collections.py``
+file exists but is not imported by the main plasma solver factory and is
+therefore not active during standard TARDIS runs. The standard plasma solver
+imports its property collections from ``legacy_property_collections.py``. 
 
 Property Categories
 ~~~~~~~~~~~~~~~~~~~
 
 The following describes the property categories defined in
-``legacy_property_collections.py`` and whether each class is built or
-referenced outside its definition:
+``legacy_property_collections.py`` and the integration test coverage
+status of each class:
 
 .. note::
 
    * **Green** — Covered in integration tests, with unit tests written
      where deemed useful.
-   * **Yellow** — Referenced in the TARDIS codebase but never run in
-     integration tests. These classes are not usually built during
-     real TARDIS runs.
-   * **Red** — Never referenced outside their class definition.
+   * **Yellow** — Referenced in the TARDIS codebase but not exercised
+     by integration tests. These classes are not built during standard
+     TARDIS runs.
+   * **Red** — Not referenced outside their class definition.
    * **Unhighlighted** — See inline notes for explanation.
 
 Adiabatic Cooling Properties
@@ -117,9 +116,10 @@ Basic Inputs
 
 .. note::
 
-   For Basic Inputs, green indicates the input is used for classes built
-   by plasma that TARDIS users actually use. Red indicates the input is
-   usually never used. No unit tests are needed for Inputs.
+   For Basic Inputs, green indicates the input is used by plasma
+   configurations that are active in standard TARDIS runs. Red indicates
+   the input is not activated by any current simulation configuration.
+   Input classes do not require unit tests.
 
 * ``DilutePlanckianRadField``
 * ``NumberDensity``
@@ -128,9 +128,10 @@ Basic Inputs
 * ``JBlues``
 * ``LinkTRadTElectron``
 * ``HeliumTreatment``
-* ``ContinuumInteractionSpecies`` — Never used as an input in any
-  integration test. Many associated properties seem to be part of an
-  unfinished refactor attempt.
+* ``ContinuumInteractionSpecies`` — Not exercised by any current
+  integration test. The associated continuum interaction properties
+  are scoped to Type II supernova plasmas and are not activated in
+  standard Type Ia simulation configs.
 * ``NLTEIonizationSpecies``
 * ``NLTEExcitationSpecies``
 
@@ -159,19 +160,22 @@ Continuum Interaction Inputs
 * ``StimRecombRateFactor``
 * ``BfHeatingRateCoeffEstimator``
 * ``StimRecombCoolingRateCoeffEstimator``
-* ``YgData`` — Referenced in
+* ``YgData`` — Tested directly in
   ``plasma/equilibrium/tests/test_collisional_transitions.py`` and
-  ``plasma/tests/test_plasma_continuum.py`` but not referenced in the
-  plasma solver factory.
+  ``plasma/tests/test_plasma_continuum.py``, but not wired into the
+  main plasma solver factory and therefore not built during standard
+  TARDIS runs.
 
 Continuum Interaction Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``BoundFreeOpacity``
-* ``CollDeexcRateCoeff`` — Imported into ``collision_strengths.py``.
-  Defined in two files: ``plasma/equilibrium/rates/collision_strengths.py``
-  and ``plasma/properties/continuum_processes/rates.py``. The class
-  defined in ``collision_strengths.py`` is fully uncovered.
+* ``CollDeexcRateCoeff`` — Defined in two files:
+  ``plasma/equilibrium/rates/collision_strengths.py`` and
+  ``plasma/properties/continuum_processes/rates.py``. The active class
+  is the one imported into the property collection from ``rates.py``.
+  The class in ``collision_strengths.py`` is not covered by the test
+  suite.
 * ``CollExcRateCoeff`` — Same as above.
 * ``CollIonRateCoeffSeaton``
 * ``CollRecombRateCoeff``
@@ -190,8 +194,8 @@ Continuum Interaction Properties
 * ``NonContinuumTransProbsMask``
 * ``NonMarkovChainTransitionProbabilities``
 * ``PhotoIonBoltzmannFactor``
-* ``PhotoIonizationData`` — Referenced in the main plasma solver factory
-  but never run.
+* ``PhotoIonizationData`` — Registered in the plasma solver factory
+  but not exercised by any current integration test configuration.
 * ``RawCollIonTransProbs``
 * ``RawCollisionTransProbs``
 * ``RawPhotoIonTransProbs``
@@ -199,9 +203,10 @@ Continuum Interaction Properties
 * ``RawRecombTransProbs``
 * ``SahaFactor``
 * ``SpontRecombCoolingRateCoeff``
-* ``SpontRecombRateCoeff`` — Only defined in the class and put into
-  property collections but never referenced in the main plasma solver
-  factory.
+* ``SpontRecombRateCoeff`` — Defined in the property collection but
+  not referenced by the main plasma solver factory. Developers
+  extending continuum interaction support should note this class
+  requires explicit wiring to become active.
 * ``StimRecombRateCoeff``
 * ``ThermalGElectron``
 * ``ThermalLTEPartitionFunction``
@@ -233,8 +238,9 @@ Helium NLTE Properties
 Helium Numerical NLTE Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``HeliumNumericalNLTE`` — Requires a specific numerical NLTE solver and
-  a specific atomic dataset, neither of which are distributed with TARDIS.
+* ``HeliumNumericalNLTE`` — Requires a specific numerical NLTE solver
+  and a specific atomic dataset. Neither are distributed with TARDIS.
+  This class is not activated in standard simulation runs.
 
 LTE Excitation Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -258,8 +264,9 @@ NLTE LU Solver Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``NLTEIndexHelper``
-* ``NLTEPopulationSolverLU`` — Referenced in ``test_nlte_solver`` but
-  never run in a full integration test.
+* ``NLTEPopulationSolverLU`` — Tested in ``test_nlte_solver`` but not
+  exercised in full integration tests. This solver is not activated
+  in standard simulation configurations.
 
 NLTE Properties
 ^^^^^^^^^^^^^^^^
@@ -274,8 +281,9 @@ NLTE Root Solver Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``NLTEIndexHelper``
-* ``NLTEPopulationSolverRoot`` — Referenced in ``test_nlte_solver`` but
-  never run in a full integration test.
+* ``NLTEPopulationSolverRoot`` — Tested in ``test_nlte_solver`` but
+  not exercised in full integration tests. This solver is not activated
+  in standard simulation configurations.
 
 Non NLTE Properties
 ^^^^^^^^^^^^^^^^^^^^
@@ -293,100 +301,111 @@ Two Photon Properties
 Equilibrium
 -----------
 
-In ``tardis/plasma/equilibrium`` there are files under a ``rates/`` folder
-that represent another attempt at a plasma module refactor using
-``RateSolver`` classes. These are not used in the actual implemented plasma
-module but do have direct tests.
+The ``tardis/plasma/equilibrium/rates/`` folder contains an alternative
+plasma implementation based on ``RateSolver`` classes. This implementation
+is independent of the NetworkX-based plasma module used in standard TARDIS
+simulations and is not invoked during normal runs. The rate solver classes
+have dedicated unit tests and are retained for future development.
 
-Uncovered Plasma Module Files
-==============================
+Developer Notes: Inactive and Partially Covered Modules
+========================================================
 
-The following files in the plasma module are either fully uncovered or have
-very little coverage, beyond what was already noted in the property
-sections above.
+The following plasma module files are not invoked during standard TARDIS
+simulation runs. Developers modifying the plasma module should be aware
+of their status.
 
 ``tardis/plasma/standard_plasmas.py``
-   Zero percent coverage. Appears to be an attempt at refactoring how
-   ``assemble_plasma`` is used by ``PlasmaSolverFactory``. Referenced
-   only in ``grotarian_mockup.ipynb``.
+   Not covered by the plasma test suite and not called during standard
+   TARDIS runs. This module is used exclusively by
+   ``grotrian_mockup.ipynb``. The active plasma assembly entry point
+   is ``assemble_plasma`` in ``plasma/assembly/legacy_assembly.py``.
 
 ``tardis/plasma/properties/property_collections.py``
-   Property collection for a plasma module refactor that was never
-   completed. Appears to be imported into
-   ``tardis/plasma/standard_plasmas.py``.
+   An alternative property collection used by ``standard_plasmas.py``.
+   Not imported by the main plasma solver factory and therefore inactive
+   during normal simulation runs. Developers should use
+   ``legacy_property_collections.py`` as the authoritative reference
+   for active plasma properties.
 
 ``tardis/plasma/properties/nlte_excitation_data.py``
-   Defines ``NLTEExcitationData``, which is not used anywhere else in
-   the codebase.
+   Defines ``NLTEExcitationData``, which is not referenced elsewhere in 
+   the active codebase and is the existing implementation relevant to 
+   future NLTE excitation work.
 
 ``tardis/plasma/properties/hydrogen_continuum.py``
-   Zero percent coverage by plasma tests.
+   Not activated by any current simulation configuration and not
+   covered by the plasma test suite.
 
 ``tardis/plasma/properties/continuum_processes/fast_array_util.py``
-   Defines two numba functions:
+   Provides two Numba-accelerated integration utilities:
 
-   * ``numba_cumulative_trapezoid`` — Used in the uncovered class
-     ``TwoPhotonEmissionCDF`` in
-     ``tardis/plasma/properties/continuum_processes/rates.py``.
-   * ``cumulative_integrate_array_by_blocks`` — Same as above.
+   * ``numba_cumulative_trapezoid`` — Used by ``TwoPhotonEmissionCDF``
+     in ``tardis/plasma/properties/continuum_processes/rates.py``.
+   * ``cumulative_integrate_array_by_blocks`` — Used by the same class.
 
-Tools to Understand the Plasma Module
-======================================
+   Both functions are not exercised by the plasma test suite, as
+   ``TwoPhotonEmissionCDF`` is not activated in standard simulation
+   configurations.
 
-Test Coverage Reports
----------------------
+Developer Reference: Test Coverage and Plasma Graphs
+=====================================================
 
-Generating coverage reports of the plasma module test cases is a useful
-way to understand what parts of the plasma module are actually used by
-researchers running TARDIS. Running exclusively the tests in the plasma
-module and examining coverage results can reveal, for example:
+Test Coverage
+-------------
 
-* ``plasma/standard_plasmas.py`` is fully uncovered. The
-  ``assemble_plasma`` function defined there is never used in the actual
-  TARDIS simulation. The ``assemble_plasma`` that TARDIS actually uses is
-  in ``plasma/assembly/legacy_assembly.py``.
-* The continuum interactions setup in ``PlasmaSolverFactory``
-  (``plasma/assembly/base.py``) is never triggered because none of the
-  tested plasma configs set up continuum interactions.
+The plasma module test suite provides a practical way to identify which
+properties are exercised by standard plasma configurations.
+Running the plasma module tests with coverage enabled allows developers
+to verify which property ``calculate`` methods are exercised by the
+current set of simulation configurations.
+
+Key architectural notes for developers:
+
+* ``plasma/standard_plasmas.py`` is not covered by the plasma test
+  suite. The active assembly entry point is
+  ``plasma/assembly/legacy_assembly.py``.
+* Continuum interaction properties in ``PlasmaSolverFactory``
+  (``plasma/assembly/base.py``) are not activated by any current
+  integration test configuration. Continuum interactions are not
+  used in standard Type Ia supernova simulations.
 
 .. TODO: Add screenshot of PlasmaSolverFactory continuum interactions code here
 
-* ``hydrogen_continuum.py`` is not used anywhere and has zero percent
-  coverage.
+* ``hydrogen_continuum.py`` is not activated by any current simulation
+  configuration and is not covered by the plasma test suite.
 
-The best way to find which classes are actually being called is to go
-through ``legacy_property_collections.py``, click on each class, and
-check whether the code inside the ``calculate`` function is covered.
+To determine whether a specific property class is active, inspect its
+``calculate`` method under coverage. For example:
 
-For example, ``LinesLowerLevelIndex`` is in legacy properties and has
-full coverage, meaning it is actually being calculated when
-``test_full_plasmas`` builds its plasma configurations.
+* ``LinesLowerLevelIndex`` has full coverage, confirming it is
+  calculated in every standard plasma configuration built by
+  ``test_complete_plasmas``.
 
 .. TODO: Add screenshot of LinesLowerLevelIndex coverage here
 
-On the other hand, ``SpontRecombRateCoeff`` is in
-``continuum_interactions_properties`` and its ``calculate`` method is
-never run by any config in ``test_complete_plasmas``.
+* ``SpontRecombRateCoeff``, defined in
+  ``continuum_interactions_properties``, has no coverage in
+  ``test_complete_plasmas``, confirming it is not built by any
+  current standard simulation configuration.
 
 .. TODO: Add screenshot of SpontRecombRateCoeff coverage here
 
-Going through coverage results for ``test_complete_plasma`` is a good
-way to:
+Coverage analysis of ``test_complete_plasmas`` can be used to:
 
-* Guide what is worth writing unit tests for.
-* Identify features unused by the plasma module that should be migrated
-  to Type II plasma exclusively.
-* Find features that should be removed completely.
-* Find features that need to be fleshed out further.
+* Identify which property classes require additional unit tests.
+* Determine which features are scoped to Type II plasma and should
+  not be assumed available in Type Ia runs.
+* Identify property classes that are candidates for removal or
+  consolidation.
 
 Plasma Graph Generation
 -----------------------
 
-As described in the :ref:`NetworkX - Plasma Graphs <plasma_module>`
-section above, TARDIS can generate diagrams showing how plasma graph
-properties connect to one another. Generating diagrams across multiple
-configs is a good way to understand which plasma properties are relevant
-to general TARDIS users.
+TARDIS can generate diagrams of the plasma property graph, showing
+which properties depend on one another. Generating graphs across
+multiple simulation configurations is a practical method for
+identifying which plasma properties are relevant to standard
+simulation runs.
 
 Useful resources:
 


### PR DESCRIPTION
### :pencil: Description

**Type:** : :memo: `documentation` 

This PR creates a new plasma module documentation page that was previously missing. A hyperlink in the how-to plasma graph documentation page referenced "Plasma Documentation" but pointed to a page that did not exist.
Changes made:

- Created `docs/physics_walkthrough/setup/plasma/plasma_module.rst` based on the reference material provided in the issue
- Fixed the broken "Plasma Documentation" link in `how_to_plasma_graph.ipynb` to point to the new page
- Added `plasma_module` to the toctree in `docs/physics_walkthrough/setup/plasma/index.rst`

Closes #3645 


### :pushpin: Resources

- Reference material: https://docs.google.com/document/d/1mKOwtIm39_eU3GmDYa8vG7d_BJWtvbucwW6AIgxN3Hs/edit?usp=sharing
- How to plasma graph page: https://tardis-sn.github.io/tardis/how_to/output/how_to_plasma_graph.html


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label


