### PR TITLE
Fix Panel communication modes for logger widgets

### DIFF
--- a/tardis/io/logger/tests/test_panel_init.py
+++ b/tardis/io/logger/tests/test_panel_init.py
@@ -1,0 +1,31 @@
+"""Tests for Panel communication initialization used by logger widgets."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from tardis.util import panel_init
+
+
+def test_notebook_uses_default_panel_comms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep standard notebooks on Panel's default communication backend."""
+    extension = Mock()
+    monkeypatch.setattr(panel_init.pn, "extension", extension)
+
+    panel_init.notebook()
+
+    extension.assert_called_once_with()
+
+
+def test_vscode_uses_vscode_panel_comms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep VS Code widgets on Panel's VS Code communication backend."""
+    extension = Mock()
+    monkeypatch.setattr(panel_init.pn, "extension", extension)
+
+    panel_init.vscode()
+
+    extension.assert_called_once_with(comms="vscode")

--- a/tardis/util/panel_init.py
+++ b/tardis/util/panel_init.py
@@ -14,13 +14,13 @@ def ssh_jh():
     """Initialize panel for JupyterHub (colab comms)"""
     pn.extension(comms="ipywidgets")
 
-def notebook():
+def notebook() -> None:
     """Initialize panel for standard Jupyter notebook (default comms)"""
-    pn.extension(comms="ipywidgets")
+    pn.extension()
 
-def vscode():
-    """Initialize panel for VSCode (ipywidgets comms)"""
-    pn.extension(comms="ipywidgets")
+def vscode() -> None:
+    """Initialize panel for VSCode (VS Code comms)"""
+    pn.extension(comms="vscode")
 
 def vscode_noipy():
     """Initialize panel for VSCode without ipywidgets (vscode comms)"""


### PR DESCRIPTION
## Description

Fixes #3672 by keeping standard notebooks on Panel's default communication backend and using Panel's VS Code backend in VS Code. This prevents TARDIS logger initialization from globally selecting the ipywidgets backend for later widgets.

## Testing

- Added focused tests for the notebook and VS Code Panel initialization calls.
- Not run: conda run --no-capture-output -n tardis pytest tardis/io/logger/tests/test_panel_init.py. This machine has no tardis Conda environment, and WSL is unavailable because virtualization is disabled.
- git diff --check passed before commit.

## AI/LLM disclosure

Codex was used for issue triage and implementation assistance. Before marking this PR ready for review, the human contributor must review the change, understand the Panel-backend behavior it changes, and disclose this assistance to their mentor as required by the TARDIS AI/LLM policy.