### PR TITLE
Make review and behavior skills explicit

### DIFF
--- a/.agents/skills/tardis-behavior-change/agents/openai.yaml
+++ b/.agents/skills/tardis-behavior-change/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "TARDIS Behavior Change"
   short_description: "Implement TARDIS behavior test-first"
   default_prompt: "Use $tardis-behavior-change to implement this TARDIS behavior change with test-first validation."
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/tardis-pr-review/agents/openai.yaml
+++ b/.agents/skills/tardis-pr-review/agents/openai.yaml
@@ -2,3 +2,5 @@ interface:
   display_name: "TARDIS Science Review Guide"
   short_description: "Brief, code-driven science questions"
   default_prompt: "Use $tardis-pr-review to briefly identify only the science questions directly raised by code changes in TARDIS pull request #123."
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

The behavior change skill is sometimes activated for changes that are experimental and do not require full TDD. This makes it explicit. Activate with $tardis-behavior-change

The PR review skill has also been made explicit since it has a lot of additional processing. Activate with $tardis-pr-review


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
