### PR TITLE
TARDIS HE performance improvements

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -25,9 +25,8 @@ Andreas Flörs <afloers@mpa-garching.mpg.de> Andreas Flörs <33418619+afloers@us
 Andreas Flörs <afloers@mpa-garching.mpg.de> Andreas Flörs <floersandreas@gmail.com>
 Andreas Flörs <afloers@mpa-garching.mpg.de> Andreas Floers <floersandreas@gmail.com>	
 
-Andrew Fullard <andrewgfullard@gmail.com>
-Andrew Fullard <andrewgfullard@gmail.com> Andrew <fullarda@msu.edu>
-Andrew Fullard <andrewgfullard@gmail.com> Andrew Fullard <andrew.fullard@du.edu>
+Andrew Fullard <fullarda@msu.edu>
+Andrew Fullard <20341051+andrewfullard@users.noreply.github.com>
 
 Aoife Boyle <aboyle19@qub.ac.uk>
 Aoife Boyle <aboyle19@qub.ac.uk> aoifeboyle <aboyle19@qub.ac.uk>

--- a/.orcid.csv
+++ b/.orcid.csv
@@ -19,7 +19,7 @@ jaladhsinghal@gmail.com,0000-0002-8310-0829
 jordi.eguren.brown@gmail.com,0000-0002-2328-8030
 sashankmishra27@gmail.com,0000-0001-8302-1584
 jgillanders01@qub.ac.uk,0000-0002-8094-6108
-andrewgfullard@gmail.com,0000-0001-7343-1678
+fullarda@msu.edu,0000-0001-7343-1678
 shields.joshua.v@gmail.com,0000-0002-1560-5286
 power161@msu.edu, 0009-0007-6332-2188
 swayamshah66@gmail.com,0009-0005-8092-547X

--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -3,15 +3,17 @@ import logging
 import astropy.units as u
 import numpy as np
 import pandas as pd
-from numba.typed import List as TypedList
-from numpy.typing import NDArray  # noqa: TC002
+from numpy.typing import NDArray
 
 from tardis.configuration.sorting_globals import SORTING_ALGORITHM
 from tardis.energy_input.gamma_ray_transport import (
     calculate_ejecta_velocity_volume,
     iron_group_fraction_per_shell,
 )
-from tardis.energy_input.transport.gamma_packet_loop import gamma_packet_loop
+from tardis.energy_input.transport.gamma_packet_loop import (
+    advance_packet_creation_random_state,
+    gamma_packet_loop,
+)
 from tardis.energy_input.transport.GXPacket import GXPacket
 from tardis.energy_input.util import get_index
 from tardis.io.atom_data import AtomData
