### PR TITLE
[GSoC] Allow reusing configuration HDF output

### DIFF
--- a/docs/io/hdf/index.rst
+++ b/docs/io/hdf/index.rst
@@ -15,6 +15,25 @@ What is HDF5?
 In TARDIS, it is used to store the data from simulations and other actions.
 
 
+Configuration output
+--------------------
+
+The ``/simulation/config`` dataset stores the configuration used for a
+simulation as YAML. The stored configuration can be read and validated again:
+
+.. code-block:: python
+
+   import pandas as pd
+   import yaml
+
+   from tardis.io.configuration.config_reader import Configuration
+   from tardis.io.util import YAMLLoader
+
+   serialized_config = pd.read_hdf("simulation.h5", key="/simulation/config")[0]
+   config_dict = yaml.load(serialized_config, Loader=YAMLLoader)
+   config = Configuration.from_config_dict(config_dict)
+
+
 HDF5 structure
 --------------
 

--- a/tardis/io/configuration/config_reader.py
+++ b/tardis/io/configuration/config_reader.py
@@ -197,8 +197,17 @@ class ConfigWriterMixin(HDFWriterMixin):
     Overrides HDFWriterMixin to obtain HDF properties from configuration keys
     """
 
-    def get_properties(self):
-        data = yaml.dump(self)
+    def get_properties(self) -> pd.DataFrame:
+        """Return the configuration output stored in simulation HDF files.
+
+        Returns
+        -------
+        pandas.DataFrame
+            A single-row table containing the YAML configuration output.
+        """
+        configuration_output = dict(self)
+        configuration_output.pop("config_dirname", None)
+        data = yaml.dump(configuration_output)
         data = pd.DataFrame(index=[0], data={"config": data})
         return data
 

--- a/tardis/io/configuration/tests/test_config_reader.py
+++ b/tardis/io/configuration/tests/test_config_reader.py
@@ -1,6 +1,7 @@
 # tests for the config reader module
 import pandas as pd
 import pytest
+import yaml
 from astropy.units import Quantity
 from jsonschema.exceptions import ValidationError
 from numpy.testing import assert_almost_equal
@@ -82,6 +83,18 @@ def test_config_hdf(hdf_file_path, tardis_config_verysimple):
     actual = pd.read_hdf(hdf_file_path, key="/simulation/config")
     expected = expected.get_properties()["config"]
     assert actual[0] == expected[0]
+
+
+def test_config_hdf_output_can_be_read_as_configuration(
+    hdf_file_path, tardis_config_verysimple
+):
+    config = Configuration.from_config_dict(tardis_config_verysimple)
+    config.to_hdf(hdf_file_path, overwrite=True)
+
+    serialized_config = pd.read_hdf(hdf_file_path, key="/simulation/config")[0]
+    output_config = yaml.load(serialized_config, Loader=config_reader.YAMLLoader)
+
+    Configuration.from_config_dict(output_config)
 
 
 def test_model_section_config(tardis_config_verysimple):


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #2654.

Configuration HDF output included the runtime-only `config_dirname` key,
which is not accepted by the input schema. Exclude it from
`/simulation/config` and add regression coverage for parsing HDF output back into a `Configuration`.

### :pushpin: Resources

N/A

### :vertical_traffic_light: Testing

- [x] `conda run --no-capture-output -n tardis pytest tardis/io/configuration/tests/test_config_reader.py -q`
- [x] `conda run --no-capture-output -n tardis pytest tardis -q`
- [x] Direct HDF configuration-output round trip.
- [ ] Documentation build/preview — not run.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request.
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.

### :robot: AI Usage Statement

OpenAI Codex was used to inspect the configuration serialization path and draft
code changes. The human contributor reviewed all AI-assisted changes, fully
understanding them.