### PR TITLE
[GSoC] Initialize logger widgets only when needed

### DIFF
--- a/docs/io/optional/index.rst
+++ b/docs/io/optional/index.rst
@@ -6,6 +6,9 @@ Optional Inputs
 
 TARDIS also allows other inputs that are passed as keyword arguments into the ``run_tardis`` function.
 
+When widgets cannot be displayed, TARDIS configures standard stream logging
+without creating a Panel logger widget.
+
 .. toctree::
     :maxdepth: 1
 

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -1,13 +1,17 @@
 import logging
 import sys
 from dataclasses import dataclass, field
-import panel as pn
+
 from IPython.display import display
-import pandas as pd
-from tardis.io.logger.colored_logger import ColoredFormatter
-from tardis.util.environment import Environment
-from tardis.io.logger.logger_widget import create_logger_columns, PanelWidgetLogHandler
+
 import tardis.util.panel_init as panel_init
+from tardis.io.logger.colored_logger import ColoredFormatter
+from tardis.io.logger.logger_widget import (
+    PanelWidgetLogHandler,
+    create_logger_columns,
+)
+from tardis.util.environment import Environment
+
 panel_init.auto()
 
 PYTHON_WARNINGS_LOGGER = logging.getLogger("py.warnings")
@@ -17,7 +21,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class LoggingConfig:
     """Logging configuration.
-    
+
     Attributes
     ----------
     LEVELS : dict
@@ -29,6 +33,7 @@ class LoggingConfig:
     DEFAULT_SPECIFIC_STATE : bool
         The default specific log level state.
     """