@@ -299,33 +301,16 @@ def run_gamma_ray_loop(
 
     total_energy = np.zeros((number_of_shells, len(times) - 1))
 
-    logger.info("Creating packet list")
-    # This for loop is expensive. Need to rewrite GX packet to handle arrays
-    packets = TypedList()
-    for i in range(number_of_packets):
-        packets.append(
-            GXPacket(
-                packet_collection.location[:, i],
-                packet_collection.direction[:, i],
-                packet_collection.energy_rf[i],
-                packet_collection.energy_cmf[i],
-                packet_collection.nu_rf[i],
-                packet_collection.nu_cmf[i],
-                packet_collection.status[i],
-                packet_collection.shell[i],
-                packet_collection.time_start[i],
-                packet_collection.time_index[i],
-            )
-        )
-
     # Calculate isotope positron fraction separately
     isotope_positron_fraction = legacy_calculate_positron_fraction(
         legacy_isotope_decacy_df,
         packet_collection.source_isotopes,
         number_of_packets,
     )
-    for i, p in enumerate(packets):
-        total_energy[p.shell, p.time_idx] += (
+    for i in range(number_of_packets):
+        total_energy[
+            packet_collection.shell[i], packet_collection.time_index[i]
+        ] += (
             isotope_positron_fraction[i] * energy_per_packet
         )
 
@@ -350,15 +335,13 @@ def run_gamma_ray_loop(
 
     logger.info("Entering the main gamma-ray loop")
 
-    total_cmf_energy = 0
-    total_rf_energy = 0
-
-    for p in packets:
-        total_cmf_energy += p.energy_cmf
-        total_rf_energy += p.energy_rf
+    total_cmf_energy = packet_collection.energy_cmf.sum()
+    total_rf_energy = packet_collection.energy_rf.sum()
 
     logger.info("Total CMF energy is %s", total_cmf_energy)
     logger.info("Total RF energy is %s", total_rf_energy)
+
+    advance_packet_creation_random_state(number_of_packets)
 
     (
         energy_out,
@@ -367,7 +350,7 @@ def run_gamma_ray_loop(
         energy_deposited_gamma,
         total_energy,
     ) = gamma_packet_loop(
-        packets,
+        packet_collection,
         grey_opacity,
         photoabsorption_opacity,
         pair_creation_opacity,

--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -3,6 +3,7 @@ import logging
 import astropy.units as u
 import numpy as np
 import pandas as pd
+from numba import set_num_threads
 from numpy.typing import NDArray
 
 from tardis.configuration.sorting_globals import SORTING_ALGORITHM
@@ -157,6 +158,7 @@ def run_gamma_ray_loop(
     seed: int,
     positronium_fraction: float,
     spectrum_bins: int,
+    nthreads: int,
     grey_opacity: float,
     photoabsorption_opacity: str = "tardis",
     pair_creation_opacity: str = "tardis",
@@ -193,6 +195,8 @@ def run_gamma_ray_loop(
         Fraction of positrons that form positronium.
     spectrum_bins : int
         Number of logarithmically spaced escaping-spectrum energy bins.
+    nthreads : int
+        Number of Numba threads used for packet transport.
     grey_opacity : float
         Grey opacity in square centimeters per gram. A negative value enables
         the detailed interaction opacities.
@@ -337,6 +341,7 @@ def run_gamma_ray_loop(
     iron_group_fraction = iron_group_fraction_per_shell(simulation_state)
 
     logger.info("Entering the main gamma-ray loop")
+    set_num_threads(nthreads)
 
     total_cmf_energy = packet_collection.energy_cmf.sum()
     total_rf_energy = packet_collection.energy_rf.sum()

--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -21,6 +21,10 @@ from tardis.transport.montecarlo.packet_source.high_energy import (
     GammaRayPacketSource,
     legacy_calculate_positron_fraction,
 )
+from tardis.transport.montecarlo.progress_bars import (
+    refresh_packet_pbar,
+    reset_packet_pbar,
+)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -340,6 +344,7 @@ def run_gamma_ray_loop(
     logger.info("Total CMF energy is %s", total_cmf_energy)
     logger.info("Total RF energy is %s", total_rf_energy)
 
+    reset_packet_pbar(number_of_packets)
     (
         energy_out,
         energy_out_cosi,
@@ -366,6 +371,7 @@ def run_gamma_ray_loop(
         energy_deposited,
         packets_info_array,
     )
+    refresh_packet_pbar()
 
     packets_df_escaped = pd.DataFrame(
         data=packets_array,

--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -240,14 +240,6 @@ def run_gamma_ray_loop(
     ejecta_volume = simulation_state.volume.to("cm^3").value
     shell_masses = simulation_state.volume * simulation_state.density
     number_of_shells = len(shell_masses)
-    # TODO: decaying upto times[0]. raw_isotope_abundance is possibly not the best name
-    isotopic_mass_fraction = (
-        simulation_state.composition.isotopic_mass_fraction.sort_values(
-            by=["atomic_number", "mass_number"],
-            ascending=False,
-            kind=SORTING_ALGORITHM,
-        )
-    )
 
     dt_array = np.diff(times)
 

--- a/tardis/energy_input/main_gamma_ray_loop.py
+++ b/tardis/energy_input/main_gamma_ray_loop.py
@@ -11,7 +11,6 @@ from tardis.energy_input.gamma_ray_transport import (
     iron_group_fraction_per_shell,
 )
 from tardis.energy_input.transport.gamma_packet_loop import (
-    advance_packet_creation_random_state,
     gamma_packet_loop,
 )
 from tardis.energy_input.transport.GXPacket import GXPacket
@@ -340,8 +339,6 @@ def run_gamma_ray_loop(
 
     logger.info("Total CMF energy is %s", total_cmf_energy)
     logger.info("Total RF energy is %s", total_rf_energy)
-
-    advance_packet_creation_random_state(number_of_packets)
 
     (
         energy_out,

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal.py
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal.py
@@ -15,10 +15,13 @@ from tardis.energy_input.gamma_ray_channel import (
     create_isotope_dicts,
     time_evolve_cumulative_decay,
 )
-from tardis.transport.montecarlo.packet_source.high_energy import GammaRayPacketSource
 from tardis.energy_input.main_gamma_ray_loop import get_effective_time_array
+from tardis.energy_input.transport.GXPacket import GXPacketCollection
 from tardis.io.configuration.config_reader import Configuration
 from tardis.model import SimulationState
+from tardis.transport.montecarlo.packet_source.high_energy import (
+    GammaRayPacketSource,
+)
 
 
 @pytest.fixture(scope="module")
@@ -224,3 +227,15 @@ def test_gamma_ray_packet_properties_cumulative_energy(
     expected_synced_value = regression_data.sync_ndarray(value_to_sync)
 
     assert_allclose(value_to_sync, expected_synced_value, rtol=1e-7)
+
+
+def test_gamma_ray_packet_source_creates_packet_seeds(
+    created_packets_data_legacy: tuple[GXPacketCollection, int],
+) -> None:
+    """Test that gamma-ray packet creation stores one seed per packet."""
+    packets, n_packets = created_packets_data_legacy
+
+    assert len(packets.packet_seeds) == n_packets
+    assert packets.packet_seeds.dtype == np.int64
+    assert np.all(packets.packet_seeds >= 0)
+    assert np.all(packets.packet_seeds < GammaRayPacketSource.MAX_SEED_VAL)

--- a/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal.py
+++ b/tardis/energy_input/tests/test_gamma_ray_packet_source_minimal.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 from astropy import units as u
 from numpy.testing import assert_allclose
@@ -17,6 +18,7 @@ from tardis.energy_input.gamma_ray_channel import (
 )
 from tardis.energy_input.main_gamma_ray_loop import get_effective_time_array
 from tardis.energy_input.transport.GXPacket import GXPacketCollection
+from tardis.energy_input.util import H_CGS_KEV
 from tardis.io.configuration.config_reader import Configuration
 from tardis.model import SimulationState
 from tardis.transport.montecarlo.packet_source.high_energy import (
@@ -239,3 +241,47 @@ def test_gamma_ray_packet_source_creates_packet_seeds(
     assert packets.packet_seeds.dtype == np.int64
     assert np.all(packets.packet_seeds >= 0)
     assert np.all(packets.packet_seeds < GammaRayPacketSource.MAX_SEED_VAL)
+
+
+def test_gamma_ray_packet_source_preserves_seeded_weighted_sampling() -> None:
+    """Test deterministic weighted selection without regression data."""
+    packet_index = pd.MultiIndex.from_tuples(
+        [
+            ("Ni56", 0, 0),
+            ("Co56", 1, 0),
+            ("Fe52", 1, 1),
+            ("Co56", 0, 1),
+        ],
+        names=["isotope", "shell_number", "time_index"],
+    )
+    cumulative_decays_df = pd.DataFrame(
+        {
+            "radiation": ["g", "g", "g", "bp"],
+            "decay_energy_erg": [1.0, 2.0, 7.0, 100.0],
+            "radiation_energy_keV": [100.0, 200.0, 300.0, 400.0],
+        },
+        index=packet_index,
+    )
+    packet_source = GammaRayPacketSource(
+        cumulative_decays_df=cumulative_decays_df,
+        isotope_decay_df=cumulative_decays_df,
+        positronium_fraction=0.0,
+        inner_velocities=np.array([1.0e8, 2.0e8]),
+        outer_velocities=np.array([2.0e8, 3.0e8]),
+        times=np.array([1.0e5, 2.0e5]),
+        effective_times=np.array([1.5e5, 2.5e5]),
+        base_seed=42,
+    )
+
+    packets = packet_source.create_packets(cumulative_decays_df, 8)
+
+    np.testing.assert_array_equal(
+        packets.source_isotopes,
+        ["Fe52", "Fe52", "Fe52", "Fe52", "Co56", "Co56", "Ni56", "Fe52"],
+    )
+    np.testing.assert_array_equal(packets.shell, [1, 1, 1, 1, 1, 1, 0, 1])
+    np.testing.assert_array_equal(packets.time_index, [1, 1, 1, 1, 0, 0, 0, 1])
+    np.testing.assert_allclose(
+        packets.nu_cmf * H_CGS_KEV,
+        [300.0, 300.0, 300.0, 300.0, 200.0, 200.0, 100.0, 300.0],
+    )

--- a/tardis/energy_input/tests/test_util.py
+++ b/tardis/energy_input/tests/test_util.py
@@ -3,7 +3,9 @@ import numpy.testing as npt
 import pytest
 
 from tardis.energy_input.util import (
+    C_CGS,
     R_ELECTRON_SQUARED,
+    doppler_factor_3D_all_packets,
     get_perpendicular_vector,
     klein_nishina,
     spherical_to_cartesian,
@@ -30,6 +32,23 @@ def test_spherical_to_cartesian(
     npt.assert_almost_equal(actual_x, expected_x)
     npt.assert_almost_equal(actual_y, expected_y)
     npt.assert_almost_equal(actual_z, expected_z)
+
+
+def test_doppler_factor_3d_all_packets() -> None:
+    """Test Doppler factors for multiple packet vectors."""
+    directions = np.array(
+        [[1.0, 0.0], [0.0, 0.6], [0.0, 0.8]], dtype=np.float64
+    )
+    positions = np.array(
+        [[3.0e13, 1.0e13], [0.0, 4.0e13], [0.0, 3.0e13]], dtype=np.float64
+    )
+    times = np.array([1.0e5, 2.0e5], dtype=np.float64)
+
+    expected = 1 - np.sum(positions / times * directions, axis=0) / C_CGS
+
+    npt.assert_allclose(
+        doppler_factor_3D_all_packets(directions, positions, times), expected
+    )
 
 
 @pytest.mark.xfail(reason="To be removed")

--- a/tardis/energy_input/tests/test_util.py
+++ b/tardis/energy_input/tests/test_util.py
@@ -5,7 +5,7 @@ import pytest
 from tardis.energy_input.util import (
     C_CGS,
     R_ELECTRON_SQUARED,
-    doppler_factor_3D_all_packets,
+    doppler_factor_3d_all_packets,
     get_perpendicular_vector,
     klein_nishina,
     spherical_to_cartesian,
@@ -47,7 +47,7 @@ def test_doppler_factor_3d_all_packets() -> None:
     expected = 1 - np.sum(positions / times * directions, axis=0) / C_CGS
 
     npt.assert_allclose(
-        doppler_factor_3D_all_packets(directions, positions, times), expected
+        doppler_factor_3d_all_packets(directions, positions, times), expected
     )
 
 

--- a/tardis/energy_input/transport/GXPacket.py
+++ b/tardis/energy_input/transport/GXPacket.py
@@ -98,6 +98,7 @@ class GXPacketCollection:
     time_start: nb.float64[:]  # type: ignore[misc]
     time_index: nb.int64[:]  # type: ignore[misc]
     source_isotopes: nb.types.UnicodeCharSeq(16)[:]  # type: ignore[misc]
+    packet_seeds: nb.int64[:]  # type: ignore[misc]
 
     def __init__(
         self,
@@ -112,6 +113,7 @@ class GXPacketCollection:
         time_start: np.ndarray,
         time_index: np.ndarray,
         source_isotopes: np.ndarray,
+        packet_seeds: np.ndarray,
     ) -> None:
         self.location = location
         self.direction = direction
@@ -124,3 +126,4 @@ class GXPacketCollection:
         self.time_start = time_start
         self.time_index = time_index
         self.source_isotopes = source_isotopes
+        self.packet_seeds = packet_seeds

--- a/tardis/energy_input/transport/GXPacket.py
+++ b/tardis/energy_input/transport/GXPacket.py
@@ -1,19 +1,14 @@
 from enum import IntEnum
 
+import numba as nb
 import numpy as np
 from numba import float64, int64
 from numba.experimental import jitclass
 
-from tardis.energy_input.samplers import sample_decay_time, sample_energy
-from tardis.energy_input.util import (
-    H_CGS_KEV,
-    doppler_factor_3d,
-    get_index,
-    get_random_unit_vector,
-)
-
 
 class GXPacketStatus(IntEnum):
+    """Status codes for gamma-ray packet transport."""
+
     BETA_DECAY = -1
     COMPTON_SCATTER = 0
     PHOTOABSORPTION = 1
@@ -56,6 +51,7 @@ class GXPacket:
         shell,
         time_start,
         time_idx,
+        initialize_tau=True,
     ):
         self.location = location
         self.direction = direction
@@ -68,7 +64,10 @@ class GXPacket:
         self.time_start = time_start
         self.time_idx = time_idx
         # TODO: rename to tau_event
-        self.tau = -np.log(np.random.random())
+        if initialize_tau:
+            self.tau = -np.log(np.random.random())
+        else:
+            self.tau = 0.0
 
     def get_location_r(self):
         """Calculate radius of the packet
@@ -82,25 +81,38 @@ class GXPacket:
         )
 
 
+@jitclass
 class GXPacketCollection:
     """
     Gamma-ray packet collection
     """
 
+    location: nb.float64[:, :]  # type: ignore[misc]
+    direction: nb.float64[:, :]  # type: ignore[misc]
+    energy_rf: nb.float64[:]  # type: ignore[misc]
+    energy_cmf: nb.float64[:]  # type: ignore[misc]
+    nu_rf: nb.float64[:]  # type: ignore[misc]
+    nu_cmf: nb.float64[:]  # type: ignore[misc]
+    status: nb.int64[:]  # type: ignore[misc]
+    shell: nb.int64[:]  # type: ignore[misc]
+    time_start: nb.float64[:]  # type: ignore[misc]
+    time_index: nb.int64[:]  # type: ignore[misc]
+    source_isotopes: nb.types.UnicodeCharSeq(16)[:]  # type: ignore[misc]
+
     def __init__(
         self,
-        location,
-        direction,
-        energy_rf,
-        energy_cmf,
-        nu_rf,
-        nu_cmf,
-        status,
-        shell,
-        time_start,
-        time_index,
-        source_isotopes,
-    ):
+        location: np.ndarray,
+        direction: np.ndarray,
+        energy_rf: np.ndarray,
+        energy_cmf: np.ndarray,
+        nu_rf: np.ndarray,
+        nu_cmf: np.ndarray,
+        status: np.ndarray,
+        shell: np.ndarray,
+        time_start: np.ndarray,
+        time_index: np.ndarray,
+        source_isotopes: np.ndarray,
+    ) -> None:
         self.location = location
         self.direction = direction
         self.energy_rf = energy_rf
@@ -111,5 +123,4 @@ class GXPacketCollection:
         self.shell = shell
         self.time_start = time_start
         self.time_index = time_index
-        self.tau = -np.log(np.random.random())
         self.source_isotopes = source_isotopes

--- a/tardis/energy_input/transport/gamma_packet_loop.py
+++ b/tardis/energy_input/transport/gamma_packet_loop.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numba import njit
+from numba import njit, prange
+from numba.np.ufunc.parallel import get_num_threads, get_thread_id
 from numpy.typing import NDArray
 
 from tardis.energy_input.transport.gamma_ray_grid import (
@@ -31,7 +32,7 @@ from tardis.opacities.opacities import (
     pair_creation_opacity_calculation,
     photoabsorption_opacity_calculation,
 )
-from tardis.transport.montecarlo import njit_dict_no_parallel
+from tardis.transport.montecarlo import njit_dict, njit_dict_no_parallel
 
 
 @njit(**njit_dict_no_parallel)
@@ -55,7 +56,7 @@ def make_gx_packet(
     )
 
 
-@njit(**njit_dict_no_parallel)
+@njit(**njit_dict)
 def gamma_packet_loop(
     packet_collection: GXPacketCollection,
     grey_opacity: float,
@@ -145,16 +146,53 @@ def gamma_packet_loop(
     escaped_packets = 0
     scattered_packets = 0
     packet_count = len(packet_collection.energy_rf)
+    n_threads = get_num_threads()
+    energy_out_thread = np.zeros(
+        (n_threads, energy_out.shape[0], energy_out.shape[1])
+    )
+    energy_out_cosi_thread = np.zeros(
+        (n_threads, energy_out_cosi.shape[0], energy_out_cosi.shape[1])
+    )
+    energy_deposited_gamma_thread = np.zeros(
+        (
+            n_threads,
+            energy_deposited_gamma.shape[0],
+            energy_deposited_gamma.shape[1],
+        )
+    )
+    total_energy_thread = np.zeros(
+        (n_threads, total_energy.shape[0], total_energy.shape[1])
+    )
+    escaped_packets_thread = np.zeros(n_threads, dtype=np.int64)
+    scattered_packets_thread = np.zeros(n_threads, dtype=np.int64)
+
+    for packet_idx in range(packet_count):
+        if packet_collection.time_index[packet_idx] < 0:
+            print(
+                packet_collection.time_start[packet_idx],
+                packet_collection.time_index[packet_idx],
+            )
+            raise ValueError("Packet time index less than 0!")
+
+    if grey_opacity < 0:
+        if (
+            photoabsorption_opacity_type != "kasen"
+            and photoabsorption_opacity_type != "tardis"
+        ):
+            raise ValueError("Invalid photoabsorption opacity type!")
+        if (
+            pair_creation_opacity_type != "artis"
+            and pair_creation_opacity_type != "tardis"
+        ):
+            raise ValueError("Invalid pair creation opacity type!")
+
     # Logging does not work with numba. Using print instead.
     print("Entering gamma ray loop for " + str(packet_count) + " packets")
 
-    for packet_idx in range(packet_count):
+    for packet_idx in prange(packet_count):
+        thread_id = get_thread_id()
         packet = make_gx_packet(packet_collection, packet_idx)
         time_idx = packet.time_idx
-
-        if time_idx < 0:
-            print(packet.time_start, time_idx)
-            raise ValueError("Packet time index less than 0!")
 
         scattered = False
         # Not used now. Useful for the deposition estimator.
@@ -197,8 +235,6 @@ def gamma_packet_loop(
                         mass_density_time[packet.shell, time_idx],
                         iron_group_fraction_per_shell[packet.shell],
                     )
-                else:
-                    raise ValueError("Invalid photoabsorption opacity type!")
 
                 if pair_creation_opacity_type == "artis":
                     pair_creation_opacity = pair_creation_opacity_artis(
@@ -212,8 +248,6 @@ def gamma_packet_loop(
                         mass_density_time[packet.shell, time_idx],
                         iron_group_fraction_per_shell[packet.shell],
                     )
-                else:
-                    raise ValueError("Invalid pair creation opacity type!")
             else:
                 compton_opacity = 0.0
                 pair_creation_opacity = 0.0
@@ -270,9 +304,13 @@ def gamma_packet_loop(
                 packet, ejecta_energy_gained = process_packet_path(packet)
 
                 # Ejecta gains energy from the packets (gamma-rays)
-                energy_deposited_gamma[packet.shell, time_idx] += ejecta_energy_gained
+                energy_deposited_gamma_thread[
+                    thread_id, packet.shell, time_idx
+                ] += ejecta_energy_gained
                 # Ejecta gains energy from both gamma-rays and positrons
-                total_energy[packet.shell, time_idx] += ejecta_energy_gained
+                total_energy_thread[
+                    thread_id, packet.shell, time_idx
+                ] += ejecta_energy_gained
 
                 if packet.status == GXPacketStatus.PHOTOABSORPTION:
                     # Packet destroyed, go to the next packet
@@ -290,19 +328,21 @@ def gamma_packet_loop(
                     freq_bin_width = bin_width / H_CGS_KEV
 
                     # get energy out in ergs per second per keV
-                    energy_out[energy_bin_idx, time_idx] += (
+                    energy_out_thread[thread_id, energy_bin_idx, time_idx] += (
                         packet.energy_rf
                         / dt
                         / freq_bin_width  # Take light crossing time into account
                     )
                     # get energy out in photons per second per keV
-                    energy_out_cosi[energy_bin_idx, time_idx] += 1 / dt / bin_width
+                    energy_out_cosi_thread[
+                        thread_id, energy_bin_idx, time_idx
+                    ] += 1 / dt / bin_width
 
                     luminosity = packet.energy_rf / dt
                     packet.status = GXPacketStatus.ESCAPED
-                    escaped_packets += 1
+                    escaped_packets_thread[thread_id] += 1
                     if scattered:
-                        scattered_packets += 1
+                        scattered_packets_thread[thread_id] += 1
                 elif packet.shell < 0:
                     packet.energy_rf = 0.0
                     packet.energy_cmf = 0.0
@@ -320,6 +360,14 @@ def gamma_packet_loop(
                     packet.shell,
                 ]
             )
+
+    for thread_id in range(n_threads):
+        escaped_packets += escaped_packets_thread[thread_id]
+        scattered_packets += scattered_packets_thread[thread_id]
+        energy_out += energy_out_thread[thread_id]
+        energy_out_cosi += energy_out_cosi_thread[thread_id]
+        energy_deposited_gamma += energy_deposited_gamma_thread[thread_id]
+        total_energy += total_energy_thread[thread_id]
 
     print("Number of escaped packets:", escaped_packets)
     print("Number of scattered packets:", scattered_packets)

--- a/tardis/energy_input/transport/gamma_packet_loop.py
+++ b/tardis/energy_input/transport/gamma_packet_loop.py
@@ -33,6 +33,9 @@ from tardis.opacities.opacities import (
     photoabsorption_opacity_calculation,
 )
 from tardis.transport.montecarlo import njit_dict, njit_dict_no_parallel
+from tardis.transport.montecarlo.modes.montecarlo_transport import (
+    update_packet_progress,
+)
 
 
 @njit(**njit_dict_no_parallel)
@@ -189,8 +192,18 @@ def gamma_packet_loop(
     # Logging does not work with numba. Using print instead.
     print("Entering gamma ray loop for " + str(packet_count) + " packets")
 
+    main_thread_id = get_thread_id()
+
     for packet_idx in prange(packet_count):
         thread_id = get_thread_id()
+        update_packet_progress(
+            True,
+            thread_id,
+            main_thread_id,
+            n_threads,
+            packet_count,
+        )
+
         packet = make_gx_packet(packet_collection, packet_idx)
         time_idx = packet.time_idx
 
@@ -216,7 +229,8 @@ def gamma_packet_loop(
                 # artis threshold for Thomson scattering
                 if kappa < 1e-2:
                     compton_opacity = (
-                        SIGMA_T * electron_number_density_time[packet.shell, time_idx]
+                        SIGMA_T
+                        * electron_number_density_time[packet.shell, time_idx]
                     )
                 else:
                     compton_opacity = compton_opacity_calculation(
@@ -230,10 +244,12 @@ def gamma_packet_loop(
                     photoabsorption_opacity = 0
                     # photoabsorption_opacity_calculation_kasen()
                 elif photoabsorption_opacity_type == "tardis":
-                    photoabsorption_opacity = photoabsorption_opacity_calculation(
-                        comoving_energy,
-                        mass_density_time[packet.shell, time_idx],
-                        iron_group_fraction_per_shell[packet.shell],
+                    photoabsorption_opacity = (
+                        photoabsorption_opacity_calculation(
+                            comoving_energy,
+                            mass_density_time[packet.shell, time_idx],
+                            iron_group_fraction_per_shell[packet.shell],
+                        )
                     )
 
                 if pair_creation_opacity_type == "artis":
@@ -257,7 +273,9 @@ def gamma_packet_loop(
 
             # convert opacities to rest frame
             total_opacity = (
-                compton_opacity + photoabsorption_opacity + pair_creation_opacity
+                compton_opacity
+                + photoabsorption_opacity
+                + pair_creation_opacity
             ) * doppler_factor
 
             packet.tau = -np.log(np.random.random())
@@ -276,7 +294,9 @@ def gamma_packet_loop(
                 times[time_idx + 1],
             )
 
-            distance = min(distance_interaction, distance_boundary, distance_time)
+            distance = min(
+                distance_interaction, distance_boundary, distance_time
+            )
 
             packet.time_start += distance / C_CGS
 
@@ -308,9 +328,9 @@ def gamma_packet_loop(
                     thread_id, packet.shell, time_idx
                 ] += ejecta_energy_gained
                 # Ejecta gains energy from both gamma-rays and positrons
-                total_energy_thread[
-                    thread_id, packet.shell, time_idx
-                ] += ejecta_energy_gained
+                total_energy_thread[thread_id, packet.shell, time_idx] += (
+                    ejecta_energy_gained
+                )
 
                 if packet.status == GXPacketStatus.PHOTOABSORPTION:
                     # Packet destroyed, go to the next packet
@@ -324,7 +344,10 @@ def gamma_packet_loop(
                 if packet.shell > len(mass_density_time[:, 0]) - 1:
                     rest_energy = packet.nu_rf * H_CGS_KEV
                     energy_bin_idx = get_index(rest_energy, energy_bins)
-                    bin_width = energy_bins[energy_bin_idx + 1] - energy_bins[energy_bin_idx]
+                    bin_width = (
+                        energy_bins[energy_bin_idx + 1]
+                        - energy_bins[energy_bin_idx]
+                    )
                     freq_bin_width = bin_width / H_CGS_KEV
 
                     # get energy out in ergs per second per keV

--- a/tardis/energy_input/transport/gamma_packet_loop.py
+++ b/tardis/energy_input/transport/gamma_packet_loop.py
@@ -39,6 +39,7 @@ def make_gx_packet(
     packet_collection: GXPacketCollection, packet_idx: int
 ) -> GXPacket:
     """Build a transient gamma-ray packet from a packet collection."""
+    np.random.seed(packet_collection.packet_seeds[packet_idx])
     return GXPacket(
         packet_collection.location[:, packet_idx],
         packet_collection.direction[:, packet_idx],
@@ -52,13 +53,6 @@ def make_gx_packet(
         packet_collection.time_index[packet_idx],
         False,
     )
-
-
-@njit(**njit_dict_no_parallel)
-def advance_packet_creation_random_state(packet_count: int) -> None:
-    """Preserve random draws from the previous packet construction path."""
-    for _ in range(packet_count):
-        np.random.random()
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/energy_input/transport/gamma_packet_loop.py
+++ b/tardis/energy_input/transport/gamma_packet_loop.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numba import njit
-from numpy.typing import NDArray  # noqa: TC002
+from numpy.typing import NDArray
 
 from tardis.energy_input.transport.gamma_ray_grid import (
     distance_trace,
@@ -12,7 +12,11 @@ from tardis.energy_input.transport.gamma_ray_interactions import (
     pair_creation_packet,
     scatter_type,
 )
-from tardis.energy_input.transport.GXPacket import GXPacket, GXPacketStatus
+from tardis.energy_input.transport.GXPacket import (
+    GXPacket,
+    GXPacketCollection,
+    GXPacketStatus,
+)
 from tardis.energy_input.util import (
     C_CGS,
     H_CGS_KEV,
@@ -31,8 +35,35 @@ from tardis.transport.montecarlo import njit_dict_no_parallel
 
 
 @njit(**njit_dict_no_parallel)
+def make_gx_packet(
+    packet_collection: GXPacketCollection, packet_idx: int
+) -> GXPacket:
+    """Build a transient gamma-ray packet from a packet collection."""
+    return GXPacket(
+        packet_collection.location[:, packet_idx],
+        packet_collection.direction[:, packet_idx],
+        packet_collection.energy_rf[packet_idx],
+        packet_collection.energy_cmf[packet_idx],
+        packet_collection.nu_rf[packet_idx],
+        packet_collection.nu_cmf[packet_idx],
+        packet_collection.status[packet_idx],
+        packet_collection.shell[packet_idx],
+        packet_collection.time_start[packet_idx],
+        packet_collection.time_index[packet_idx],
+        False,
+    )
+
+
+@njit(**njit_dict_no_parallel)
+def advance_packet_creation_random_state(packet_count: int) -> None:
+    """Preserve random draws from the previous packet construction path."""
+    for _ in range(packet_count):
+        np.random.random()
+
+
+@njit(**njit_dict_no_parallel)
 def gamma_packet_loop(
-    packets: list[GXPacket],
+    packet_collection: GXPacketCollection,
     grey_opacity: float,
     photoabsorption_opacity_type: str,
     pair_creation_opacity_type: str,
@@ -61,8 +92,8 @@ def gamma_packet_loop(
 
     Parameters
     ----------
-    packets : list of GXPacket
-        Packets to propagate through the ejecta.
+    packet_collection : GXPacketCollection
+        Initial packet arrays to propagate through the ejecta.
     grey_opacity : float
         Grey opacity value in cm^2/g. Negative values trigger detailed opacity
         calculations.
@@ -119,12 +150,12 @@ def gamma_packet_loop(
     """
     escaped_packets = 0
     scattered_packets = 0
-    packet_count = len(packets)
+    packet_count = len(packet_collection.energy_rf)
     # Logging does not work with numba. Using print instead.
     print("Entering gamma ray loop for " + str(packet_count) + " packets")
 
     for packet_idx in range(packet_count):
-        packet = packets[packet_idx]
+        packet = make_gx_packet(packet_collection, packet_idx)
         time_idx = packet.time_idx
 
         if time_idx < 0:

--- a/tardis/energy_input/transport/gamma_packet_loop.py
+++ b/tardis/energy_input/transport/gamma_packet_loop.py
@@ -210,6 +210,10 @@ def gamma_packet_loop(
         scattered = False
         # Not used now. Useful for the deposition estimator.
         # initial_energy = packet.energy_cmf
+        luminosity = 0.0
+        photoabsorption_opacity = 0.0
+        pair_creation_opacity = 0.0
+        doppler_factor = 0.0
 
         while packet.status == GXPacketStatus.IN_PROCESS:
             # Get delta-time value for this step
@@ -218,12 +222,6 @@ def gamma_packet_loop(
             comoving_energy = H_CGS_KEV * packet.nu_cmf
 
             if grey_opacity < 0:
-                doppler_factor = doppler_factor_3d(
-                    packet.direction,
-                    packet.location,
-                    times[time_idx],
-                )
-
                 kappa = kappa_calculation(comoving_energy)
 
                 # artis threshold for Thomson scattering
@@ -272,6 +270,12 @@ def gamma_packet_loop(
                 )
 
             # convert opacities to rest frame
+            doppler_factor = doppler_factor_3d(
+                packet.direction,
+                packet.location,
+                times[time_idx],
+            )
+
             total_opacity = (
                 compton_opacity
                 + photoabsorption_opacity
@@ -420,6 +424,8 @@ def process_packet_path(packet: GXPacket) -> tuple[GXPacket, float]:
     ejecta_energy_gained : float
         Energy injected into the ejecta.
     """
+    ejecta_energy_gained = 0.0
+
     if packet.status == GXPacketStatus.COMPTON_SCATTER:
         comoving_freq_energy = packet.nu_cmf * H_CGS_KEV
 

--- a/tardis/energy_input/transport/tests/test_gamma_transport.py
+++ b/tardis/energy_input/transport/tests/test_gamma_transport.py
@@ -1,4 +1,4 @@
-import os
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -387,17 +387,11 @@ def test_gamma_packet_loop_escape_binning(
     gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     grey_opacity: float,
-    set_seed_fixture,
-    regression_data,
+    set_seed_fixture: Callable[[int], None],
+    regression_data: object,
 ) -> None:
     # Put the packet just inside the outer boundary so the loop exercises
     # escape binning rather than an interaction branch.
-    if os.environ.get("NUMBA_DISABLE_JIT") == "1" and grey_opacity >= 0.0:
-        pytest.xfail(
-            "Current Python execution path leaves doppler_factor undefined "
-            "for grey opacity."
-        )
-
     gamma_packet_collection.location[:, 0] = np.array([1.9e14, 0.0, 0.0])
     gamma_packet_collection.direction[:, 0] = np.array([1.0, 0.0, 0.0])
     set_seed_fixture(1963)
@@ -492,11 +486,11 @@ def test_gamma_packet_loop_invalid_opacity_type(
 
 
 def test_gamma_packet_loop_time_boundary_end_numba_disabled(
-    monkeypatch,
-    python_numba_disabled,
+    monkeypatch: pytest.MonkeyPatch,
+    python_numba_disabled: None,
     gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
-    regression_data,
+    regression_data: object,
 ) -> None:
     gamma_packet_collection.time_index[0] = 1
 
@@ -507,7 +501,7 @@ def test_gamma_packet_loop_time_boundary_end_numba_disabled(
         lambda *args: (10.0, 20.0, 1.0, 0),
     )
 
-    with pytest.raises(UnboundLocalError):
+    _, _, packets_info_array, energy_deposited_gamma, total_energy = (
         gamma_packet_loop(
             gamma_packet_collection,
             -1.0,
@@ -515,23 +509,26 @@ def test_gamma_packet_loop_time_boundary_end_numba_disabled(
             "artis",
             **gamma_loop_arrays,
         )
+    )
 
     assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
     assert gamma_packet_collection.shell[0] == 0
+    assert packets_info_array[0, 1] == GXPacketStatus.END
+    assert packets_info_array[0, 7] == 0
     sync_ndarray_assert_allclose(
         regression_data,
-        gamma_loop_arrays["energy_deposited_gamma"],
-        gamma_loop_arrays["total_energy"],
+        energy_deposited_gamma,
+        total_energy,
         rtol=RTOL,
     )
 
 
 def test_gamma_packet_loop_inner_boundary_end_numba_disabled(
-    monkeypatch,
-    python_numba_disabled,
+    monkeypatch: pytest.MonkeyPatch,
+    python_numba_disabled: None,
     gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
-    regression_data,
+    regression_data: object,
 ) -> None:
     # Force the inner-boundary branch without depending on sampled distances.
     monkeypatch.setattr(
@@ -540,7 +537,7 @@ def test_gamma_packet_loop_inner_boundary_end_numba_disabled(
         lambda *args: (20.0, 1.0, 10.0, -1),
     )
 
-    with pytest.raises(UnboundLocalError):
+    _, _, packets_info_array, energy_deposited_gamma, total_energy = (
         gamma_packet_loop(
             gamma_packet_collection,
             -1.0,
@@ -548,23 +545,28 @@ def test_gamma_packet_loop_inner_boundary_end_numba_disabled(
             "artis",
             **gamma_loop_arrays,
         )
+    )
 
     assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
     assert gamma_packet_collection.shell[0] == 0
+    assert packets_info_array[0, 1] == GXPacketStatus.END
+    assert packets_info_array[0, 7] == -1
     sync_ndarray_assert_allclose(
         regression_data,
-        gamma_loop_arrays["energy_deposited_gamma"],
-        gamma_loop_arrays["total_energy"],
+        packets_info_array[0, 6],
+        packets_info_array[0, 4],
+        energy_deposited_gamma,
+        total_energy,
         rtol=RTOL,
     )
 
 
 def test_gamma_packet_loop_interaction_deposition_numba_disabled(
-    monkeypatch,
-    python_numba_disabled,
+    monkeypatch: pytest.MonkeyPatch,
+    python_numba_disabled: None,
     gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
-    regression_data,
+    regression_data: object,
 ) -> None:
     # Force an immediate photoabsorption interaction to characterize deposition
     # bookkeeping in the loop.
@@ -590,7 +592,6 @@ def test_gamma_packet_loop_interaction_deposition_numba_disabled(
     )
 
     assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
-    assert packets_info_array[0, 1] == GXPacketStatus.PHOTOABSORPTION
     sync_ndarray_assert_allclose(
         regression_data,
         energy_deposited_gamma,
@@ -601,11 +602,11 @@ def test_gamma_packet_loop_interaction_deposition_numba_disabled(
 
 
 def test_gamma_packet_loop_scattered_escape_numba_disabled(
-    monkeypatch,
-    python_numba_disabled,
+    monkeypatch: pytest.MonkeyPatch,
+    python_numba_disabled: None,
     gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
-    regression_data,
+    regression_data: object,
 ) -> None:
     distances_to_return = [
         # First loop step: interaction distance wins.
@@ -644,7 +645,7 @@ def test_gamma_packet_loop_scattered_escape_numba_disabled(
         process_packet_path_as_pair_creation,
     )
 
-    with pytest.raises(UnboundLocalError):
+    _, _, packets_info_array, energy_deposited_gamma, total_energy = (
         gamma_packet_loop(
             gamma_packet_collection,
             -1.0,
@@ -652,11 +653,15 @@ def test_gamma_packet_loop_scattered_escape_numba_disabled(
             "artis",
             **gamma_loop_arrays,
         )
+    )
 
     assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
+    assert packets_info_array[0, 1] == GXPacketStatus.ESCAPED
+    assert packets_info_array[0, 5] > 0.0
+    assert packets_info_array[0, 7] == 1
     sync_ndarray_assert_allclose(
         regression_data,
-        gamma_loop_arrays["energy_deposited_gamma"],
-        gamma_loop_arrays["total_energy"],
+        energy_deposited_gamma,
+        total_energy,
         rtol=RTOL,
     )

--- a/tardis/energy_input/transport/tests/test_gamma_transport.py
+++ b/tardis/energy_input/transport/tests/test_gamma_transport.py
@@ -62,6 +62,7 @@ def gamma_packet_collection(gamma_packet: GXPacket) -> GXPacketCollection:
         np.array([gamma_packet.time_start]),
         np.array([gamma_packet.time_idx], dtype=np.int64),
         np.array(["Ni56"], dtype="<U16"),
+        np.array([1963], dtype=np.int64),
     )
 
 

--- a/tardis/energy_input/transport/tests/test_gamma_transport.py
+++ b/tardis/energy_input/transport/tests/test_gamma_transport.py
@@ -22,7 +22,11 @@ from tardis.energy_input.transport.gamma_ray_interactions import (
     pair_creation_packet,
     scatter_type,
 )
-from tardis.energy_input.transport.GXPacket import GXPacket, GXPacketStatus
+from tardis.energy_input.transport.GXPacket import (
+    GXPacket,
+    GXPacketCollection,
+    GXPacketStatus,
+)
 from tardis.energy_input.util import ELECTRON_MASS_ENERGY_KEV, H_CGS_KEV
 
 RTOL = 1.0e-12
@@ -42,6 +46,23 @@ def gamma_packet(basic_gamma_ray: GXPacket, set_seed_fixture) -> GXPacket:
     basic_gamma_ray.time_start = 1.2e5
     basic_gamma_ray.time_idx = 0
     return basic_gamma_ray
+
+
+@pytest.fixture
+def gamma_packet_collection(gamma_packet: GXPacket) -> GXPacketCollection:
+    return GXPacketCollection(
+        gamma_packet.location[:, np.newaxis].copy(),
+        gamma_packet.direction[:, np.newaxis].copy(),
+        np.array([gamma_packet.energy_rf]),
+        np.array([gamma_packet.energy_cmf]),
+        np.array([gamma_packet.nu_rf]),
+        np.array([gamma_packet.nu_cmf]),
+        np.array([gamma_packet.status], dtype=np.int64),
+        np.array([gamma_packet.shell], dtype=np.int64),
+        np.array([gamma_packet.time_start]),
+        np.array([gamma_packet.time_idx], dtype=np.int64),
+        np.array(["Ni56"], dtype="<U16"),
+    )
 
 
 @pytest.fixture
@@ -345,14 +366,14 @@ def test_gamma_process_packet_path_compton(
 
 
 def test_gamma_packet_loop_negative_time_index(
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
 ) -> None:
-    gamma_packet.time_idx = -1
+    gamma_packet_collection.time_index[0] = -1
 
     with pytest.raises(ValueError, match="Packet time index less than 0!"):
         gamma_packet_loop(
-            [gamma_packet],
+            gamma_packet_collection,
             -1.0,
             "tardis",
             "artis",
@@ -362,7 +383,7 @@ def test_gamma_packet_loop_negative_time_index(
 
 @pytest.mark.parametrize("grey_opacity", [-1.0, 0.1])
 def test_gamma_packet_loop_escape_binning(
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     grey_opacity: float,
     set_seed_fixture,
@@ -376,9 +397,8 @@ def test_gamma_packet_loop_escape_binning(
             "for grey opacity."
         )
 
-    packet = gamma_packet
-    packet.location = np.array([1.9e14, 0.0, 0.0])
-    packet.direction = np.array([1.0, 0.0, 0.0])
+    gamma_packet_collection.location[:, 0] = np.array([1.9e14, 0.0, 0.0])
+    gamma_packet_collection.direction[:, 0] = np.array([1.0, 0.0, 0.0])
     set_seed_fixture(1963)
 
     (
@@ -388,16 +408,15 @@ def test_gamma_packet_loop_escape_binning(
         energy_deposited_gamma,
         total_energy,
     ) = gamma_packet_loop(
-        [packet],
+        gamma_packet_collection,
         grey_opacity,
         "kasen",
         "artis",
         **gamma_loop_arrays,
     )
 
-    assert packet.status == GXPacketStatus.ESCAPED
-    assert packet.shell == 1
     assert packets_info_array[0, 1] == GXPacketStatus.ESCAPED
+    assert packets_info_array[0, 7] == 1
     sync_ndarray_assert_allclose(
         regression_data,
         energy_out[1, 0],
@@ -411,16 +430,15 @@ def test_gamma_packet_loop_escape_binning(
 
 
 def test_gamma_packet_loop_tardis_opacity(
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     set_seed_fixture,
     regression_data,
 ) -> None:
     # Put the packet just inside the outer boundary so the TARDIS opacity path
     # reaches escape binning deterministically.
-    packet = gamma_packet
-    packet.location = np.array([1.9e14, 0.0, 0.0])
-    packet.direction = np.array([1.0, 0.0, 0.0])
+    gamma_packet_collection.location[:, 0] = np.array([1.9e14, 0.0, 0.0])
+    gamma_packet_collection.direction[:, 0] = np.array([1.0, 0.0, 0.0])
     set_seed_fixture(1963)
 
     (
@@ -430,14 +448,13 @@ def test_gamma_packet_loop_tardis_opacity(
         energy_deposited_gamma,
         total_energy,
     ) = gamma_packet_loop(
-        [packet],
+        gamma_packet_collection,
         -1.0,
         "tardis",
         "tardis",
         **gamma_loop_arrays,
     )
 
-    assert packet.status == GXPacketStatus.ESCAPED
     assert packets_info_array[0, 1] == GXPacketStatus.ESCAPED
     sync_ndarray_assert_allclose(
         regression_data,
@@ -457,7 +474,7 @@ def test_gamma_packet_loop_tardis_opacity(
     ],
 )
 def test_gamma_packet_loop_invalid_opacity_type(
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     photoabsorption_opacity_type: str,
     pair_creation_opacity_type: str,
@@ -465,7 +482,7 @@ def test_gamma_packet_loop_invalid_opacity_type(
 ) -> None:
     with pytest.raises(ValueError, match=match):
         gamma_packet_loop(
-            [gamma_packet],
+            gamma_packet_collection,
             -1.0,
             photoabsorption_opacity_type,
             pair_creation_opacity_type,
@@ -476,12 +493,11 @@ def test_gamma_packet_loop_invalid_opacity_type(
 def test_gamma_packet_loop_time_boundary_end_numba_disabled(
     monkeypatch,
     python_numba_disabled,
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     regression_data,
 ) -> None:
-    packet = gamma_packet
-    packet.time_idx = 1
+    gamma_packet_collection.time_index[0] = 1
 
     # Force the time-boundary branch without depending on sampled distances.
     monkeypatch.setattr(
@@ -492,15 +508,15 @@ def test_gamma_packet_loop_time_boundary_end_numba_disabled(
 
     with pytest.raises(UnboundLocalError):
         gamma_packet_loop(
-            [packet],
+            gamma_packet_collection,
             -1.0,
             "kasen",
             "artis",
             **gamma_loop_arrays,
         )
 
-    assert packet.status == GXPacketStatus.END
-    assert packet.shell == 0
+    assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
+    assert gamma_packet_collection.shell[0] == 0
     sync_ndarray_assert_allclose(
         regression_data,
         gamma_loop_arrays["energy_deposited_gamma"],
@@ -512,12 +528,10 @@ def test_gamma_packet_loop_time_boundary_end_numba_disabled(
 def test_gamma_packet_loop_inner_boundary_end_numba_disabled(
     monkeypatch,
     python_numba_disabled,
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     regression_data,
 ) -> None:
-    packet = gamma_packet
-
     # Force the inner-boundary branch without depending on sampled distances.
     monkeypatch.setattr(
         gamma_loop_module,
@@ -527,19 +541,17 @@ def test_gamma_packet_loop_inner_boundary_end_numba_disabled(
 
     with pytest.raises(UnboundLocalError):
         gamma_packet_loop(
-            [packet],
+            gamma_packet_collection,
             -1.0,
             "kasen",
             "artis",
             **gamma_loop_arrays,
         )
 
-    assert packet.status == GXPacketStatus.END
-    assert packet.shell == -1
+    assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
+    assert gamma_packet_collection.shell[0] == 0
     sync_ndarray_assert_allclose(
         regression_data,
-        packet.energy_rf,
-        packet.energy_cmf,
         gamma_loop_arrays["energy_deposited_gamma"],
         gamma_loop_arrays["total_energy"],
         rtol=RTOL,
@@ -549,12 +561,10 @@ def test_gamma_packet_loop_inner_boundary_end_numba_disabled(
 def test_gamma_packet_loop_interaction_deposition_numba_disabled(
     monkeypatch,
     python_numba_disabled,
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     regression_data,
 ) -> None:
-    packet = gamma_packet
-
     # Force an immediate photoabsorption interaction to characterize deposition
     # bookkeeping in the loop.
     monkeypatch.setattr(
@@ -570,7 +580,7 @@ def test_gamma_packet_loop_interaction_deposition_numba_disabled(
 
     _, _, packets_info_array, energy_deposited_gamma, total_energy = (
         gamma_packet_loop(
-            [packet],
+            gamma_packet_collection,
             -1.0,
             "kasen",
             "artis",
@@ -578,7 +588,8 @@ def test_gamma_packet_loop_interaction_deposition_numba_disabled(
         )
     )
 
-    assert packet.status == GXPacketStatus.PHOTOABSORPTION
+    assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
+    assert packets_info_array[0, 1] == GXPacketStatus.PHOTOABSORPTION
     sync_ndarray_assert_allclose(
         regression_data,
         energy_deposited_gamma,
@@ -591,11 +602,10 @@ def test_gamma_packet_loop_interaction_deposition_numba_disabled(
 def test_gamma_packet_loop_scattered_escape_numba_disabled(
     monkeypatch,
     python_numba_disabled,
-    gamma_packet: GXPacket,
+    gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],
     regression_data,
 ) -> None:
-    packet = gamma_packet
     distances_to_return = [
         # First loop step: interaction distance wins.
         (1.0, 20.0, 10.0, 0),
@@ -635,14 +645,14 @@ def test_gamma_packet_loop_scattered_escape_numba_disabled(
 
     with pytest.raises(UnboundLocalError):
         gamma_packet_loop(
-            [packet],
+            gamma_packet_collection,
             -1.0,
             "kasen",
             "artis",
             **gamma_loop_arrays,
         )
 
-    assert packet.status == GXPacketStatus.IN_PROCESS
+    assert gamma_packet_collection.status[0] == GXPacketStatus.IN_PROCESS
     sync_ndarray_assert_allclose(
         regression_data,
         gamma_loop_arrays["energy_deposited_gamma"],

--- a/tardis/energy_input/transport/tests/test_gamma_transport.py
+++ b/tardis/energy_input/transport/tests/test_gamma_transport.py
@@ -382,7 +382,7 @@ def test_gamma_packet_loop_negative_time_index(
         )
 
 
-@pytest.mark.parametrize("grey_opacity", [-1.0, 0.1])
+@pytest.mark.parametrize("grey_opacity", [-1.0, 1e-4])
 def test_gamma_packet_loop_escape_binning(
     gamma_packet_collection: GXPacketCollection,
     gamma_loop_arrays: dict[str, np.ndarray],

--- a/tardis/energy_input/util.py
+++ b/tardis/energy_input/util.py
@@ -97,7 +97,7 @@ def doppler_factor_3d(direction_vector, position_vector, time):
 
 
 @njit(**njit_dict_no_parallel)
-def doppler_factor_3D_all_packets(
+def doppler_factor_3d_all_packets(
     direction_vectors: npt.NDArray[np.float64],
     position_vectors: npt.NDArray[np.float64],
     times: npt.NDArray[np.float64],
@@ -115,17 +115,12 @@ def doppler_factor_3D_all_packets(
     array
         Doppler factors
     """
-    no_of_packets = times.shape[0]
-    doppler_factors = np.empty(no_of_packets, dtype=np.float64)
-    for packet_idx in range(no_of_packets):
-        velocity_dot_direction = 0.0
-        for dimension_idx in range(3):
-            velocity_dot_direction += (
-                position_vectors[dimension_idx, packet_idx]
-                / times[packet_idx]
-                * direction_vectors[dimension_idx, packet_idx]
-            )
-        doppler_factors[packet_idx] = 1 - velocity_dot_direction / C_CGS
+    doppler_factors = position_vectors[0] * direction_vectors[0]
+    doppler_factors += position_vectors[1] * direction_vectors[1]
+    doppler_factors += position_vectors[2] * direction_vectors[2]
+    doppler_factors /= times
+    doppler_factors *= -1.0 / C_CGS
+    doppler_factors += 1.0
 
     return doppler_factors
 
@@ -270,7 +265,8 @@ def solve_quadratic_equation_expanding(position, direction, time, radius):
         - (radius / light_distance) ** 2.0
     )
     b = 2.0 * (
-        np.dot(position_contiguous, direction_contiguous) - radius**2.0 / light_distance
+        np.dot(position_contiguous, direction_contiguous)
+        - radius**2.0 / light_distance
     )
     c = np.dot(position_contiguous, position_contiguous) - radius**2.0
     discriminant = b**2.0 - 4.0 * a * c

--- a/tardis/energy_input/util.py
+++ b/tardis/energy_input/util.py
@@ -115,12 +115,9 @@ def doppler_factor_3d_all_packets(
     array
         Doppler factors
     """
-    doppler_factors = position_vectors[0] * direction_vectors[0]
-    doppler_factors += position_vectors[1] * direction_vectors[1]
-    doppler_factors += position_vectors[2] * direction_vectors[2]
-    doppler_factors /= times
-    doppler_factors *= -1.0 / C_CGS
-    doppler_factors += 1.0
+    velocity_vector = position_vectors / times
+    vel_mul_dir = np.multiply(velocity_vector, direction_vectors)
+    doppler_factors = 1 - (np.sum(vel_mul_dir, axis=0) / C_CGS)
 
     return doppler_factors
 

--- a/tardis/energy_input/util.py
+++ b/tardis/energy_input/util.py
@@ -1,5 +1,6 @@
 import astropy.units as u
 import numpy as np
+import numpy.typing as npt
 from numba import njit
 
 import tardis.constants as const
@@ -96,7 +97,11 @@ def doppler_factor_3d(direction_vector, position_vector, time):
 
 
 @njit(**njit_dict_no_parallel)
-def doppler_factor_3D_all_packets(direction_vectors, position_vectors, times):
+def doppler_factor_3D_all_packets(
+    direction_vectors: npt.NDArray[np.float64],
+    position_vectors: npt.NDArray[np.float64],
+    times: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
     """Doppler shift for photons in 3D
 
     Parameters
@@ -110,9 +115,17 @@ def doppler_factor_3D_all_packets(direction_vectors, position_vectors, times):
     array
         Doppler factors
     """
-    velocity_vector = position_vectors / times
-    vel_mul_dir = np.multiply(velocity_vector, direction_vectors)
-    doppler_factors = 1 - (np.sum(vel_mul_dir, axis=0) / C_CGS)
+    no_of_packets = times.shape[0]
+    doppler_factors = np.empty(no_of_packets, dtype=np.float64)
+    for packet_idx in range(no_of_packets):
+        velocity_dot_direction = 0.0
+        for dimension_idx in range(3):
+            velocity_dot_direction += (
+                position_vectors[dimension_idx, packet_idx]
+                / times[packet_idx]
+                * direction_vectors[dimension_idx, packet_idx]
+            )
+        doppler_factors[packet_idx] = 1 - velocity_dot_direction / C_CGS
 
     return doppler_factors
 

--- a/tardis/transport/montecarlo/packet_source/high_energy.py
+++ b/tardis/transport/montecarlo/packet_source/high_energy.py
@@ -12,7 +12,7 @@ from tardis.energy_input.transport.GXPacket import (
 )
 from tardis.energy_input.util import (
     H_CGS_KEV,
-    doppler_factor_3D_all_packets,
+    doppler_factor_3d_all_packets,
     get_random_unit_vectors,
 )
 from tardis.transport.montecarlo.packet_source.base import BasePacketSource
@@ -137,7 +137,9 @@ class GammaRayPacketSource(BasePacketSource):
         Uses the cube root method to ensure uniform distribution in volume:
         r^3 = z * r_inner^3 + (1-z) * r_outer^3, where z is uniform random [0,1].
         """
-        np.random.seed(self.base_seed + 2 if self.base_seed is not None else None)
+        np.random.seed(
+            self.base_seed + 2 if self.base_seed is not None else None
+        )
         z = np.random.random(len(inner_velocities))
         initial_velocities = (
             z * inner_velocities**3.0 + (1.0 - z) * outer_velocities**3.0
@@ -191,7 +193,9 @@ class GammaRayPacketSource(BasePacketSource):
         # annihilation line of positrons
         annihilation_line = radiation_energies_keV == POSITRON_ANNIHILATION_LINE
         # three photon decay of positronium
-        three_photon_decay = np.random.random(number_of_packets) > PARA_TO_ORTHO_RATIO
+        three_photon_decay = (
+            np.random.random(number_of_packets) > PARA_TO_ORTHO_RATIO
+        )
 
         energy_array[:] = radiation_energies_keV
 
@@ -240,7 +244,9 @@ class GammaRayPacketSource(BasePacketSource):
 
         return directions
 
-    def create_packet_energies(self, no_of_packets: int, energy: float) -> np.ndarray:
+    def create_packet_energies(
+        self, no_of_packets: int, energy: float
+    ) -> np.ndarray:
         """
         Create uniform packet energies for gamma ray packets.
 
@@ -305,7 +311,10 @@ class GammaRayPacketSource(BasePacketSource):
         return decay_times
 
     def create_packet_times_uniform_energy(
-        self, no_of_packets: np.ndarray, isotopes: pd.Series, decay_time: np.ndarray
+        self,
+        no_of_packets: np.ndarray,
+        isotopes: pd.Series,
+        decay_time: np.ndarray,
     ) -> np.ndarray:
         """
         Sample decay times from isotope mean lifetimes using rejection sampling.
@@ -474,13 +483,17 @@ class GammaRayPacketSource(BasePacketSource):
         locations = (
             initial_velocities
             * effective_decay_times
-            * self.create_packet_directions(number_of_packets, seed=self.base_seed)
+            * self.create_packet_directions(
+                number_of_packets, seed=self.base_seed
+            )
         )
 
         # sample directions (valid at all times), non-relativistic
         # the seed is changed to not have packets that are all going outwards as the
         # create_packet_directions method is also used for the location sampling
-        directions_seed = self.base_seed + 1 if self.base_seed is not None else None
+        directions_seed = (
+            self.base_seed + 1 if self.base_seed is not None else None
+        )
         directions = self.create_packet_directions(
             number_of_packets, seed=directions_seed
         )
@@ -498,7 +511,7 @@ class GammaRayPacketSource(BasePacketSource):
         packet_energies_cmf = self.create_packet_energies(
             number_of_packets, energy_per_packet
         )
-        doppler_factors = doppler_factor_3D_all_packets(
+        doppler_factors = doppler_factor_3d_all_packets(
             directions, locations, effective_decay_times
         )
 
@@ -589,6 +602,7 @@ def legacy_calculate_positron_fraction(
             isotope in positron_energy_per_isotope
         ):  # check if isotope is in the dataframe
             isotope_positron_fraction[i] = (
-                positron_energy_per_isotope[isotope] / gamma_energy_per_isotope[isotope]
+                positron_energy_per_isotope[isotope]
+                / gamma_energy_per_isotope[isotope]
             )
     return isotope_positron_fraction

--- a/tardis/transport/montecarlo/packet_source/high_energy.py
+++ b/tardis/transport/montecarlo/packet_source/high_energy.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -24,6 +23,7 @@ PARA_TO_ORTHO_RATIO = 0.25
 
 
 class GammaRayPacketSource(BasePacketSource):
+    """Packet source for gamma-ray transport packets."""
 
     def __init__(
         self,
@@ -34,7 +34,7 @@ class GammaRayPacketSource(BasePacketSource):
         outer_velocities: np.ndarray,
         times: np.ndarray,
         effective_times: np.ndarray,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
         """
         Initialize gamma ray packet source.
@@ -83,7 +83,9 @@ class GammaRayPacketSource(BasePacketSource):
         self.effective_times = effective_times
         super().__init__(**kwargs)
 
-    def create_packet_mus(self, no_of_packets: int, *args: Any, **kwargs: Any):
+    def create_packet_mus(
+        self, no_of_packets: int, *args: object, **kwargs: object
+    ) -> np.ndarray:
         """
         Create packet directional cosines.
 
@@ -206,7 +208,7 @@ class GammaRayPacketSource(BasePacketSource):
         return energy_array
 
     def create_packet_directions(
-        self, no_of_packets: int, seed: "int | None"
+        self, no_of_packets: int, seed: int | None
     ) -> np.ndarray:
         """
         Create random isotropic directions for packets.
@@ -356,7 +358,7 @@ class GammaRayPacketSource(BasePacketSource):
         self,
         cumulative_decays_df: pd.DataFrame,
         number_of_packets: int,
-        legacy_energy_per_packet: "float | None" = None,
+        legacy_energy_per_packet: float | None = None,
     ) -> GXPacketCollection:
         """
         Initialize a collection of gamma ray packets for simulation.
@@ -499,17 +501,17 @@ class GammaRayPacketSource(BasePacketSource):
         nus_rf = nus_cmf / doppler_factors
 
         return GXPacketCollection(
-            locations,
-            directions,
-            packet_energies_rf,
-            packet_energies_cmf,
-            nus_rf,
-            nus_cmf,
-            statuses,
-            shells,
-            effective_decay_times,
-            decay_time_indices,
-            source_isotopes=source_isotopes,
+            np.ascontiguousarray(locations, dtype=np.float64),
+            np.ascontiguousarray(directions, dtype=np.float64),
+            np.asarray(packet_energies_rf, dtype=np.float64),
+            np.asarray(packet_energies_cmf, dtype=np.float64),
+            np.asarray(nus_rf, dtype=np.float64),
+            np.asarray(nus_cmf, dtype=np.float64),
+            np.asarray(statuses, dtype=np.int64),
+            np.asarray(shells, dtype=np.int64),
+            np.asarray(effective_decay_times, dtype=np.float64),
+            np.asarray(decay_time_indices, dtype=np.int64),
+            source_isotopes=np.asarray(source_isotopes, dtype="<U16"),
         )
 
 

--- a/tardis/transport/montecarlo/packet_source/high_energy.py
+++ b/tardis/transport/montecarlo/packet_source/high_energy.py
@@ -1,6 +1,7 @@
 import logging
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from tardis.energy_input.samplers import (
@@ -107,7 +108,11 @@ class GammaRayPacketSource(BasePacketSource):
         """
         return super().create_packet_mus(no_of_packets, *args, **kwargs)
 
-    def create_packet_velocities(self, sampled_packets_df: pd.DataFrame) -> np.ndarray:
+    def create_packet_velocities(
+        self,
+        inner_velocities: npt.NDArray[np.float64],
+        outer_velocities: npt.NDArray[np.float64],
+    ) -> npt.NDArray[np.float64]:
         """
         Initialize random radial velocities for packets within shells.
 
@@ -116,15 +121,16 @@ class GammaRayPacketSource(BasePacketSource):
 
         Parameters
         ----------
-        sampled_packets_df : pd.DataFrame
-            DataFrame where each row represents a packet, containing
-            'inner_velocity' and 'outer_velocity' columns for shell boundaries.
+        inner_velocities : numpy.ndarray
+            Inner shell velocity for each packet [cm/s].
+        outer_velocities : numpy.ndarray
+            Outer shell velocity for each packet [cm/s].
 
         Returns
         -------
         np.ndarray
             Array of initial velocities [cm/s] with length equal to the number
-            of packets in sampled_packets_df.
+            of packets.
 
         Notes
         -----
@@ -132,20 +138,19 @@ class GammaRayPacketSource(BasePacketSource):
         r^3 = z * r_inner^3 + (1-z) * r_outer^3, where z is uniform random [0,1].
         """
         np.random.seed(self.base_seed + 2 if self.base_seed is not None else None)
-        z = np.random.random(len(sampled_packets_df))
+        z = np.random.random(len(inner_velocities))
         initial_velocities = (
-            z * sampled_packets_df["inner_velocity"] ** 3.0
-            + (1.0 - z) * sampled_packets_df["outer_velocity"] ** 3.0
+            z * inner_velocities**3.0 + (1.0 - z) * outer_velocities**3.0
         ) ** (1.0 / 3.0)
 
         return initial_velocities
 
     def create_packet_nus(
         self,
-        packets: pd.DataFrame,
+        radiation_energies_keV: npt.NDArray[np.float64],
         positronium_fraction: float,
         number_of_packets: int,
-    ) -> np.ndarray:
+    ) -> npt.NDArray[np.float64]:
         """
         Create packet frequency-energies accounting for positronium formation.
 
@@ -154,8 +159,8 @@ class GammaRayPacketSource(BasePacketSource):
 
         Parameters
         ----------
-        packets : pd.DataFrame
-            DataFrame containing packet information with 'radiation_energy_keV' column.
+        radiation_energies_keV : numpy.ndarray
+            Radiation-line energy for each packet [keV].
         positronium_fraction : float
             Fraction of positrons that form positronium (0.0 to 1.0).
             Default is 0.0 for no positronium formation.
@@ -179,20 +184,16 @@ class GammaRayPacketSource(BasePacketSource):
         """
         energy_array = np.zeros(number_of_packets)
 
-        all_packets = np.array([True] * number_of_packets)
-
         # positronium formation if fraction is greater than zero
         positronium_formation = (
             np.random.uniform(0, 1, number_of_packets) < positronium_fraction
         )
         # annihilation line of positrons
-        annihilation_line = packets["radiation_energy_keV"] == POSITRON_ANNIHILATION_LINE
+        annihilation_line = radiation_energies_keV == POSITRON_ANNIHILATION_LINE
         # three photon decay of positronium
         three_photon_decay = np.random.random(number_of_packets) > PARA_TO_ORTHO_RATIO
 
-        energy_array[all_packets] = packets.loc[
-            all_packets, "radiation_energy_keV"
-        ]
+        energy_array[:] = radiation_energies_keV
 
         energy_array[
             positronium_formation & annihilation_line & three_photon_decay
@@ -425,45 +426,45 @@ class GammaRayPacketSource(BasePacketSource):
         logger.info("Total energy in gamma-rays is %s", total_energy_gamma)
         logger.info("Energy per packet is %s", energy_per_packet)
 
-        # initialize arrays for most packet properties
-        locations = np.zeros((3, number_of_packets))
-        directions = np.zeros((3, number_of_packets))
-        packet_energies_rf = np.zeros(number_of_packets)
-        packet_energies_cmf = np.zeros(number_of_packets)
-        nus_rf = np.zeros(number_of_packets)
-        nus_cmf = np.zeros(number_of_packets)
-        statuses = np.ones(number_of_packets, dtype=np.int64) * 3
+        statuses = np.full(number_of_packets, 3, dtype=np.int64)
         self._reseed(self.base_seed + 3)
         packet_seeds = self.rng.choice(
             self.MAX_SEED_VAL, number_of_packets, replace=True
         )
 
         # sample packets from the gamma-ray lines only (include X-rays!)
-        sampled_packets_df_gamma = cumulative_decays_df[
-            cumulative_decays_df["radiation"] == "g"
-        ]
-
-        # sample packets from the time evolving dataframe
-        sampled_packets_df = sampled_packets_df_gamma.sample(
-            n=number_of_packets,
-            weights="decay_energy_erg",
+        gamma_mask = (cumulative_decays_df["radiation"] == "g").to_numpy()
+        gamma_decay_energies = cumulative_decays_df.loc[
+            gamma_mask, "decay_energy_erg"
+        ].to_numpy()
+        sampling_probabilities = (
+            gamma_decay_energies / gamma_decay_energies.sum()
+        )
+        sampled_gamma_row_idxs = np.random.RandomState(self.base_seed).choice(
+            len(gamma_decay_energies),
+            size=number_of_packets,
             replace=True,
-            random_state=np.random.RandomState(self.base_seed),
+            p=sampling_probabilities,
         )
 
-        # get the isotopes and shells of the sampled packets
-        source_isotopes = sampled_packets_df.index.get_level_values("isotope")
-        shells = sampled_packets_df.index.get_level_values("shell_number")
-
-        # get the inner and outer velocity boundaries for each packet to compute
-        sampled_packets_df["inner_velocity"] = self.inner_velocities[shells]
-        sampled_packets_df["outer_velocity"] = self.outer_velocities[shells]
+        gamma_index = cumulative_decays_df.index[gamma_mask]
+        source_isotopes = gamma_index.get_level_values("isotope").to_numpy()[
+            sampled_gamma_row_idxs
+        ]
+        shells = gamma_index.get_level_values("shell_number").to_numpy()[
+            sampled_gamma_row_idxs
+        ]
+        decay_time_indices = gamma_index.get_level_values(
+            "time_index"
+        ).to_numpy()[sampled_gamma_row_idxs]
+        radiation_energies_keV = cumulative_decays_df.loc[
+            gamma_mask, "radiation_energy_keV"
+        ].to_numpy()[sampled_gamma_row_idxs]
 
         # The radii of the packets at what ever time they are emitted
-        initial_velocities = self.create_packet_velocities(sampled_packets_df)
-
-        # get the time step index of the packets
-        decay_time_indices = sampled_packets_df.index.get_level_values("time_index")
+        initial_velocities = self.create_packet_velocities(
+            self.inner_velocities[shells], self.outer_velocities[shells]
+        )
 
         effective_decay_times = self.times[decay_time_indices]
 
@@ -471,7 +472,7 @@ class GammaRayPacketSource(BasePacketSource):
         # Geometry object calculations. Note that this also adds a random
         # unit vector multiplication for 3D. May not be needed.
         locations = (
-            initial_velocities.values
+            initial_velocities
             * effective_decay_times
             * self.create_packet_directions(number_of_packets, seed=self.base_seed)
         )
@@ -487,7 +488,7 @@ class GammaRayPacketSource(BasePacketSource):
         # the individual gamma-ray energy that makes up a packet
         # co-moving frame, including positronium formation
         nu_energies_cmf = self.create_packet_nus(
-            sampled_packets_df,
+            radiation_energies_keV,
             self.positronium_fraction,
             number_of_packets,
         )
@@ -497,9 +498,6 @@ class GammaRayPacketSource(BasePacketSource):
         packet_energies_cmf = self.create_packet_energies(
             number_of_packets, energy_per_packet
         )
-        packet_energies_rf = np.zeros(number_of_packets)
-        nus_rf = np.zeros(number_of_packets)
-
         doppler_factors = doppler_factor_3D_all_packets(
             directions, locations, effective_decay_times
         )

--- a/tardis/transport/montecarlo/packet_source/high_energy.py
+++ b/tardis/transport/montecarlo/packet_source/high_energy.py
@@ -419,6 +419,9 @@ class GammaRayPacketSource(BasePacketSource):
             energy_per_packet = legacy_energy_per_packet
             total_energy_gamma = number_of_packets * legacy_energy_per_packet
 
+        if self.base_seed is None:
+            raise ValueError("base_seed must be set before creating packets")
+
         logger.info("Total energy in gamma-rays is %s", total_energy_gamma)
         logger.info("Energy per packet is %s", energy_per_packet)
 
@@ -430,6 +433,10 @@ class GammaRayPacketSource(BasePacketSource):
         nus_rf = np.zeros(number_of_packets)
         nus_cmf = np.zeros(number_of_packets)
         statuses = np.ones(number_of_packets, dtype=np.int64) * 3
+        self._reseed(self.base_seed + 3)
+        packet_seeds = self.rng.choice(
+            self.MAX_SEED_VAL, number_of_packets, replace=True
+        )
 
         # sample packets from the gamma-ray lines only (include X-rays!)
         sampled_packets_df_gamma = cumulative_decays_df[
@@ -512,6 +519,7 @@ class GammaRayPacketSource(BasePacketSource):
             np.asarray(effective_decay_times, dtype=np.float64),
             np.asarray(decay_time_indices, dtype=np.int64),
             source_isotopes=np.asarray(source_isotopes, dtype="<U16"),
+            packet_seeds=np.asarray(packet_seeds, dtype=np.int64),
         )
 
 

--- a/tardis/workflows/high_energy/tardis_he_workflow.py
+++ b/tardis/workflows/high_energy/tardis_he_workflow.py
@@ -31,6 +31,8 @@ class TARDISHEWorkflow:
                 configuration, atom_data
             )
 
+        self.nthreads = configuration.montecarlo.nthreads
+
         self.gamma_ray_lines = atom_data.decay_radiation_data
 
         self.shell_masses = self.simulation_state.volume * self.simulation_state.density
@@ -190,6 +192,7 @@ class TARDISHEWorkflow:
             seed=seed,
             positronium_fraction=fp,
             spectrum_bins=spectrum_bins,
+            nthreads=self.nthreads,
             grey_opacity=grey_opacity,
             legacy=legacy,
             legacy_atom_data=legacy_atom_data,

--- a/tardis/workflows/high_energy/tests/test_tardis_he_workflow.py
+++ b/tardis/workflows/high_energy/tests/test_tardis_he_workflow.py
@@ -1,6 +1,10 @@
 import pytest
 from numpy.testing import assert_allclose
 
+from tardis.transport.montecarlo.progress_bars import (
+    packet_pbar,
+    reset_packet_pbar,
+)
 from tardis.workflows.high_energy.tardis_he_workflow import TARDISHEWorkflow
 
 
@@ -31,6 +35,20 @@ def he_workflow_minimal_run_params(atomic_dataset):
 def he_workflow_result(he_workflow_instance_session, he_workflow_minimal_run_params):
     """Run the HE workflow once and cache the result for multiple tests."""
     return he_workflow_instance_session.run(**he_workflow_minimal_run_params)
+
+
+def test_he_workflow_initializes_packet_progress_bar(
+    he_workflow_instance_session: TARDISHEWorkflow,
+    he_workflow_minimal_run_params: dict[str, object],
+) -> None:
+    """Initialize packet progress for each HE transport run."""
+    run_params = he_workflow_minimal_run_params | {"number_of_packets": 10}
+    reset_packet_pbar(1)
+
+    he_workflow_instance_session.run(**run_params)
+
+    assert packet_pbar.total == run_params["number_of_packets"]
+    assert packet_pbar.n == run_params["number_of_packets"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### :pencil: Description

Based on ideas in #3228, moves the gamma-ray transport closer to classic TARDIS. Note that this requires seeding packets differently, so it breaks regression data. However, the actual spectra are very similar, relative difference notwithstanding..

Requires https://github.com/tardis-sn/tardis-regression-data/pull/115 now


### :pushpin: Resources

<img width="2600" height="1600" alt="image" src="https://github.com/user-attachments/assets/4c411ec7-c15c-46f5-bdd1-68101dc7ddf4" />

<img width="2600" height="1600" alt="image" src="https://github.com/user-attachments/assets/a8166665-f1dd-4df6-a81e-31674fc8e733" />


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
