### PR TITLE
Example refactor of transport with a physics-driven approach

### DIFF
--- a/tardis/transport/montecarlo/configuration/base.py
+++ b/tardis/transport/montecarlo/configuration/base.py
@@ -9,7 +9,6 @@ from tardis.transport.montecarlo.interaction_events import (
 )
 
 numba_config_spec = [
-    ("ENABLE_FULL_RELATIVITY", boolean),
     ("TEMPORARY_V_PACKET_BINS", int64),
     ("NUMBER_OF_VPACKETS", int64),
     ("MONTECARLO_SEED", int64),
@@ -30,7 +29,6 @@ numba_config_spec = [
 @jitclass(numba_config_spec)
 class MonteCarloConfiguration:
     def __init__(self):
-        self.ENABLE_FULL_RELATIVITY = False
         self.TEMPORARY_V_PACKET_BINS = 0
         self.NUMBER_OF_VPACKETS = 0
         self.MONTECARLO_SEED = 0
@@ -64,7 +62,6 @@ def configuration_initialize(config, transport, number_of_vpackets):
         )
     config.NUMBER_OF_VPACKETS = number_of_vpackets
     config.TEMPORARY_V_PACKET_BINS = number_of_vpackets
-    config.ENABLE_FULL_RELATIVITY = transport.enable_full_relativity
     config.MONTECARLO_SEED = transport.packet_source.base_seed
     config.VPACKET_SPAWN_START_FREQUENCY = transport.vpacket_spawn_range.end.to(
         u.Hz, equivalencies=u.spectral()

--- a/tardis/transport/montecarlo/modes/classic/packet_propagation.py
+++ b/tardis/transport/montecarlo/modes/classic/packet_propagation.py
@@ -2,7 +2,6 @@
 
 from numba import njit
 
-from tardis import constants as const
 from tardis.model.geometry.radial1d_homologous import (
     NumbaHomologousRadial1DGeometry,
 )
@@ -10,7 +9,6 @@ from tardis.opacities.opacities import chi_electron_calculator
 from tardis.opacities.opacity_state_numba import OpacityStateNumba
 from tardis.transport.frame_transformations import (
     get_doppler_factor,
-    get_inverse_doppler_factor,
 )
 from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
@@ -31,6 +29,7 @@ from tardis.transport.montecarlo.modes.homologous_rad_packet_transport import (
     trace_packet,
 )
 from tardis.transport.montecarlo.packets.movement import (
+    initialize_packet_frame,
     move_packet_across_shell_boundary,
     move_r_packet,
 )
@@ -46,20 +45,18 @@ from tardis.transport.montecarlo.packets.virtual_packet import (
     trace_vpacket_volley,
 )
 
-C_SPEED_OF_LIGHT = const.c.to("cm/s").value
-
 
 @njit
 def packet_propagation(
     r_packet: RPacket,
     geometry: NumbaHomologousRadial1DGeometry,
-    time_explosion: float,
     opacity_state: OpacityStateNumba,
     estimators_bulk: EstimatorsBulk,
     estimators_line: EstimatorsLine,
     vpacket_collection: VPacketCollection,
-    rpacket_tracker,
+    rpacket_tracker: object,
     montecarlo_configuration: MonteCarloConfiguration,
+    enable_full_relativity: bool,
 ) -> None:
     """
     Execute Monte Carlo transport for a single radiative packet in classic mode.
@@ -73,8 +70,6 @@ def packet_propagation(
         The radiative packet to transport through the ejecta.
     geometry : NumbaHomologousRadial1DGeometry
         The spherically symmetric geometry of the supernova ejecta.
-    time_explosion : float
-        Time since explosion in seconds.
     opacity_state : OpacityStateNumba
         Current opacity state containing line opacities.
     estimators_bulk : EstimatorsBulk
@@ -87,23 +82,22 @@ def packet_propagation(
         Tracker for recording packet interactions and trajectories.
     montecarlo_configuration : MonteCarloConfiguration
         Configuration parameters for the Monte Carlo simulation.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
 
-    Returns
-    -------
-    None
-        This function modifies the r_packet object in-place and updates
-        estimators and collections.
     """
+    time_explosion = geometry.time_explosion
     line_interaction_type = montecarlo_configuration.LINE_INTERACTION_TYPE
 
-    if montecarlo_configuration.ENABLE_FULL_RELATIVITY:
-        set_packet_props_full_relativity(r_packet, time_explosion)
-    else:
-        set_packet_props_partial_relativity(r_packet, time_explosion)
+    initialize_packet_frame(
+        r_packet,
+        geometry,
+        enable_full_relativity,
+    )
     r_packet.initialize_line_id(
         opacity_state,
         time_explosion,
-        montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+        enable_full_relativity,
     )
 
     trace_vpacket_volley(
@@ -112,7 +106,7 @@ def packet_propagation(
         geometry,
         time_explosion,
         opacity_state,
-        montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+        enable_full_relativity,
         montecarlo_configuration.VPACKET_TAU_RUSSIAN,
         montecarlo_configuration.SURVIVAL_PROBABILITY,
     )
@@ -128,7 +122,7 @@ def packet_propagation(
         doppler_factor = get_doppler_factor(
             velocity,
             r_packet.mu,
-            montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+            enable_full_relativity,
         )
 
         comov_nu = r_packet.nu * doppler_factor
@@ -136,7 +130,7 @@ def packet_propagation(
             opacity_state, comov_nu, r_packet.current_shell_id
         )
 
-        if montecarlo_configuration.ENABLE_FULL_RELATIVITY:
+        if enable_full_relativity:
             opacity_electron *= doppler_factor
 
         distance, interaction_type, delta_shell = trace_packet(
@@ -148,7 +142,7 @@ def packet_propagation(
             opacity_electron,
             1.0,
             False,
-            montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+            enable_full_relativity,
             montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
 
@@ -158,7 +152,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_boundary_event(
                 r_packet,
@@ -178,7 +172,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
 
             rpacket_tracker.track_line_interaction_before(r_packet)
@@ -188,7 +182,7 @@ def packet_propagation(
                 time_explosion,
                 line_interaction_type,
                 opacity_state,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_line_interaction_after(r_packet)
             trace_vpacket_volley(
@@ -197,7 +191,7 @@ def packet_propagation(
                 geometry,
                 time_explosion,
                 opacity_state,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
                 montecarlo_configuration.VPACKET_TAU_RUSSIAN,
                 montecarlo_configuration.SURVIVAL_PROBABILITY,
             )
@@ -208,13 +202,13 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_escattering_interaction_before(r_packet)
             thomson_scatter(
                 r_packet,
                 time_explosion,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_escattering_interaction_after(r_packet)
 
@@ -224,7 +218,7 @@ def packet_propagation(
                 geometry,
                 time_explosion,
                 opacity_state,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
                 montecarlo_configuration.VPACKET_TAU_RUSSIAN,
                 montecarlo_configuration.SURVIVAL_PROBABILITY,
             )
@@ -249,70 +243,3 @@ def packet_propagation(
         from_shell_id=r_packet.current_shell_id,
         to_shell_id=r_packet.current_shell_id + 1,
     )
-
-
-@njit
-def set_packet_props_partial_relativity(
-    r_packet: RPacket, time_explosion: float
-) -> None:
-    """
-    Set packet properties using partial relativistic corrections.
-
-    This function applies inverse Doppler corrections to the packet frequency
-    and energy based on partial relativistic treatment (first-order in v/c).
-
-    Parameters
-    ----------
-    r_packet
-        The radiative packet whose properties will be modified.
-    time_explosion
-        Time since explosion in seconds, used to calculate velocity.
-
-    Returns
-    -------
-    Modifies r_packet.nu and r_packet.energy in-place.
-    """
-    velocity = r_packet.r / time_explosion
-    inverse_doppler_factor = get_inverse_doppler_factor(
-        velocity,
-        r_packet.mu,
-        enable_full_relativity=False,
-    )
-    r_packet.nu *= inverse_doppler_factor
-    r_packet.energy *= inverse_doppler_factor
-
-
-@njit
-def set_packet_props_full_relativity(
-    r_packet: RPacket, time_explosion: float
-) -> None:
-    """
-    Set packet properties using full relativistic corrections.
-
-    This function applies inverse Doppler corrections to the packet frequency,
-    energy, and direction cosine based on full relativistic treatment, including
-    aberration effects on the direction cosine.
-
-    Parameters
-    ----------
-    r_packet
-        The radiative packet whose properties will be modified.
-    time_explosion
-        Time since explosion in seconds, used to calculate velocity.
-
-    Returns
-    -------
-    Modifies r_packet.nu, r_packet.energy, and r_packet.mu in-place.
-    """
-    beta = (r_packet.r / time_explosion) / C_SPEED_OF_LIGHT
-
-    velocity = r_packet.r / time_explosion
-    inverse_doppler_factor = get_inverse_doppler_factor(
-        velocity,
-        r_packet.mu,
-        enable_full_relativity=True,
-    )
-
-    r_packet.nu *= inverse_doppler_factor
-    r_packet.energy *= inverse_doppler_factor
-    r_packet.mu = (r_packet.mu + beta) / (1 + beta * r_packet.mu)

--- a/tardis/transport/montecarlo/modes/classic/solver.py
+++ b/tardis/transport/montecarlo/modes/classic/solver.py
@@ -7,6 +7,9 @@ import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
 from tardis.io.hdf_writer_mixin import HDFWriterMixin
 from tardis.io.logger import montecarlo_tracking as mc_tracker
+from tardis.model.geometry.radial1d_homologous import (
+    NumbaHomologousRadial1DGeometry,
+)
 from tardis.transport.montecarlo.configuration import montecarlo_globals
 from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
@@ -14,12 +17,6 @@ from tardis.transport.montecarlo.configuration.base import (
 )
 from tardis.transport.montecarlo.estimators.mc_rad_field_solver import (
     MCRadiationFieldPropertiesSolver,
-)
-from tardis.transport.montecarlo.modes.classic.packet_propagation import (
-    packet_propagation,
-)
-from tardis.transport.montecarlo.modes.montecarlo_transport import (
-    montecarlo_transport_with_vpackets,
 )
 from tardis.transport.montecarlo.montecarlo_transport_state import (
     MonteCarloTransportState,
@@ -37,6 +34,9 @@ from tardis.transport.montecarlo.progress_bars import (
     refresh_packet_pbar,
     reset_packet_pbar,
     update_iterations_pbar,
+)
+from tardis.transport.montecarlo.transport_physics import (
+    resolve_transport_physics,
 )
 from tardis.util.base import (
     quantity_linspace,
@@ -141,10 +141,6 @@ class MCTransportSolverClassic(HDFWriterMixin):
             n_levels_bf_species_by_n_cells_tuple=n_levels_bf_species_by_n_cells_tuple,
         )
 
-        transport_state.enable_full_relativity = (
-            self.montecarlo_configuration.ENABLE_FULL_RELATIVITY
-        )
-
         configuration_initialize(
             self.montecarlo_configuration, self, no_of_virtual_packets
         )
@@ -214,23 +210,34 @@ class MCTransportSolverClassic(HDFWriterMixin):
         if show_progress_bars:
             reset_packet_pbar(number_of_rpackets)
 
+        if not isinstance(
+            transport_state.geometry_state_numba,
+            NumbaHomologousRadial1DGeometry,
+        ):
+            raise TypeError("Classic transport requires homologous geometry.")
+        transport_physics = resolve_transport_physics(
+            transport_state.geometry_state_numba,
+            self.enable_full_relativity,
+            continuum_process_enabled=False,
+        )
+
         # Classic mode: returns 4 values (no continuum estimators)
         (
             v_packets_energy_hist,
             vpacket_tracker,
             estimators_bulk,
             estimators_line,
-        ) = montecarlo_transport_with_vpackets(
+        ) = transport_physics.transport_packets(
             transport_state.packet_collection,
             transport_state.geometry_state_numba,
-            transport_state.time_explosion.cgs.value,
             transport_state.opacity_state_numba,
             self.montecarlo_configuration,
             self.spectrum_frequency_grid.value,
             trackers_list,
             number_of_vpackets,
             show_progress_bars=show_progress_bars,
-            packet_propagation_function=packet_propagation,
+            packet_propagation_function=(transport_physics.propagate_packet),
+            enable_full_relativity=(transport_physics.enable_full_relativity),
         )
 
         # Attach estimators to transport state

--- a/tardis/transport/montecarlo/modes/iip/montecarlo_transport.py
+++ b/tardis/transport/montecarlo/modes/iip/montecarlo_transport.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import numpy as np
 from numba import njit, prange
 from numba.np.ufunc.parallel import get_num_threads, get_thread_id
@@ -12,19 +14,19 @@ from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
 )
 from tardis.transport.montecarlo.estimators.estimators_bulk import (
+    EstimatorsBulk,
     create_estimators_bulk_list,
     init_estimators_bulk,
 )
 from tardis.transport.montecarlo.estimators.estimators_continuum import (
+    EstimatorsContinuum,
     create_estimators_continuum_list,
     init_estimators_continuum,
 )
 from tardis.transport.montecarlo.estimators.estimators_line import (
+    EstimatorsLine,
     create_estimators_line_list,
     init_estimators_line,
-)
-from tardis.transport.montecarlo.modes.iip.packet_propagation import (
-    packet_propagation,
 )
 from tardis.transport.montecarlo.modes.montecarlo_transport import (
     make_r_packet,
@@ -40,15 +42,16 @@ from tardis.transport.montecarlo.packets.packet_collections import (
 def montecarlo_transport(
     packet_collection: PacketCollection,
     geometry_state_numba: NumbaHomologousRadial1DGeometry,
-    time_explosion: float,
     opacity_state_numba: OpacityStateNumba,
     montecarlo_configuration: MonteCarloConfiguration,
     n_levels_bf_species_by_n_cells_tuple: tuple,
     trackers: List,
     show_progress_bars: bool,
-):
+    packet_propagation_function: Callable,
+    enable_full_relativity: bool,
+) -> tuple[EstimatorsBulk, EstimatorsLine, EstimatorsContinuum]:
     """
-    Main loop of the Monte Carlo radiative transfer routine for IIP mode.
+    Run the Monte Carlo radiative transfer loop for IIP mode.
 
     This function generates packet objects from the packet collection and
     propagates them through the ejecta, performing interactions with both
@@ -63,8 +66,6 @@ def montecarlo_transport(
     geometry_state_numba : NumbaHomologousRadial1DGeometry
         Numba-compiled simulation geometry containing shell boundaries
         and velocity information.
-    time_explosion : float
-        Time since explosion in seconds, used for relativistic calculations.
     opacity_state_numba : OpacityStateNumba
         Numba-compiled opacity state containing line opacities, continuum
         opacities, and atomic data required for interactions.
@@ -77,6 +78,10 @@ def montecarlo_transport(
         List of packet trackers for detailed packet interaction logging.
     show_progress_bars : bool
         Flag to enable/disable progress bar updates during simulation.
+    packet_propagation_function
+        Compiled packet state machine compatible with the resolved physics.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
 
     Returns
     -------
@@ -144,16 +149,16 @@ def montecarlo_transport(
         # Get the RPacket tracker for this thread
         tracker = trackers[packet_index]
 
-        packet_propagation(
+        packet_propagation_function(
             r_packet,
             geometry_state_numba,
-            time_explosion,
             opacity_state_numba,
             estimators_bulk_thread,
             estimators_line_thread,
             estimators_continuum_thread,
             tracker,
             montecarlo_configuration,
+            enable_full_relativity,
         )
         set_packet_collection_output(packet_collection, r_packet, i)
 

--- a/tardis/transport/montecarlo/modes/iip/packet_propagation.py
+++ b/tardis/transport/montecarlo/modes/iip/packet_propagation.py
@@ -1,6 +1,5 @@
 from numba import njit
 
-from tardis import constants as const
 from tardis.model.geometry.radial1d_homologous import (
     NumbaHomologousRadial1DGeometry,
 )
@@ -11,7 +10,6 @@ from tardis.opacities.opacities import (
 from tardis.opacities.opacity_state_numba_iip import OpacityStateNumbaIIP
 from tardis.transport.frame_transformations import (
     get_doppler_factor,
-    get_inverse_doppler_factor,
 )
 from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
@@ -39,6 +37,7 @@ from tardis.transport.montecarlo.modes.homologous_rad_packet_transport import (
     trace_packet,
 )
 from tardis.transport.montecarlo.packets.movement import (
+    initialize_packet_frame,
     move_packet_across_shell_boundary,
     move_r_packet,
 )
@@ -48,20 +47,18 @@ from tardis.transport.montecarlo.packets.radiative_packet import (
     RPacket,
 )
 
-C_SPEED_OF_LIGHT = const.c.to("cm/s").value
-
 
 @njit
 def packet_propagation(
     r_packet: RPacket,
     geometry: NumbaHomologousRadial1DGeometry,
-    time_explosion: float,
     opacity_state: OpacityStateNumbaIIP,
     estimators_bulk: EstimatorsBulk,
     estimators_line: EstimatorsLine,
     estimators_continuum: EstimatorsContinuum,
-    rpacket_tracker,  # Excluded from type hints as it might be different types
+    rpacket_tracker: object,
     montecarlo_configuration: MonteCarloConfiguration,
+    enable_full_relativity: bool,
 ) -> None:
     """
     Execute Monte Carlo transport for a single radiative packet.
@@ -77,8 +74,6 @@ def packet_propagation(
         The radiative packet to transport through the ejecta.
     geometry
         The spherically symmetric geometry of the supernova ejecta.
-    time_explosion
-        Time since explosion in seconds.
     opacity_state
         Current opacity state containing line and continuum opacities.
     estimators_bulk
@@ -91,21 +86,23 @@ def packet_propagation(
         Tracker for recording packet interactions and trajectories.
     montecarlo_configuration
         Configuration parameters for the Monte Carlo simulation.
-
-    Returns
-    -------
-    This function modifies the r_packet object in-place and updates
-    estimators and collections. No return value.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
 
     """
+    if not enable_full_relativity:
+        raise NotImplementedError(
+            "Continuum transport currently requires full relativity."
+        )
+
+    time_explosion = geometry.time_explosion
     line_interaction_type = montecarlo_configuration.LINE_INTERACTION_TYPE
 
-    # IIP mode: always use full relativity
-    set_packet_props_full_relativity(r_packet, time_explosion)
+    initialize_packet_frame(r_packet, geometry, enable_full_relativity)
     r_packet.initialize_line_id(
         opacity_state,
         time_explosion,
-        enable_full_relativity=True,
+        enable_full_relativity,
     )
 
     rpacket_tracker.track_boundary_event(
@@ -120,7 +117,7 @@ def packet_propagation(
         doppler_factor = get_doppler_factor(
             velocity,
             r_packet.mu,
-            enable_full_relativity=True,
+            enable_full_relativity,
         )
 
         comov_nu = r_packet.nu * doppler_factor
@@ -140,8 +137,8 @@ def packet_propagation(
         chi_continuum = chi_e + chi_bf_tot + chi_ff
 
         escat_prob = chi_e / chi_continuum  # probability of e-scatter
-        # IIP mode: full relativity always enabled
-        chi_continuum *= doppler_factor
+        if enable_full_relativity:
+            chi_continuum *= doppler_factor
         distance, interaction_type, delta_shell = trace_packet(
             r_packet,
             geometry,
@@ -151,7 +148,7 @@ def packet_propagation(
             chi_continuum,
             escat_prob,
             True,
-            enable_full_relativity=True,
+            enable_full_relativity,
             disable_line_scattering=montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
         update_estimators_bound_free(
@@ -174,7 +171,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
             rpacket_tracker.track_boundary_event(
                 r_packet,
@@ -194,7 +191,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
 
             rpacket_tracker.track_line_interaction_before(r_packet)
@@ -204,7 +201,7 @@ def packet_propagation(
                 time_explosion,
                 line_interaction_type,
                 opacity_state,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
             rpacket_tracker.track_line_interaction_after(r_packet)
 
@@ -214,13 +211,13 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
             rpacket_tracker.track_escattering_interaction_before(r_packet)
             thomson_scatter(
                 r_packet,
                 time_explosion,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
             rpacket_tracker.track_escattering_interaction_after(r_packet)
 
@@ -231,7 +228,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
             rpacket_tracker.track_continuum_interaction_before(r_packet)
             continuum_event(
@@ -242,7 +239,7 @@ def packet_propagation(
                 chi_ff,
                 chi_bf_contributions,
                 current_continua,
-                enable_full_relativity=True,
+                enable_full_relativity,
             )
 
             rpacket_tracker.track_continuum_interaction_after(r_packet)
@@ -268,70 +265,3 @@ def packet_propagation(
         from_shell_id=r_packet.current_shell_id,
         to_shell_id=r_packet.current_shell_id + 1,
     )
-
-
-@njit
-def set_packet_props_partial_relativity(
-    r_packet: RPacket, time_explosion: float
-) -> None:
-    """
-    Set packet properties using partial relativistic corrections.
-
-    This function applies inverse Doppler corrections to the packet frequency
-    and energy based on partial relativistic treatment (first-order in v/c).
-
-    Parameters
-    ----------
-    r_packet
-        The radiative packet whose properties will be modified.
-    time_explosion
-        Time since explosion in seconds, used to calculate velocity.
-
-    Returns
-    -------
-    Modifies r_packet.nu and r_packet.energy in-place.
-    """
-    velocity = r_packet.r / time_explosion
-    inverse_doppler_factor = get_inverse_doppler_factor(
-        velocity,
-        r_packet.mu,
-        enable_full_relativity=False,
-    )
-    r_packet.nu *= inverse_doppler_factor
-    r_packet.energy *= inverse_doppler_factor
-
-
-@njit
-def set_packet_props_full_relativity(
-    r_packet: RPacket, time_explosion: float
-) -> None:
-    """
-    Set packet properties using full relativistic corrections.
-
-    This function applies inverse Doppler corrections to the packet frequency,
-    energy, and direction cosine based on full relativistic treatment, including
-    aberration effects on the direction cosine.
-
-    Parameters
-    ----------
-    r_packet
-        The radiative packet whose properties will be modified.
-    time_explosion
-        Time since explosion in seconds, used to calculate velocity.
-
-    Returns
-    -------
-    Modifies r_packet.nu, r_packet.energy, and r_packet.mu in-place.
-    """
-    beta = (r_packet.r / time_explosion) / C_SPEED_OF_LIGHT
-
-    velocity = r_packet.r / time_explosion
-    inverse_doppler_factor = get_inverse_doppler_factor(
-        velocity,
-        r_packet.mu,
-        enable_full_relativity=True,
-    )
-
-    r_packet.nu *= inverse_doppler_factor
-    r_packet.energy *= inverse_doppler_factor
-    r_packet.mu = (r_packet.mu + beta) / (1 + beta * r_packet.mu)

--- a/tardis/transport/montecarlo/modes/iip/solver.py
+++ b/tardis/transport/montecarlo/modes/iip/solver.py
@@ -8,6 +8,9 @@ import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
 from tardis.io.hdf_writer_mixin import HDFWriterMixin
 from tardis.io.logger import montecarlo_tracking as mc_tracker
+from tardis.model.geometry.radial1d_homologous import (
+    NumbaHomologousRadial1DGeometry,
+)
 from tardis.transport.montecarlo.configuration import montecarlo_globals
 from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
@@ -15,9 +18,6 @@ from tardis.transport.montecarlo.configuration.base import (
 )
 from tardis.transport.montecarlo.estimators.mc_rad_field_solver import (
     MCRadiationFieldPropertiesSolver,
-)
-from tardis.transport.montecarlo.modes.iip.montecarlo_transport import (
-    montecarlo_transport,
 )
 from tardis.transport.montecarlo.montecarlo_transport_state import (
     MonteCarloTransportState,
@@ -35,6 +35,9 @@ from tardis.transport.montecarlo.progress_bars import (
     refresh_packet_pbar,
     reset_packet_pbar,
     update_iterations_pbar,
+)
+from tardis.transport.montecarlo.transport_physics import (
+    resolve_transport_physics,
 )
 from tardis.util.base import (
     quantity_linspace,
@@ -198,20 +201,32 @@ class MCTransportSolverIIP(HDFWriterMixin):
         if show_progress_bars:
             reset_packet_pbar(number_of_rpackets)
 
+        if not isinstance(
+            transport_state.geometry_state_numba,
+            NumbaHomologousRadial1DGeometry,
+        ):
+            raise TypeError("Continuum transport requires homologous geometry.")
+        transport_physics = resolve_transport_physics(
+            transport_state.geometry_state_numba,
+            True,
+            continuum_process_enabled=True,
+        )
+
         # IIP mode: returns 3 estimator objects (bulk, line, continuum)
         (
             estimators_bulk,
             estimators_line,
             estimators_continuum,
-        ) = montecarlo_transport(
+        ) = transport_physics.transport_packets(
             transport_state.packet_collection,
             transport_state.geometry_state_numba,
-            transport_state.time_explosion.cgs.value,
             transport_state.opacity_state_numba,
             self.montecarlo_configuration,
             transport_state.n_levels_bf_species_by_n_cells_tuple,
             trackers_list,
             show_progress_bars=show_progress_bars,
+            packet_propagation_function=(transport_physics.propagate_packet),
+            enable_full_relativity=(transport_physics.enable_full_relativity),
         )
 
         # Attach estimators to transport state

--- a/tardis/transport/montecarlo/modes/montecarlo_transport.py
+++ b/tardis/transport/montecarlo/modes/montecarlo_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -29,6 +30,12 @@ from tardis.transport.montecarlo.packets.radiative_packet import (
 from tardis.transport.montecarlo.progress_bars import update_packets_pbar
 
 if TYPE_CHECKING:
+    from tardis.model.geometry.radial1d import NumbaRadial1DGeometry
+    from tardis.model.geometry.radial1d_homologous import (
+        NumbaHomologousRadial1DGeometry,
+    )
+    from tardis.opacities.opacity_state_numba import OpacityStateNumba
+    from tardis.opacities.opacity_state_numba_iip import OpacityStateNumbaIIP
     from tardis.transport.montecarlo.configuration.base import (
         MonteCarloConfiguration,
     )
@@ -238,15 +245,16 @@ def get_vpacket_tracker(
 @njit(**njit_dict)
 def montecarlo_transport_with_vpackets(
     packet_collection: PacketCollection,
-    geometry_state_numba,
-    time_explosion: float,
-    opacity_state_numba,
+    geometry_state_numba: NumbaRadial1DGeometry
+    | NumbaHomologousRadial1DGeometry,
+    opacity_state_numba: OpacityStateNumba | OpacityStateNumbaIIP,
     montecarlo_configuration: MonteCarloConfiguration,
     spectrum_frequency_grid: np.ndarray,
-    trackers,
+    trackers: TypedList,
     number_of_vpackets: int,
     show_progress_bars: bool,
-    packet_propagation_function,
+    packet_propagation_function: Callable,
+    enable_full_relativity: bool,
 ) -> tuple[
     np.ndarray,
     VPacketCollection,
@@ -262,9 +270,6 @@ def montecarlo_transport_with_vpackets(
         Packet collection containing packet input and output arrays.
     geometry_state_numba
         Numba geometry object for the transport mode.
-    time_explosion : float
-        Time since explosion in seconds. Non-homologous mode accepts but does
-        not use this value.
     opacity_state_numba
         Numba opacity state.
     montecarlo_configuration : MonteCarloConfiguration
@@ -279,6 +284,8 @@ def montecarlo_transport_with_vpackets(
         Whether packet progress bars are enabled.
     packet_propagation_function
         Mode-specific packet propagation function.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
 
     Returns
     -------
@@ -333,13 +340,13 @@ def montecarlo_transport_with_vpackets(
         packet_propagation_function(
             r_packet,
             geometry_state_numba,
-            time_explosion,
             opacity_state_numba,
             estimators_bulk_thread,
             estimators_line_thread,
             vpacket_collection,
             tracker,
             montecarlo_configuration,
+            enable_full_relativity,
         )
         set_packet_collection_output(packet_collection, r_packet, i)
 

--- a/tardis/transport/montecarlo/modes/nonhomologous/packet_propagation.py
+++ b/tardis/transport/montecarlo/modes/nonhomologous/packet_propagation.py
@@ -3,7 +3,6 @@
 import numpy as np
 from numba import njit
 
-from tardis import constants as const
 from tardis.model.geometry.radial1d import (
     NumbaRadial1DGeometry,
 )
@@ -11,7 +10,6 @@ from tardis.opacities.opacities import chi_electron_calculator
 from tardis.opacities.opacity_state_numba import OpacityStateNumba
 from tardis.transport.frame_transformations import (
     get_doppler_factor,
-    get_inverse_doppler_factor,
 )
 from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
@@ -35,6 +33,7 @@ from tardis.transport.montecarlo.modes.nonhomologous.virtual_packet import (
     trace_vpacket_volley,
 )
 from tardis.transport.montecarlo.packets.movement import (
+    initialize_packet_frame,
     move_packet_across_shell_boundary,
     move_r_packet,
 )
@@ -47,20 +46,18 @@ from tardis.transport.montecarlo.packets.radiative_packet import (
     RPacket,
 )
 
-C_SPEED_OF_LIGHT = const.c.to("cm/s").value
-
 
 @njit
 def packet_propagation(
     r_packet: RPacket,
     geometry: NumbaRadial1DGeometry,
-    time_explosion: float,
     opacity_state: OpacityStateNumba,
     estimators_bulk: EstimatorsBulk,
     estimators_line: EstimatorsLine,
     vpacket_collection: VPacketCollection,
-    rpacket_tracker,
+    rpacket_tracker: object,
     montecarlo_configuration: MonteCarloConfiguration,
+    enable_full_relativity: bool,
 ) -> None:
     """
     Execute Monte Carlo transport for a single radiative packet in nonhomologous mode.
@@ -74,9 +71,6 @@ def packet_propagation(
         The radiative packet to transport through the ejecta.
     geometry : NumbaRadial1DGeometry
         The spherically symmetric geometry of the supernova ejecta.
-    time_explosion : float
-        Time since explosion in seconds. Accepted for interface parity with
-        homologous transport; not used by nonhomologous transport.
     opacity_state : OpacityStateNumba
         Current opacity state containing line opacities.
     estimators_bulk : EstimatorsBulk
@@ -89,18 +83,17 @@ def packet_propagation(
         Tracker for recording packet interactions and trajectories.
     montecarlo_configuration : MonteCarloConfiguration
         Configuration parameters for the Monte Carlo simulation.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
 
-    Returns
-    -------
-    None
-        This function modifies the r_packet object in-place and updates
-        estimators and collections.
     """
     line_interaction_type = montecarlo_configuration.LINE_INTERACTION_TYPE
 
-    if montecarlo_configuration.ENABLE_FULL_RELATIVITY:
-        raise NotImplementedError("Full relativity not supported for non-homology.")
-    set_packet_props_partial_relativity(r_packet, geometry)
+    if enable_full_relativity:
+        raise NotImplementedError(
+            "Full relativity not supported for non-homology."
+        )
+    initialize_packet_frame(r_packet, geometry, enable_full_relativity)
     # Manually perform the function of r_packet.initialize_line_id for now until
     # nonhomology is supported
     inverse_line_list_nu = opacity_state.line_list_nu[::-1]
@@ -108,7 +101,7 @@ def packet_propagation(
     doppler_factor = get_doppler_factor(
         v,
         r_packet.mu,
-        montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+        enable_full_relativity,
     )
     comov_nu = r_packet.nu * doppler_factor
     next_line_id = len(opacity_state.line_list_nu) - np.searchsorted(
@@ -124,7 +117,7 @@ def packet_propagation(
         vpacket_collection,
         geometry,
         opacity_state,
-        montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+        enable_full_relativity,
         montecarlo_configuration.VPACKET_TAU_RUSSIAN,
         montecarlo_configuration.SURVIVAL_PROBABILITY,
     )
@@ -140,7 +133,7 @@ def packet_propagation(
         doppler_factor = get_doppler_factor(
             v,
             r_packet.mu,
-            montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+            enable_full_relativity,
         )
 
         comov_nu = r_packet.nu * doppler_factor
@@ -148,7 +141,7 @@ def packet_propagation(
             opacity_state, comov_nu, r_packet.current_shell_id
         )
 
-        if montecarlo_configuration.ENABLE_FULL_RELATIVITY:
+        if enable_full_relativity:
             opacity_electron *= doppler_factor
 
         distance, interaction_type, delta_shell = trace_packet(
@@ -157,7 +150,7 @@ def packet_propagation(
             opacity_state,
             estimators_line,
             opacity_electron,
-            montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+            enable_full_relativity,
             montecarlo_configuration.DISABLE_LINE_SCATTERING,
         )
 
@@ -167,7 +160,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_boundary_event(
                 r_packet,
@@ -187,7 +180,7 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
 
             rpacket_tracker.track_line_interaction_before(r_packet)
@@ -197,7 +190,7 @@ def packet_propagation(
                 geometry,
                 line_interaction_type,
                 opacity_state,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_line_interaction_after(r_packet)
             trace_vpacket_volley(
@@ -205,7 +198,7 @@ def packet_propagation(
                 vpacket_collection,
                 geometry,
                 opacity_state,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
                 montecarlo_configuration.VPACKET_TAU_RUSSIAN,
                 montecarlo_configuration.SURVIVAL_PROBABILITY,
             )
@@ -216,13 +209,13 @@ def packet_propagation(
                 distance,
                 geometry,
                 estimators_bulk,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_escattering_interaction_before(r_packet)
             thomson_scatter(
                 r_packet,
                 geometry,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
             )
             rpacket_tracker.track_escattering_interaction_after(r_packet)
 
@@ -231,7 +224,7 @@ def packet_propagation(
                 vpacket_collection,
                 geometry,
                 opacity_state,
-                montecarlo_configuration.ENABLE_FULL_RELATIVITY,
+                enable_full_relativity,
                 montecarlo_configuration.VPACKET_TAU_RUSSIAN,
                 montecarlo_configuration.SURVIVAL_PROBABILITY,
             )
@@ -256,54 +249,3 @@ def packet_propagation(
         from_shell_id=r_packet.current_shell_id,
         to_shell_id=r_packet.current_shell_id + 1,
     )
-
-
-@njit
-def set_packet_props_partial_relativity(
-    r_packet: RPacket,
-    geometry: NumbaRadial1DGeometry
-) -> None:
-    """
-    Set packet properties using partial relativistic corrections.
-
-    This function applies inverse Doppler corrections to the packet frequency
-    and energy based on partial relativistic treatment (first-order in v/c).
-
-    Parameters
-    ----------
-    r_packet
-        The radiative packet whose properties will be modified.
-    geometry
-        NumbaRadial1DGeometry object
-
-    Returns
-    -------
-    Modifies r_packet.nu and r_packet.energy in-place.
-    """
-    v = geometry.get_velocity(r_packet.r, r_packet.current_shell_id)
-    inverse_doppler_factor = get_inverse_doppler_factor(
-        v, r_packet.mu, False
-    )
-    r_packet.nu *= inverse_doppler_factor
-    r_packet.energy *= inverse_doppler_factor
-
-
-@njit
-def set_packet_props_full_relativity(
-    r_packet: RPacket, time_explosion: float
-) -> None:
-
-    raise NotImplementedError("Full relativity not supported for non-homology.")
-#    beta = (r_packet.r / time_explosion) / C_SPEED_OF_LIGHT
-#
-#    inverse_doppler_factor = get_inverse_doppler_factor(
-#        r_packet.r,
-#        r_packet.mu,
-#        time_explosion,
-#        enable_full_relativity=True,
-#    )
-#
-#    r_packet.nu *= inverse_doppler_factor
-#    r_packet.energy *= inverse_doppler_factor
-#    r_packet.mu = (r_packet.mu + beta) / (1 + beta * r_packet.mu)
-#

--- a/tardis/transport/montecarlo/modes/nonhomologous/solver.py
+++ b/tardis/transport/montecarlo/modes/nonhomologous/solver.py
@@ -7,21 +7,16 @@ import tardis.transport.montecarlo.configuration.constants as constants
 from tardis import constants as const
 from tardis.io.hdf_writer_mixin import HDFWriterMixin
 from tardis.io.logger import montecarlo_tracking as mc_tracker
+from tardis.model.geometry.radial1d import NumbaRadial1DGeometry
 from tardis.transport.montecarlo.configuration.base import (
     MonteCarloConfiguration,
     configuration_initialize,
-)
-from tardis.transport.montecarlo.modes.montecarlo_transport import (
-    montecarlo_transport_with_vpackets,
 )
 from tardis.transport.montecarlo.modes.nonhomologous.mc_rad_field_solver import (
     MCRadiationFieldPropertiesSolver,
 )
 from tardis.transport.montecarlo.modes.nonhomologous.montecarlo_transport_state import (
     MonteCarloTransportStateNonhomologous,
-)
-from tardis.transport.montecarlo.modes.nonhomologous.packet_propagation import (
-    packet_propagation,
 )
 from tardis.transport.montecarlo.packets.trackers.tracker_full_util import (
     generate_tracker_full_list,
@@ -36,6 +31,9 @@ from tardis.transport.montecarlo.progress_bars import (
     refresh_packet_pbar,
     reset_packet_pbar,
     update_iterations_pbar,
+)
+from tardis.transport.montecarlo.transport_physics import (
+    resolve_transport_physics,
 )
 from tardis.util.base import (
     quantity_linspace,
@@ -136,10 +134,6 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
             n_levels_bf_species_by_n_cells_tuple=n_levels_bf_species_by_n_cells_tuple,
         )
 
-        transport_state.enable_full_relativity = (
-            self.montecarlo_configuration.ENABLE_FULL_RELATIVITY
-        )
-
         configuration_initialize(
             self.montecarlo_configuration, self, no_of_virtual_packets
         )
@@ -209,23 +203,36 @@ class MCTransportSolverNonhomologous(HDFWriterMixin):
         if show_progress_bars:
             reset_packet_pbar(number_of_rpackets)
 
+        if not isinstance(
+            transport_state.geometry_state_numba,
+            NumbaRadial1DGeometry,
+        ):
+            raise TypeError(
+                "Nonhomologous transport requires piecewise-linear geometry."
+            )
+        transport_physics = resolve_transport_physics(
+            transport_state.geometry_state_numba,
+            self.enable_full_relativity,
+            continuum_process_enabled=False,
+        )
+
         # nonhomologous mode: returns 4 values (no continuum estimators)
         (
             v_packets_energy_hist,
             vpacket_tracker,
             estimators_bulk,
             estimators_line,
-        ) = montecarlo_transport_with_vpackets(
+        ) = transport_physics.transport_packets(
             transport_state.packet_collection,
             transport_state.geometry_state_numba,
-            0.0,
             transport_state.opacity_state_numba,
             self.montecarlo_configuration,
             self.spectrum_frequency_grid.value,
             trackers_list,
             number_of_vpackets,
             show_progress_bars=show_progress_bars,
-            packet_propagation_function=packet_propagation,
+            packet_propagation_function=(transport_physics.propagate_packet),
+            enable_full_relativity=(transport_physics.enable_full_relativity),
         )
 
         # Attach estimators to transport state

--- a/tardis/transport/montecarlo/packets/movement.py
+++ b/tardis/transport/montecarlo/packets/movement.py
@@ -7,8 +7,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numba import njit
 
-from tardis.transport.frame_transformations import get_doppler_factor
+from tardis.transport.frame_transformations import (
+    get_doppler_factor,
+    get_inverse_doppler_factor,
+)
 from tardis.transport.montecarlo import njit_dict_no_parallel
+from tardis.transport.montecarlo.configuration.constants import C_SPEED_OF_LIGHT
 from tardis.transport.montecarlo.estimators.radfield_estimator_calcs import (
     update_estimators_bulk,
 )
@@ -25,6 +29,40 @@ if TYPE_CHECKING:
         EstimatorsBulk,
     )
     from tardis.transport.montecarlo.packets.radiative_packet import RPacket
+
+
+@njit
+def initialize_packet_frame(
+    r_packet: RPacket,
+    geometry: NumbaRadial1DGeometry | NumbaHomologousRadial1DGeometry,
+    enable_full_relativity: bool,
+) -> None:
+    """Transform a source packet from the comoving to the lab frame.
+
+    Parameters
+    ----------
+    r_packet : tardis.transport.montecarlo.packets.radiative_packet.RPacket
+        Packet whose frequency, energy, and possibly direction are updated.
+    geometry : NumbaRadial1DGeometry or NumbaHomologousRadial1DGeometry
+        Geometry supplying the local velocity.
+    enable_full_relativity : bool
+        Whether to include the full Doppler factor and angle aberration.
+    """
+    velocity = geometry.get_velocity(
+        r_packet.r,
+        r_packet.current_shell_id,
+    )
+    inverse_doppler_factor = get_inverse_doppler_factor(
+        velocity,
+        r_packet.mu,
+        enable_full_relativity,
+    )
+    r_packet.nu *= inverse_doppler_factor
+    r_packet.energy *= inverse_doppler_factor
+
+    if enable_full_relativity:
+        beta = velocity / C_SPEED_OF_LIGHT
+        r_packet.mu = (r_packet.mu + beta) / (1.0 + beta * r_packet.mu)
 
 
 @njit(**njit_dict_no_parallel)

--- a/tardis/transport/montecarlo/tests/test_montecarlo.py
+++ b/tardis/transport/montecarlo/tests/test_montecarlo.py
@@ -363,9 +363,7 @@ def test_move_packet(packet_params, expected_params, full_relativity):
     # model.full_relativity = full_relativity
 
     velocity = packet.r / time_explosion
-    doppler_factor = get_doppler_factor(
-        velocity, packet.mu, full_relativity
-    )
+    doppler_factor = get_doppler_factor(velocity, packet.mu, full_relativity)
 
     numba_estimator = init_estimators_bulk(
         mean_intensity_total=packet_params["j"],
@@ -379,9 +377,7 @@ def test_move_packet(packet_params, expected_params, full_relativity):
         None,
         time_explosion_quantity,
     ).to_numba()
-    move_r_packet(
-        packet, distance, geometry, numba_estimator, full_relativity
-    )
+    move_r_packet(packet, distance, geometry, numba_estimator, full_relativity)
 
     assert_almost_equal(packet.mu, expected_params["mu"])
     assert_almost_equal(packet.r, expected_params["r"])
@@ -391,8 +387,6 @@ def test_move_packet(packet_params, expected_params, full_relativity):
     if full_relativity:
         expected_j *= doppler_factor
         expected_nubar *= doppler_factor
-
-    mc.ENABLE_FULL_RELATIVITY = False
 
     assert_allclose(
         numba_estimator.j_estimator[packet.current_shell_id],
@@ -477,9 +471,6 @@ methods related to continuum interactions.
 )
 def test_frame_transformations(mu, r, inv_t_exp, full_relativity):
     packet = radiative_packet.RPacket(r=r, mu=mu, energy=0.9, nu=0.4)
-    mc.ENABLE_FULL_RELATIVITY = bool(full_relativity)
-    mc.ENABLE_FULL_RELATIVITY = full_relativity
-
     velocity = r * inv_t_exp
     inverse_doppler_factor = get_inverse_doppler_factor(
         velocity, mu, full_relativity
@@ -489,8 +480,6 @@ def test_frame_transformations(mu, r, inv_t_exp, full_relativity):
     )
 
     doppler_factor = get_doppler_factor(velocity, mu, full_relativity)
-    mc.ENABLE_FULL_RELATIVITY = False
-
     assert_almost_equal(doppler_factor * inverse_doppler_factor, 1.0)
 
 
@@ -505,12 +494,9 @@ def test_frame_transformations(mu, r, inv_t_exp, full_relativity):
 )
 def test_angle_transformation_invariance(mu, r, inv_t_exp):
     packet = radiative_packet.RPacket(r, mu, 0.4, 0.9)
-    mc.ENABLE_FULL_RELATIVITY = True
-
     mu1 = angle_aberration_CMF_to_LF(packet, 1 / inv_t_exp, mu)
     mu_obtained = angle_aberration_LF_to_CMF(packet, 1 / inv_t_exp, mu1)
 
-    mc.ENABLE_FULL_RELATIVITY = False
     assert_almost_equal(mu_obtained, mu)
 
 
@@ -536,8 +522,6 @@ def test_compute_distance2line_relativistic(
         mean_intensity_total=transport.j_estimator,
         mean_frequency=transport.nu_bar_estimator,
     )
-    mc.ENABLE_FULL_RELATIVITY = bool(full_relativity)
-
     velocity = r / t_exp
     doppler_factor = get_doppler_factor(velocity, mu, full_relativity)
     comov_nu = packet.nu * doppler_factor
@@ -558,8 +542,6 @@ def test_compute_distance2line_relativistic(
 
     doppler_factor = get_doppler_factor(velocity, mu, full_relativity)
     comov_nu = packet.nu * doppler_factor
-    mc.ENABLE_FULL_RELATIVITY = False
-
     assert_allclose(comov_nu, nu_line, rtol=1e-14)
 
 

--- a/tardis/transport/montecarlo/tests/test_single_packet_loop.py
+++ b/tardis/transport/montecarlo/tests/test_single_packet_loop.py
@@ -1,3 +1,5 @@
+from types import ModuleType
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -9,11 +11,9 @@ from tardis.model.geometry.radial1d_homologous import (
     NumbaHomologousRadial1DGeometry,
 )
 from tardis.transport.montecarlo import RPacket
+from tardis.transport.montecarlo.configuration.constants import C_SPEED_OF_LIGHT
 from tardis.transport.montecarlo.modes.classic import (
     packet_propagation as classic_propagation,
-)
-from tardis.transport.montecarlo.modes.classic.packet_propagation import (
-    packet_propagation,
 )
 from tardis.transport.montecarlo.modes.nonhomologous import (
     packet_propagation as nonhomologous_propagation,
@@ -65,7 +65,11 @@ class _CommonPacketPropagationPatcher:
         assert self.interaction_queue
         return self.interaction_queue.pop(0)
 
-    def __call__(self, module, interactions) -> None:
+    def __call__(
+        self,
+        module: ModuleType,
+        interactions: list[tuple[float, InteractionType, int]],
+    ) -> None:
         self.interaction_queue = list(interactions)
         self.monkeypatch.setattr(module, "trace_packet", self.trace_packet)
         self.monkeypatch.setattr(
@@ -125,18 +129,21 @@ def test_classic_packet_propagation_dispatch_numba_disabled(
     if first_interaction != InteractionType.BOUNDARY:
         interactions.append((1.0e12, InteractionType.BOUNDARY, 1))
     interactions.append((1.0e12, InteractionType.BOUNDARY, 1))
-    patch_common_classic_hooks(classic_propagation, interactions)
+    patch_common_classic_hooks(
+        classic_propagation,
+        interactions,
+    )
 
     classic_propagation.packet_propagation(
         parametrized_packet,
         homologous_radial_1d_geometry,
-        5.2e7,
         classic_opacity_state,
         bulk_estimators,
         line_estimators,
         vpacket_collection,
         recording_tracker,
         montecarlo_configuration,
+        False,
     )
 
     assert parametrized_packet.status == PacketStatus.EMITTED
@@ -158,6 +165,60 @@ def test_classic_packet_propagation_dispatch_numba_disabled(
         line_estimators.energy_deposition_line_rate,
         rtol=RTOL,
     )
+
+
+def test_classic_packet_propagation_full_relativity_numba_disabled(
+    python_numba_disabled: None,
+    patch_common_classic_hooks,
+    parametrized_packet: RPacket,
+    homologous_radial_1d_geometry: NumbaHomologousRadial1DGeometry,
+    classic_opacity_state,
+    bulk_estimators,
+    line_estimators,
+    vpacket_collection,
+    recording_tracker: _RecordingTracker,
+    montecarlo_configuration,
+) -> None:
+    patch_common_classic_hooks(
+        classic_propagation,
+        [
+            (0.0, InteractionType.BOUNDARY, 1),
+            (0.0, InteractionType.BOUNDARY, 1),
+        ],
+    )
+    initial_mu = parametrized_packet.mu
+    initial_nu = parametrized_packet.nu
+    initial_energy = parametrized_packet.energy
+    velocity = homologous_radial_1d_geometry.get_velocity(
+        parametrized_packet.r,
+        parametrized_packet.current_shell_id,
+    )
+    beta = velocity / C_SPEED_OF_LIGHT
+    inverse_doppler_factor = (1.0 + initial_mu * beta) / np.sqrt(1.0 - beta**2)
+    expected_mu = (initial_mu + beta) / (1.0 + beta * initial_mu)
+
+    classic_propagation.packet_propagation(
+        parametrized_packet,
+        homologous_radial_1d_geometry,
+        classic_opacity_state,
+        bulk_estimators,
+        line_estimators,
+        vpacket_collection,
+        recording_tracker,
+        montecarlo_configuration,
+        True,
+    )
+
+    assert parametrized_packet.status == PacketStatus.EMITTED
+    npt.assert_allclose(
+        parametrized_packet.nu,
+        initial_nu * inverse_doppler_factor,
+    )
+    npt.assert_allclose(
+        parametrized_packet.energy,
+        initial_energy * inverse_doppler_factor,
+    )
+    npt.assert_allclose(parametrized_packet.mu, expected_mu)
 
 
 @pytest.mark.parametrize(
@@ -189,7 +250,10 @@ def test_iip_packet_propagation_dispatch_numba_disabled(
         (1.0e12, InteractionType.BOUNDARY, 1),
         (1.0e12, InteractionType.BOUNDARY, 1),
     ]
-    patch_common_classic_hooks(iip_propagation, interactions)
+    patch_common_classic_hooks(
+        iip_propagation,
+        interactions,
+    )
     # Continuum handling has extra collaborators; patch them only enough to
     # make the dispatch branch observable.
     monkeypatch.setattr(
@@ -213,13 +277,13 @@ def test_iip_packet_propagation_dispatch_numba_disabled(
     iip_propagation.packet_propagation(
         parametrized_packet,
         homologous_radial_1d_geometry,
-        5.2e7,
         iip_opacity_state,
         bulk_estimators,
         line_estimators,
         continuum_estimators,
         recording_tracker,
         montecarlo_configuration,
+        True,
     )
 
     assert parametrized_packet.status == PacketStatus.EMITTED
@@ -272,18 +336,21 @@ def test_nonhomologous_packet_propagation_dispatch_numba_disabled(
     if first_interaction != InteractionType.BOUNDARY:
         interactions.append((1.0e12, InteractionType.BOUNDARY, 1))
     interactions.append((1.0e12, InteractionType.BOUNDARY, 1))
-    patch_common_classic_hooks(nonhomologous_propagation, interactions)
+    patch_common_classic_hooks(
+        nonhomologous_propagation,
+        interactions,
+    )
 
     nonhomologous_propagation.packet_propagation(
         parametrized_packet,
         radial_1d_geometry,
-        0.0,
         classic_opacity_state,
         bulk_estimators,
         line_estimators,
         vpacket_collection,
         recording_tracker,
         montecarlo_configuration,
+        False,
     )
 
     assert parametrized_packet.status == PacketStatus.EMITTED
@@ -305,59 +372,3 @@ def test_nonhomologous_packet_propagation_dispatch_numba_disabled(
         line_estimators.energy_deposition_line_rate,
         rtol=RTOL,
     )
-
-
-@pytest.mark.xfail(
-    reason="Need to update for new mode architecture with correct parameters"
-)
-# TODO: Update test to provide all required parameters for packet_propagation
-def test_verysimple_single_packet_loop(
-    verysimple_numba_homologous_radial_1d_geometry,
-    verysimple_time_explosion,
-    verysimple_opacity_state,
-    verysimple_estimators,
-    verysimple_vpacket_collection,
-    verysimple_packet_collection,
-):
-    pytest.skip("Test needs to be updated for new mode architecture")
-    numba_radial_1d_geometry = verysimple_numba_homologous_radial_1d_geometry
-    packet_collection = verysimple_packet_collection
-    vpacket_collection = verysimple_vpacket_collection
-    time_explosion = verysimple_time_explosion
-    opacity_state = verysimple_opacity_state
-    numba_estimators = verysimple_estimators
-
-    i = 0
-    r_packet = RPacket(
-        numba_radial_1d_geometry.r_inner[0],
-        packet_collection.packets_input_mu[i],
-        packet_collection.packets_input_nu[i],
-        packet_collection.packets_input_energy[i],
-        i,
-    )
-    # packet_propagation requires: r_packet, geometry, time_explosion, opacity_state,
-    # estimators_bulk, estimators_line, vpacket_collection, rpacket_tracker,
-    # montecarlo_configuration
-    # This test needs to be updated with all required parameters
-    packet_propagation(
-        r_packet,
-        numba_radial_1d_geometry,
-        time_explosion,
-        opacity_state,
-        numba_estimators,
-        vpacket_collection,
-    )
-
-    npt.assert_almost_equal(r_packet.nu, 1053057938883272.8)
-    npt.assert_almost_equal(r_packet.mu, 0.9611146425440562)
-    npt.assert_almost_equal(r_packet.energy, 0.10327717505563379)
-
-
-@pytest.mark.xfail(reason="To be implemented")
-def test_set_packet_props_partial_relativity():
-    raise AssertionError()
-
-
-@pytest.mark.xfail(reason="To be implemented")
-def test_set_packet_props_full_relativity():
-    raise AssertionError()

--- a/tardis/transport/montecarlo/tests/test_transport_physics.py
+++ b/tardis/transport/montecarlo/tests/test_transport_physics.py
@@ -1,0 +1,206 @@
+import numba
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from tardis.model.geometry.radial1d import NumbaRadial1DGeometry
+from tardis.model.geometry.radial1d_homologous import (
+    NumbaHomologousRadial1DGeometry,
+)
+from tardis.transport.montecarlo.configuration.constants import C_SPEED_OF_LIGHT
+from tardis.transport.montecarlo.modes.classic.packet_propagation import (
+    packet_propagation as propagate_packet_homologous,
+)
+from tardis.transport.montecarlo.modes.iip.montecarlo_transport import (
+    montecarlo_transport as transport_packets_continuum,
+)
+from tardis.transport.montecarlo.modes.iip.packet_propagation import (
+    packet_propagation as propagate_packet_continuum,
+)
+from tardis.transport.montecarlo.modes.montecarlo_transport import (
+    montecarlo_transport_with_vpackets as transport_packets_with_vpackets,
+)
+from tardis.transport.montecarlo.modes.nonhomologous.packet_propagation import (
+    packet_propagation as propagate_packet_piecewise_linear,
+)
+from tardis.transport.montecarlo.packets.movement import (
+    initialize_packet_frame,
+)
+from tardis.transport.montecarlo.packets.radiative_packet import RPacket
+from tardis.transport.montecarlo.transport_physics import (
+    resolve_transport_physics,
+)
+
+
+@pytest.mark.parametrize("enable_full_relativity", [False, True])
+def test_resolve_homologous_transport_physics(
+    homologous_radial_1d_geometry: NumbaHomologousRadial1DGeometry,
+    enable_full_relativity: bool,
+) -> None:
+    transport_physics = resolve_transport_physics(
+        homologous_radial_1d_geometry,
+        enable_full_relativity,
+        continuum_process_enabled=False,
+    )
+
+    assert transport_physics.propagate_packet is propagate_packet_homologous
+    assert (
+        transport_physics.transport_packets is transport_packets_with_vpackets
+    )
+    assert transport_physics.enable_full_relativity is enable_full_relativity
+
+
+def test_resolve_continuum_transport_physics(
+    homologous_radial_1d_geometry: NumbaHomologousRadial1DGeometry,
+) -> None:
+    transport_physics = resolve_transport_physics(
+        homologous_radial_1d_geometry,
+        enable_full_relativity=True,
+        continuum_process_enabled=True,
+    )
+
+    assert transport_physics.propagate_packet is propagate_packet_continuum
+    assert transport_physics.transport_packets is transport_packets_continuum
+    assert transport_physics.enable_full_relativity is True
+
+
+def test_partial_relativity_continuum_transport_is_rejected(
+    homologous_radial_1d_geometry: NumbaHomologousRadial1DGeometry,
+) -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match="Continuum transport currently requires full relativity",
+    ):
+        resolve_transport_physics(
+            homologous_radial_1d_geometry,
+            enable_full_relativity=False,
+            continuum_process_enabled=True,
+        )
+
+
+def test_resolve_piecewise_linear_transport_physics(
+    radial_1d_geometry: NumbaRadial1DGeometry,
+) -> None:
+    transport_physics = resolve_transport_physics(
+        radial_1d_geometry,
+        False,
+        continuum_process_enabled=False,
+    )
+
+    assert (
+        transport_physics.propagate_packet is propagate_packet_piecewise_linear
+    )
+    assert (
+        transport_physics.transport_packets is transport_packets_with_vpackets
+    )
+    assert transport_physics.enable_full_relativity is False
+
+
+def test_piecewise_linear_full_relativity_is_rejected(
+    radial_1d_geometry: NumbaRadial1DGeometry,
+) -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match=r"Full relativity.*piecewise-linear kinematics",
+    ):
+        resolve_transport_physics(
+            radial_1d_geometry,
+            enable_full_relativity=True,
+            continuum_process_enabled=False,
+        )
+
+
+def test_piecewise_linear_continuum_transport_is_rejected(
+    radial_1d_geometry: NumbaRadial1DGeometry,
+) -> None:
+    with pytest.raises(
+        NotImplementedError,
+        match=r"Continuum transport.*piecewise-linear kinematics",
+    ):
+        resolve_transport_physics(
+            radial_1d_geometry,
+            enable_full_relativity=False,
+            continuum_process_enabled=True,
+        )
+
+
+def test_unsupported_geometry_is_rejected() -> None:
+    with pytest.raises(
+        TypeError, match="Unsupported transport geometry: object"
+    ):
+        resolve_transport_physics(
+            object(),
+            enable_full_relativity=False,
+            continuum_process_enabled=False,
+        )
+
+
+@pytest.mark.parametrize("enable_full_relativity", [False, True])
+def test_initialize_packet_frame_homologous(
+    enable_full_relativity: bool,
+) -> None:
+    time_explosion = 1.0e6
+    beta = 0.1
+    packet_radius = beta * C_SPEED_OF_LIGHT * time_explosion
+    geometry = NumbaHomologousRadial1DGeometry(
+        np.array([0.05 * C_SPEED_OF_LIGHT * time_explosion]),
+        np.array([0.15 * C_SPEED_OF_LIGHT * time_explosion]),
+        np.array([0.05 * C_SPEED_OF_LIGHT]),
+        np.array([0.15 * C_SPEED_OF_LIGHT]),
+        time_explosion,
+    )
+    initial_mu = 0.6
+    initial_nu = 1.0e15
+    initial_energy = 1.0
+    packet = RPacket(
+        r=packet_radius,
+        mu=initial_mu,
+        nu=initial_nu,
+        energy=initial_energy,
+        seed=1963,
+    )
+
+    initialize_packet_frame(packet, geometry, enable_full_relativity)
+
+    if enable_full_relativity:
+        inverse_doppler_factor = (1.0 + initial_mu * beta) / np.sqrt(
+            1.0 - beta**2
+        )
+        expected_mu = (initial_mu + beta) / (1.0 + beta * initial_mu)
+    else:
+        inverse_doppler_factor = 1.0 / (1.0 - initial_mu * beta)
+        expected_mu = initial_mu
+    npt.assert_allclose(packet.nu, initial_nu * inverse_doppler_factor)
+    npt.assert_allclose(packet.energy, initial_energy * inverse_doppler_factor)
+    npt.assert_allclose(packet.mu, expected_mu)
+    if not numba.config.DISABLE_JIT:
+        assert initialize_packet_frame.nopython_signatures
+
+
+def test_initialize_packet_frame_uses_piecewise_linear_velocity() -> None:
+    geometry = NumbaRadial1DGeometry(
+        np.array([1.0e14]),
+        np.array([2.0e14]),
+        np.array([1.0e8]),
+        np.array([2.0e8]),
+    )
+    initial_mu = 0.3
+    initial_nu = 1.0e15
+    initial_energy = 1.0
+    packet = RPacket(
+        r=1.25e14,
+        mu=initial_mu,
+        nu=initial_nu,
+        energy=initial_energy,
+        seed=1963,
+    )
+    local_velocity = 1.25e8
+    inverse_doppler_factor = 1.0 / (
+        1.0 - initial_mu * local_velocity / C_SPEED_OF_LIGHT
+    )
+
+    initialize_packet_frame(packet, geometry, False)
+
+    npt.assert_allclose(packet.nu, initial_nu * inverse_doppler_factor)
+    npt.assert_allclose(packet.energy, initial_energy * inverse_doppler_factor)
+    assert packet.mu == initial_mu

--- a/tardis/transport/montecarlo/transport_physics.py
+++ b/tardis/transport/montecarlo/transport_physics.py
@@ -1,0 +1,119 @@
+"""Resolve compatible transport physics before compiled packet transport."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from tardis.model.geometry.radial1d import NumbaRadial1DGeometry
+from tardis.model.geometry.radial1d_homologous import (
+    NumbaHomologousRadial1DGeometry,
+)
+from tardis.transport.montecarlo.modes.classic.packet_propagation import (
+    packet_propagation as propagate_packet_homologous,
+)
+from tardis.transport.montecarlo.modes.iip.montecarlo_transport import (
+    montecarlo_transport as transport_packets_continuum,
+)
+from tardis.transport.montecarlo.modes.iip.packet_propagation import (
+    packet_propagation as propagate_packet_continuum,
+)
+from tardis.transport.montecarlo.modes.montecarlo_transport import (
+    montecarlo_transport_with_vpackets as transport_packets_with_vpackets,
+)
+from tardis.transport.montecarlo.modes.nonhomologous.packet_propagation import (
+    packet_propagation as propagate_packet_piecewise_linear,
+)
+
+type GeometryState = NumbaHomologousRadial1DGeometry | NumbaRadial1DGeometry
+type PacketPropagationFunction = Callable[..., None]
+type TransportFunction = Callable[..., tuple]
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedTransportPhysics:
+    """Store a compatible compiled transport kernel and frame treatment.
+
+    Packet propagation is the temporary kinematic boundary because the current
+    nonhomologous implementation changes line initialization, resonance
+    ordering, cursor updates, estimators, virtual packets, and interaction
+    events together. Once those operations share a common contract, this field
+    can become a smaller resonance callback without changing the resolver.
+    ``transport_packets`` and ``propagate_packet`` are a matched pair and must
+    not be recombined independently.
+
+    Attributes
+    ----------
+    transport_packets : collections.abc.Callable
+        Compiled outer driver compatible with the resolved physics.
+    propagate_packet : collections.abc.Callable
+        Compiled packet state machine compatible with the resolved physics.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
+    """
+
+    transport_packets: TransportFunction
+    propagate_packet: PacketPropagationFunction
+    enable_full_relativity: bool
+
+
+def resolve_transport_physics(
+    geometry: GeometryState,
+    enable_full_relativity: bool,
+    continuum_process_enabled: bool,
+) -> ResolvedTransportPhysics:
+    """Resolve a supported transport kernel before entering Numba.
+
+    Parameters
+    ----------
+    geometry : NumbaHomologousRadial1DGeometry or NumbaRadial1DGeometry
+        Geometry state defining the velocity field.
+    enable_full_relativity : bool
+        Whether to use TARDIS's existing full-relativity branch.
+    continuum_process_enabled : bool
+        Whether bound-free and free-free interactions are enabled.
+
+    Returns
+    -------
+    ResolvedTransportPhysics
+        Compatible compiled packet kernel and frame-treatment choice.
+
+    Raises
+    ------
+    NotImplementedError
+        If the requested physics combination is not implemented.
+    TypeError
+        If the geometry is not supported by Monte Carlo transport.
+    """
+    if isinstance(geometry, NumbaHomologousRadial1DGeometry):
+        if continuum_process_enabled:
+            if not enable_full_relativity:
+                raise NotImplementedError(
+                    "Continuum transport currently requires full relativity."
+                )
+            propagate_packet = propagate_packet_continuum
+            transport_packets = transport_packets_continuum
+        else:
+            propagate_packet = propagate_packet_homologous
+            transport_packets = transport_packets_with_vpackets
+    elif isinstance(geometry, NumbaRadial1DGeometry):
+        if enable_full_relativity:
+            raise NotImplementedError(
+                "Full relativity is not implemented for piecewise-linear "
+                "kinematics."
+            )
+        if continuum_process_enabled:
+            raise NotImplementedError(
+                "Continuum transport is not implemented for piecewise-linear "
+                "kinematics."
+            )
+        propagate_packet = propagate_packet_piecewise_linear
+        transport_packets = transport_packets_with_vpackets
+    else:
+        raise TypeError(
+            f"Unsupported transport geometry: {type(geometry).__name__}"
+        )
+
+    return ResolvedTransportPhysics(
+        transport_packets,
+        propagate_packet,
+        enable_full_relativity,
+    )

--- a/tardis/transport/refactor_suggestion.md
+++ b/tardis/transport/refactor_suggestion.md
@@ -1,0 +1,140 @@
+The recommended end state is one configurable optical/UV Monte Carlo transport path—not separate classic, IIP, and nonhomologous solver stacks. Retain two small geometry-specific resonance kernels; consolidate everything around them. Because these APIs are internal, delete the old solver classes and modules directly without compatibility shims.
+
+## The real physical splits
+
+| Physical axis | Current behavior | Recommended representation |
+|---|---|---|
+| Kinematics/resonance | Classic and IIP use homologous expansion; nonhomologous uses a piecewise-linear velocity field and quartic resonance distance | Resolve a compatible compiled transport kernel now; reduce it to two resonance kernels after the surrounding state machines share a contract |
+| Interaction processes | Classic/nonhomologous: line + electron; IIP: line + electron + bound-free/free-free | Explicit process configuration and empty continuum arrays when disabled |
+| Relativity | Classic configurable; IIP forced full; nonhomologous rejects full | One explicit frame-treatment field, validated before compilation |
+| Line redistribution | Scatter, downbranch, macroatom | Keep the existing enum and transition data; not a transport mode |
+| Macro-atom sampling | Classic direct walk; IIP absorbing-chain sampler | A sampler choice inside shared event handling |
+| Virtual packets | Classic/nonhomologous only | Optional observer/peel-off component |
+| Thermal balance | Coupled to the IIP workflow | Outer iteration state update, outside packet propagation |
+
+The current mode choice is not actually configuration driven. Standard construction hard-codes classic transport in [simulation/base.py](/home/afullard/tardis/tardis/simulation/base.py:741), while IIP and nonhomologous select their classes through dedicated workflows in [type_iip_workflow.py](/home/afullard/tardis/tardis/workflows/type_iip_workflow.py:191) and [nonhomologous_tardis_workflow.py](/home/afullard/tardis/tardis/workflows/nonhomologous_tardis_workflow.py:120).
+
+The architectural duplication is substantial:
+
+- Three near-copy solver classes.
+- Three packet state machines.
+- Separate classic/nonhomologous interaction, virtual-packet, transport-state, opacity, and radiation-field modules.
+- A second IIP threaded driver whose main addition is continuum estimators. Compare the shared driver in [montecarlo_transport.py](/home/afullard/tardis/tardis/transport/montecarlo/modes/montecarlo_transport.py:238) with [iip/montecarlo_transport.py](/home/afullard/tardis/tardis/transport/montecarlo/modes/iip/montecarlo_transport.py:39).
+
+Notably, the shared homologous tracer already accepts continuous opacity, electron-scattering probability, and a continuum-enabled flag in [homologous_rad_packet_transport.py](/home/afullard/tardis/tardis/transport/montecarlo/modes/homologous_rad_packet_transport.py:75). That is strong evidence that classic versus IIP does not merit separate transport loops.
+
+## Recommended target
+
+Use:
+
+- One `MCTransportSolver`.
+- One immutable resolved transport configuration.
+- One `MonteCarloTransportState`.
+- One Numba opacity-state type; disabled capabilities use zero-length arrays.
+- One `prange` packet driver and one packet state machine.
+- Two small resonance functions:
+  - homologous analytic resonance, including current full-relativistic support;
+  - piecewise-linear nonhomologous resonance, retaining line-direction and cursor behavior.
+- Shared event functions accepting geometry or local velocity, rather than assuming `r / time_explosion`.
+- One result object containing bulk, line, continuum, virtual-packet, and tracking results consistently.
+
+The configuration should resolve these choices once before entering Numba:
+
+```text
+geometry             -> resonance kernel
+continuum species    -> enabled opacity processes and estimators
+line interaction     -> scatter/downbranch/macroatom
+relativity setting   -> frame treatment
+virtual packet count -> optional observer estimator
+```
+
+Small injected compiled functions are enough; a strategy-class hierarchy, plugin registry, or abstract solver factory would add little and complicate Numba specialization.
+
+### Example implementation boundary
+
+The example in `montecarlo/transport_physics.py` resolves the matching outer
+driver and complete packet state machine, rather than only the line-distance
+function. This is deliberately broader than the final target. Today the
+nonhomologous split also owns line initialization and ordering, both line
+cursors, estimator updates, virtual packets, and interaction events; injecting
+only its resonance function into the classic state machine would be physically
+incorrect. The resolved unit can shrink to the two resonance kernels once those
+surrounding operations have a shared interface.
+
+Relativity is resolved alongside that kernel and passed as the only
+kernel-visible Boolean. Homologous time and local velocity come from the
+geometry, avoiding a second kinematic source of truth. Unsupported combinations
+are rejected before entering Numba.
+
+This example preserves IIP's existing forced-full transport behavior. Packet
+source selection happens earlier and still follows the input configuration, so
+an IIP configuration with `enable_full_relativity: false` can pair a
+nonrelativistic source with full-relativity transport. Resolving relativity
+before packet-source construction would change scientific results and needs a
+separate behavior change with a regression baseline.
+
+Remove the mutable continuum global used by [montecarlo_globals.py](/home/afullard/tardis/tardis/transport/montecarlo/configuration/montecarlo_globals.py:1) and [opacity_state.py](/home/afullard/tardis/tardis/opacities/opacity_state.py:211). It makes run configuration implicit and potentially order-dependent. `OpacityStateNumba` already contains continuum fields and an absorbing-Markov field in [opacity_state_numba.py](/home/afullard/tardis/tardis/opacities/opacity_state_numba.py:13), so the separate IIP type is unnecessary.
+
+I would also:
+
+- Derive kinematics from the actual geometry and delete the unused `enable_nonhomologous_expansion` schema option in [montecarlo.yml](/home/afullard/tardis/tardis/io/configuration/schemas/montecarlo.yml:61).
+- Derive continuum capability from configured continuum species.
+- Move GPU selection entirely to the formal-integral solver; MC transport does not use it.
+- Reject unsupported combinations at construction time:
+  - nonhomologous + full relativity;
+  - nonhomologous + continuum;
+  - continuum with non-macroatom line treatment;
+  - continuum virtual packets until their spawning semantics are implemented.
+- Remove or explicitly reject the currently nonfunctional adiabatic-cooling and two-photon switches.
+
+Gamma-ray transport should remain separate: it has different particles, interaction physics, deposition semantics, and energy domain. The formal integral should also remain a post-processing spectrum solver rather than joining the Monte Carlo path.
+
+## Critical scientific boundary
+
+Do not generalize the nonhomologous equations as part of this behavior-preserving refactor.
+
+For a general spherical radial velocity field, the line-of-sight velocity gradient is
+
+\[
+Q(\mu)=\mu^2\frac{dv}{dr}+(1-\mu^2)\frac{v}{r},
+\]
+
+and Sobolev optical depth scales as \(1/|Q|\). Only in homologous expansion does \(dv/dr=v/r=1/t\), making this isotropic.
+
+Current nonhomologous opacity uses only \(1/(dv/dr)\) in [tau_sobolev.py](/home/afullard/tardis/tardis/transport/montecarlo/modes/nonhomologous/tau_sobolev.py:55), while line traversal is selected from the sign of `dv/dr` in [rad_packet_transport.py](/home/afullard/tardis/tardis/transport/montecarlo/modes/nonhomologous/rad_packet_transport.py:75). TARDIS’s own documentation notes that isotropic line re-emission is special to homologous expansion in [lineinteraction.rst](/home/afullard/tardis/docs/physics_walkthrough/montecarlo/lineinteraction.rst:27).
+
+Therefore:
+
+- Preserve the present nonhomologous approximation exactly during consolidation.
+- Keep its resonance and line-cursor logic isolated.
+- Treat directional Sobolev optical depth, anisotropic escape, multiple resonances, nonhomologous continuum, and full relativity as later scientific behavior changes with separate requirements and regression baselines.
+
+## Safest implementation order
+
+1. Add a capability-resolution matrix and missing characterization tests. Preserve fixed-seed packet outputs and random-number draw order.
+
+2. Consolidate the three host solvers, transport states, result contracts, tracking, threading, and configuration while retaining the existing packet functions.
+
+3. Unify the opacity-state type and outer threaded drivers. Disabled continuum and virtual-packet paths must consume no extra random draws.
+
+4. Merge interaction-event and virtual-packet copies by passing local velocity/geometry explicitly.
+
+5. Merge the three packet state machines while retaining the two resonance kernels.
+
+6. Generalize shared Sobolev and radiation-field normalization around inverse velocity gradient, verifying the homologous limit.
+
+7. Delete the old `classic`, `iip`, and nonhomologous solver/state/event modules and migrate callers directly.
+
+Only after equivalence is demonstrated should unsupported physical combinations be implemented.
+
+## Validation status
+
+Regression-backed checks were run in the `tardis` Conda environment against `/home/afullard/tardis-regression-data` at commit `631b0742fd3d2f23b8d945908c08b185ee4d71c3`:
+
+- `test_transport.py --tardis-regression-data=…`: 25 passed.
+- JIT-disabled packet dispatch selection: 9 passed.
+- `test_nonhomologous.py --tardis-regression-data=…`: 26 passed.
+- Classic-continuum configuration rejection: 1 passed.
+- `git lfs fsck`: OK.
+
+The regression checkout had pre-existing untracked files; they were preserved. The TARDIS worktree remains clean. No files were changed. The full classic/IIP integrations, broad suite, Ruff, and documentation build were not run because this was a read-only investigation.


### PR DESCRIPTION
Compare and contrast with #3707. This approach splits transport up by physics approach. There are still wrappers involved, but they tend to be a bit more obvious. This probably makes it easier to mix and match options.