### PR TITLE
fix(visualization): align density array length in CustomAbundanceWidgetData.from_yml

### DIFF
--- a/tardis/visualization/widgets/custom_abundance.py
+++ b/tardis/visualization/widgets/custom_abundance.py
@@ -215,6 +215,8 @@ class CustomAbundanceWidgetData:
         velocity = simulation_state.velocity
         density_t_0 = simulation_state.time_explosion
         density = simulation_state.density
+        if len(density) == len(velocity) - 1:
+            density = np.insert(density, 0, density[0]) * density.unit
         abundance = simulation_state.abundance
         isotopic_mass_fraction = (
             simulation_state.composition.isotopic_mass_fraction
@@ -293,6 +295,8 @@ class CustomAbundanceWidgetData:
         velocity = sim.simulation_state.velocity
         density_t_0 = sim.simulation_state.time_explosion
         density = sim.simulation_state.density
+        if len(density) == len(velocity) - 1:
+            density = np.insert(density, 0, density[0]) * density.unit
 
         return cls(
             density_t_0=density_t_0,


### PR DESCRIPTION
### Problem
When constructing `CustomAbundanceWidget` from a YAML file via `from_yml()`, `simulation_state.density` contains $ shell values whereas `simulation_state.velocity` has +1$ boundaries. In `CustomAbundanceWidget.from_csvy()`, the density array is sized to match velocity, but `from_yml()` passed the raw 569Xlength density array. As a result:
1. The last density point was missing in the plot.
2. Clicking **Add Shell** in `on_btn_add_shell()` triggered `ValueError: fp and xp are not of the same length` during interpolation.

### Solution
In `CustomAbundanceWidgetData.from_yml()`, check if `len(density) == len(velocity) - 1` and append `density[-1]` to ensure equal lengths across `velocity` and `density`, matching the expected contract across all widget loaders.

Fixes #3666