### PR TITLE
[GSoC] Use default Panel comms in notebooks

### DIFF
--- a/docs/io/optional/index.rst
+++ b/docs/io/optional/index.rst
@@ -6,6 +6,10 @@ Optional Inputs
 
 TARDIS also allows other inputs that are passed as keyword arguments into the ``run_tardis`` function.
 
+In a standard Jupyter notebook, the TARDIS logger widget uses Panel's default
+communication mode, so running a simulation does not change the communication
+mode used by other Panel widgets in the notebook.
+
 .. toctree::
     :maxdepth: 1
 

--- a/tardis/util/panel_init.py
+++ b/tardis/util/panel_init.py
@@ -1,22 +1,23 @@
-import panel as pn
-from tardis.util.environment import Environment
 import logging
-import os
+
+import panel as pn
+
+from tardis.util.environment import Environment
 
 logger = logging.getLogger(__name__)
 
 VALID_MODES = ["ssh_jh", "notebook", "vscode", "vscode_noipy"]
 preferred_mode = None
 
-# note: pn.extension(comms="ipywidgets") and pn.extension("ipywidgets") behave differently! 
+# note: pn.extension(comms="ipywidgets") and pn.extension("ipywidgets") behave differently!
 
 def ssh_jh():
     """Initialize panel for JupyterHub (colab comms)"""
     pn.extension(comms="ipywidgets")
 
-def notebook():
-    """Initialize panel for standard Jupyter notebook (default comms)"""
-    pn.extension(comms="ipywidgets")
+def notebook() -> None:
+    """Initialize Panel for a standard Jupyter notebook."""
+    pn.extension()
 
 def vscode():
     """Initialize panel for VSCode (ipywidgets comms)"""
@@ -40,7 +41,7 @@ def auto():
         modes = {"ssh_jh": ssh_jh, "notebook": notebook, "vscode": vscode, "vscode_noipy": vscode_noipy}
         modes[preferred_mode]()
         return
-    
+
     # Otherwise auto-detect
     if Environment.is_sshjh():
         print("Auto-detected JupyterHub environment")
@@ -57,4 +58,3 @@ def auto():
     else:
         print("Defaulting to default panel comms.")
         pn.extension()
-

--- a/tardis/util/tests/__init__.py
+++ b/tardis/util/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for TARDIS utility modules."""

--- a/tardis/util/tests/test_panel_init.py
+++ b/tardis/util/tests/test_panel_init.py
@@ -1,0 +1,16 @@
+from unittest.mock import Mock
+
+import pytest
+
+import tardis.util.panel_init as panel_init
+
+
+def test_notebook_uses_default_panel_comms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    panel_extension = Mock()
+    monkeypatch.setattr(panel_init.pn, "extension", panel_extension)
+
+    panel_init.notebook()
+
+    panel_extension.assert_called_once_with()


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #3672.

The standard-notebook Panel initializer forced the notebook-wide `ipywidgets`
communication mode. Use Panel's default communication mode in that path while
preserving the specialized JupyterHub and VS Code modes.

### :pushpin: Resources

N/A

### :vertical_traffic_light: Testing

- [x] `conda run --no-capture-output -n tardis pytest tardis/util/tests/test_panel_init.py -q`
- [x] `conda run --no-capture-output -n tardis pytest tardis/util/tests -q`
- [x] `conda run --no-capture-output -n tardis ruff check tardis/util/panel_init.py tardis/util/tests/test_panel_init.py`
- [x] `conda run --no-capture-output -n tardis pytest tardis -q` — 400 passed, 1885 skipped, 17 xfailed, 3 xpassed.
- [x] Local documentation build completed with pre-existing warnings.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request.
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.

### :robot: AI Usage Statement

OpenAI Codex was used to inspect the Panel initialization path, draft code
changes, add targeted test coverage, and run validation. The human contributor
reviewed all AI-assisted changes, fully understanding them.