+
     LEVELS: dict = field(default_factory=lambda: {
         "NOTSET": logging.NOTSET,
         "DEBUG": logging.DEBUG,
@@ -54,7 +59,7 @@ LOGGING_LEVELS = LoggingConfig().LEVELS
 
 class TARDISLogger:
     """Main logger class for TARDIS.
-    
+
     Parameters
     ----------
     log_columns : dict
@@ -62,6 +67,7 @@ class TARDISLogger:
     display_handles : dict, optional
         Dictionary of display handles for each column (jupyter environment).
     """
+
     def __init__(self, log_columns=None, display_handles=None, batch_size=10):
         self.config = LoggingConfig()
         self.logger = logging.getLogger("tardis")
@@ -72,7 +78,7 @@ class TARDISLogger:
 
     def configure_logging(self, log_level, tardis_config, specific_log_level=None):
         """Configure the logging level and filtering for TARDIS loggers.
-        
+
         Parameters
         ----------
         log_level : str
@@ -81,7 +87,7 @@ class TARDISLogger:
             Configuration dictionary containing debug settings.
         specific_log_level : bool, optional
             Whether to enable specific log level filtering.
-            
+
         Raises
         ------
         ValueError
@@ -96,8 +102,10 @@ class TARDISLogger:
             )
             if log_level and tardis_config["debug"].get("log_level"):
                 self.logger.debug(
-                    "log_level is defined both in Functional Argument & YAML Configuration {debug section}, "
-                    f"log_level = {log_level.upper()} will be used for Log Level Determination"
+                    "log_level is defined both in Functional Argument & YAML "
+                    "Configuration {debug section}, log_level = %s will be used "
+                    "for Log Level Determination",
+                    log_level.upper(),
                 )
         else:
             tardis_config["debug"] = {}
@@ -158,7 +166,7 @@ class TARDISLogger:
 
     def _configure_handlers(self):
         """Configure logging handlers.
-        
+
         Removes existing handlers and adds the widget handler to the
         TARDIS logger and Python warnings logger.
         """
@@ -170,54 +178,55 @@ class TARDISLogger:
 
         self.logger.addHandler(self.widget_handler)
         PYTHON_WARNINGS_LOGGER.addHandler(self.widget_handler)
-    
+
     def finalize_widget_logging(self):
         """Finalize widget logging by embedding the final state.
         """
         # Embed the final state for Jupyter environments
-        if (Environment.allows_widget_display() and hasattr(self, 'display_handles') 
+        if (Environment.allows_widget_display() and hasattr(self, 'display_handles')
             and hasattr(self, 'display_ids') and self.display_handles and self.display_ids):
             print("Embedding the final state for Jupyter environments")
             for level, column in self.log_columns.items():
-                if (level in self.display_handles and level in self.display_ids 
+                if (level in self.display_handles and level in self.display_ids
                     and self.display_handles[level] is not None):
                     self.display_handles[level].update(column.embed())
-    
+
     def remove_widget_handler(self):
         """Remove the widget handler from the logger.
         """
         self.logger.removeHandler(self.widget_handler)
         PYTHON_WARNINGS_LOGGER.removeHandler(self.widget_handler)
         self.widget_handler.close()
-        
+
     def setup_stream_handler(self):
         """Set up notebook-based logging after widget handler is removed.
         """
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(ColoredFormatter())
-        
+
         self.logger.addHandler(stream_handler)
         PYTHON_WARNINGS_LOGGER.addHandler(stream_handler)
 
 class LogFilter:
     """Filter for controlling which log levels are displayed.
-    
+
     Parameters
     ----------
     log_levels : list
         List of logging levels to allow through the filter.
     """
+
     def __init__(self, log_levels):
         self.log_levels = log_levels
 
     def filter(self, log_record):
         """Determine if a log record should be displayed.
-        
+
         Parameters
         ----------
         log_record : logging.LogRecord
             The log record to evaluate.
-            
+
         Returns
         -------
         bool
@@ -225,9 +234,17 @@ class LogFilter:
         """
         return log_record.levelno in self.log_levels
 
-def logging_state(log_level, tardis_config, specific_log_level=None, display_logging_widget=True, widget_start_height=10, widget_max_height=300, batch_size=10):
+def logging_state(
+    log_level: str | None,
+    tardis_config: dict,
+    specific_log_level: bool | None = None,
+    display_logging_widget: bool = True,
+    widget_start_height: int = 10,
+    widget_max_height: int = 300,
+    batch_size: int = 10,
+) -> tuple[dict | None, TARDISLogger]:
     """Configure and initialize the TARDIS logging system.
-    
+
     Parameters
     ----------
     log_level : str
@@ -244,17 +261,25 @@ def logging_state(log_level, tardis_config, specific_log_level=None, display_log
         Maximum height for widget columns. Default is 300.
     batch_size : int, optional
         Number of logs to batch before updating widget. Default is 10.
-        
+
     Returns
     -------
     dict
         Dictionary of log columns if display_logging_widget is True, otherwise None.
     """
-    log_columns = create_logger_columns(start_height=widget_start_height, max_height=widget_max_height)
-    tardislogger = TARDISLogger(log_columns=log_columns, batch_size=batch_size)
+    tardislogger = TARDISLogger(batch_size=batch_size)
     tardislogger.configure_logging(log_level, tardis_config, specific_log_level)
     use_widget = display_logging_widget and Environment.allows_widget_display()
-    
+
+    if not use_widget:
+        tardislogger.setup_stream_handler()
+        return None, tardislogger
+
+    log_columns = create_logger_columns(
+        start_height=widget_start_height, max_height=widget_max_height
+    )
+    tardislogger.log_columns = log_columns
+
     if Environment.is_notebook() or Environment.is_sshjh() or Environment.is_sphinx():
         display_handles = {}
         display_ids = {}
@@ -262,7 +287,7 @@ def logging_state(log_level, tardis_config, specific_log_level=None, display_log
             display_id = f"logger_column_{level.lower().replace('/', '_')}"
             display_handles[level] = display(column, display_id=display_id)
             display_ids[level] = display_id
-        
+
         # Update tardislogger with display handles and IDs
         tardislogger.display_handles = display_handles
         tardislogger.display_ids = display_ids
@@ -270,15 +295,7 @@ def logging_state(log_level, tardis_config, specific_log_level=None, display_log
         # Use direct display for vscode (no change)
         for level, column in log_columns.items():
             display(column)
-    elif Environment.is_terminal():
-        logger.warning("Terminal environment detected, skipping logger widget")
-    else:
-        logger.warning("Unknown environment, skipping logger widget")
-
     # Setup widget logging once after display handles are configured
-    tardislogger.setup_widget_logging(display_widget=display_logging_widget)
-    
-    if use_widget:
-        return log_columns, tardislogger
-    else:
-        return None, tardislogger
+    tardislogger.setup_widget_logging()
+
+    return log_columns, tardislogger

--- a/tardis/io/logger/tests/test_logging_state.py
+++ b/tardis/io/logger/tests/test_logging_state.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+
+import pytest
+
+from tardis.io.logger import logger
+
+
+def test_logging_state_uses_stream_handler_without_widget_display(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tardis_logger = Mock()
+    logger_factory = Mock(return_value=tardis_logger)
+    create_logger_columns = Mock()
+    monkeypatch.setattr(logger, "TARDISLogger", logger_factory)
+    monkeypatch.setattr(logger, "create_logger_columns", create_logger_columns)
+    monkeypatch.setattr(logger.Environment, "allows_widget_display", lambda: False)
+    monkeypatch.setattr(logger.Environment, "is_notebook", lambda: False)
+    monkeypatch.setattr(logger.Environment, "is_sshjh", lambda: False)
+    monkeypatch.setattr(logger.Environment, "is_sphinx", lambda: False)
+    monkeypatch.setattr(logger.Environment, "is_vscode", lambda: False)
+    monkeypatch.setattr(logger.Environment, "is_terminal", lambda: True)
+
+    log_columns, actual_logger = logger.logging_state(
+        "INFO", {}, display_logging_widget=True
+    )
+
+    assert log_columns is None
+    assert actual_logger is tardis_logger
+    create_logger_columns.assert_not_called()
+    tardis_logger.setup_stream_handler.assert_called_once_with()
+    tardis_logger.setup_widget_logging.assert_not_called()
+
+
+def test_logging_state_does_not_create_widget_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tardis_logger = Mock()
+    logger_factory = Mock(return_value=tardis_logger)
+    create_logger_columns = Mock()
+    monkeypatch.setattr(logger, "TARDISLogger", logger_factory)
+    monkeypatch.setattr(logger, "create_logger_columns", create_logger_columns)
+    monkeypatch.setattr(logger.Environment, "allows_widget_display", lambda: True)
+
+    log_columns, actual_logger = logger.logging_state(
+        "INFO", {}, display_logging_widget=False
+    )
+
+    assert log_columns is None
+    assert actual_logger is tardis_logger
+    create_logger_columns.assert_not_called()
+    tardis_logger.setup_stream_handler.assert_called_once_with()
+    tardis_logger.setup_widget_logging.assert_not_called()


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix`

Fixes #3061.

`logging_state` created Panel logger columns and installed a widget handler
before checking whether widgets could be displayed. It now returns a standard
stream logger for non-widget environments and when
`display_logging_widget=False`; Panel resources are created only for
display-capable widget sessions.

### :pushpin: Resources

N/A

### :vertical_traffic_light: Testing

- [x] `conda run --no-capture-output -n tardis pytest tardis/io/logger/tests/test_logging_state.py -q`
- [x] `conda run --no-capture-output -n tardis pytest tardis/io/logger/tests -q`
- [x] `conda run --no-capture-output -n tardis ruff check tardis/io/logger/logger.py tardis/io/logger/tests/test_logging_state.py`
- [x] `conda run --no-capture-output -n tardis pytest tardis -q` — 411 passed, 1886 skipped, 17 xfailed, 3 xpassed.
- [x] Local documentation build completed with pre-existing warnings.
- [ ] I built the documentation by applying the `build_docs` label.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request.
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.

### :robot: AI Usage Statement

OpenAI Codex was used to inspect the logging setup path, draft code changes, add targeted test coverage, and run validation. The human contributor reviewed all AI-assisted changes, fully understanding them.