### PR TITLE
[GSoC] Store quantity units with HDF output

### DIFF
--- a/docs/io/hdf/index.rst
+++ b/docs/io/hdf/index.rst
@@ -15,6 +15,25 @@ What is HDF5?
 In TARDIS, it is used to store the data from simulations and other actions.
 
 
+Quantity units
+--------------
+
+When TARDIS writes an Astropy quantity to HDF5, it stores the numeric values in
+CGS and writes the matching CGS units to a sibling ``units`` Series. For
+example, a property stored at ``/transport/output_nu`` has its unit at
+``/transport/units`` under the ``output_nu`` index. This lets users recreate a
+quantity without hard-coding a unit:
+
+.. code-block:: python
+
+    import pandas as pd
+    from astropy import units as u
+
+    output_nu = pd.read_hdf("transport_output.hdf", "/transport/output_nu")
+    units = pd.read_hdf("transport_output.hdf", "/transport/units")
+    output_nu = u.Quantity(output_nu.to_numpy(), units["output_nu"])
+
+
 HDF5 structure
 --------------
 

--- a/tardis/io/hdf_writer_mixin.py
+++ b/tardis/io/hdf_writer_mixin.py
@@ -54,7 +54,8 @@ class HDFWriterMixin:
         1D arrays will be stored under path/property_name as distinct Series.
         2D arrays will be stored under path/property_name as distinct DataFrames.
 
-        Units will be stored as their CGS value.
+        Quantities are stored as CGS values. Their corresponding CGS units are
+        stored in a ``units`` Series alongside the data.
 
         Parameters
         ----------
@@ -94,7 +95,9 @@ class HDFWriterMixin:
 
         try:  # when path_or_buf is a str, the HDFStore should get created
             buf = pd.HDFStore(
-                path_or_buf, complevel=complevel, complib=complib  # type: ignore[arg-type]
+                path_or_buf,
+                complevel=complevel,
+                complib=complib,  # type: ignore[arg-type]
             )
         except TypeError as e:
             if str(e) == "Expected bytes, got HDFStore":
@@ -110,10 +113,12 @@ class HDFWriterMixin:
             buf.open()
 
         scalars = {}
+        units = {}
         for key, value in elements.items():
             if value is None:
                 value = "none"
             if hasattr(value, "cgs"):
+                units[key] = str(value.cgs.unit)
                 value = value.cgs.value
             if np.isscalar(value):
                 scalars[key] = value
@@ -164,6 +169,11 @@ class HDFWriterMixin:
         if scalars:
             pd.Series(scalars, name="value").to_hdf(
                 buf, key=str(Path(path) / "scalars")
+            )
+
+        if units:
+            pd.Series(units, name="unit").to_hdf(
+                buf, key=str(Path(path) / "units")
             )
 
         if buf.is_open:
@@ -244,13 +254,18 @@ class HDFWriterMixin:
             except AttributeError:
                 name = self.convert_to_snake_case(self.__class__.__name__)
                 logger.debug(
-                    "self.hdf_name not present, setting name to %s for HDF", name
+                    "self.hdf_name not present, setting name to %s for HDF",
+                    name,
                 )
 
         data = self.get_properties()
         buff_path = str(Path(path) / (name or ""))
         self.to_hdf_util(
-            file_path_or_buf, buff_path, data, overwrite=overwrite, format=format
+            file_path_or_buf,
+            buff_path,
+            data,
+            overwrite=overwrite,
+            format=format,
         )
 
 

--- a/tardis/io/tests/test_HDFWriter.py
+++ b/tardis/io/tests/test_HDFWriter.py
@@ -1,11 +1,13 @@
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 from astropy import units as u
 from numpy.testing import assert_array_almost_equal
 
-from tardis.io.hdf_writer_mixin import HDFWriterMixin
 from tardis import __version__
+from tardis.io.hdf_writer_mixin import HDFWriterMixin
 
 # Test Cases
 
@@ -108,6 +110,24 @@ def test_scalar_quantity_objects_write(tmpdir, attr):
     assert_array_almost_equal(actual.property.cgs.value, expected)
 
 
+@pytest.mark.parametrize(
+    "attr, expected_unit",
+    [
+        (u.Quantity([1.0, 2.0], "km"), u.cm),
+        (u.Quantity(2.0, "solMass"), u.g),
+    ],
+)
+def test_quantity_units_are_written_in_cgs(
+    tmp_path: Path, attr: u.Quantity, expected_unit: u.UnitBase
+) -> None:
+    fname = str(tmp_path / "test.hdf")
+
+    MockHDF(attr).to_hdf(fname, path="test", overwrite=True)
+
+    stored_unit = pd.read_hdf(fname, key="/test/mock_hdf/units")["property"]
+    assert u.Unit(stored_unit) == expected_unit
+
+
 def test_none_write(tmpdir):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(None)
@@ -167,7 +187,7 @@ def test_tardis_version_metadata(tmpdir):
     fname = str(tmpdir.mkdir("data").join("test.hdf"))
     actual = MockHDF(1.5)
     actual.to_hdf(fname, path="test", overwrite=True)
-    
+
     metadata = pd.read_hdf(fname, key="/test/mock_hdf/metadata")
     assert "tardis_version" in metadata
     assert metadata["tardis_version"] == __version__


### PR DESCRIPTION
### :pencil: Description

**Type:** :sparkles: `feature`

Closes #1250.

Store a CGS unit for each Astropy quantity written by `HDFWriterMixin`, while
preserving the existing CGS numeric datasets. Units are exposed through a
sibling `units` HDF Series, with documentation for reconstructing a quantity
from HDF output.

### :pushpin: Resources

N/A

### :vertical_traffic_light: Testing

- [x] `conda run --no-capture-output -n tardis python -m pytest tardis/io/tests/test_HDFWriter.py -q` — 18 passed.
- [x] Direct HDF quantity round trip verified CGS values and stored units.
- [x] `conda run --no-capture-output -n tardis ruff format --check tardis/io/hdf_writer_mixin.py tardis/io/tests/test_HDFWriter.py`
- [x] Local documentation build completed with unrelated existing warnings.
- [ ] I built the documentation by applying the `build_docs` label.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request.
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.

### :robot: AI Usage Statement

OpenAI Codex was used to inspect the HDF serialization path, draft code and documentation changes, add targeted test coverage, and run validation commands. The human contributor reviewed all AI-assisted changes, fully understanding them.