### PR TITLE
[GSoC] Fix atomic-data download URL

### DIFF
--- a/docs/io/configuration/components/atomic/atomic_data.rst
+++ b/docs/io/configuration/components/atomic/atomic_data.rst
@@ -8,6 +8,10 @@ Atomic data is provided as a filepath in the configuration file or as a keyword 
 function. The `Carsus package <https://tardis-sn.github.io/carsus/>`_ can generate atomic data in a format readable
 by TARDIS.
 
+The default public atomic dataset can be downloaded with
+``tardis.io.atom_data.atom_web_download.download_atom_data``. This stores the
+dataset in TARDIS's local data directory for use in a configuration.
+
 .. toctree::
 
     atomic_data_description

--- a/tardis/data/atomic_data_repo.yml
+++ b/tardis/data/atomic_data_repo.yml
@@ -1,8 +1,8 @@
 default: kurucz_cd23_chianti_H_He_latest
 
 kurucz_cd23_chianti_H_He_latest:
-  url: https://media.githubusercontent.com/media/tardis-sn/tardis-regression-data/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5
+  url: https://raw.githubusercontent.com/tardis-sn/tardis-regression-data/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5
   mirrors:
-    - https://media.githubusercontent.com/media/tardis-sn/tardis-regression-data/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5
+    - https://raw.githubusercontent.com/tardis-sn/tardis-regression-data/main/atom_data/kurucz_cd23_chianti_H_He_latest.h5
   uuid: NA
   md5: 16341df5d104b462be4c3e51b167a893

--- a/tardis/io/atom_data/tests/__init__.py
+++ b/tardis/io/atom_data/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for atomic-data download configuration."""

--- a/tardis/io/atom_data/tests/test_atom_web_download.py
+++ b/tardis/io/atom_data/tests/test_atom_web_download.py
@@ -1,0 +1,15 @@
+from tardis.io.atom_data.atom_web_download import get_atomic_repo_config
+
+
+def test_default_atomic_data_uses_raw_github_url():
+    atomic_data_name = "kurucz_cd23_chianti_H_He_latest"
+    expected_url = (
+        "https://raw.githubusercontent.com/tardis-sn/"
+        "tardis-regression-data/main/atom_data/"
+        f"{atomic_data_name}.h5"
+    )
+
+    atomic_repo = get_atomic_repo_config()
+
+    assert atomic_repo[atomic_data_name]["url"] == expected_url
+    assert atomic_repo[atomic_data_name]["mirrors"] == [expected_url]


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #3612.

The packaged atomic-data registry pointed at a retired
`media.githubusercontent.com` endpoint. Use the supported raw GitHub endpoint
for the primary download URL and mirror, with regression coverage for the
default dataset configuration.

### :pushpin: Resources

N/A

### :vertical_traffic_light: Testing

- [x] `conda run --no-capture-output -n tardis pytest tardis/io/atom_data/tests/test_atom_web_download.py -q`
- [x] `conda run --no-capture-output -n tardis pytest tardis/io/atom_data -q`
- [x] `conda run --no-capture-output -n tardis ruff check tardis/io/atom_data/tests`
- [x] Direct raw GitHub endpoint check returned HTTP 200.
- [ ] Documentation build/preview — not run.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request.
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.

### :robot: AI Usage Statement

OpenAI Codex was used to inspect the atomic-data download configuration and
draft code changes. The human contributor reviewed all AI-assisted changes, fully
understanding them.