### PR TITLE
Add regression data commit info to the release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get regression data commit
+        uses: actions/checkout@v6
+        with:
+          repository: tardis-sn/tardis-regression-data
+          path: tardis-regression-data
+          fetch-depth: 1
+
+      - name: Record regression data commit
+        run: echo "REGRESSION_DATA_COMMIT=$(git -C tardis-regression-data rev-parse HEAD)" >> $GITHUB_ENV
+
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
@@ -100,6 +110,8 @@ jobs:
             This release has been created automatically by the TARDIS continuous delivery pipeline.
             ${{ env.doi_badge }}
             ${{ steps.git-cliff.outputs.content }}
+
+            Regression data: [${{ env.REGRESSION_DATA_COMMIT }}](https://github.com/tardis-sn/tardis-regression-data/commit/${{ env.REGRESSION_DATA_COMMIT }})
 
             A complete list of changes for this release is available at [CHANGELOG.md](https://github.com/tardis-sn/tardis/blob/master/CHANGELOG.md).
           files: |


### PR DESCRIPTION
### :pencil: Description

**Type:** :roller_coaster: `infrastructure`

This will make it easier to test old versions of tardis if necessary. Note that it is not back-propagating.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [x] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
