### PR TITLE
[GSoC] Add configuration-based file logging

### DIFF
--- a/docs/io/optional/index.rst
+++ b/docs/io/optional/index.rst
@@ -23,3 +23,16 @@ Additionally, ``run_tardis`` can take in a filepath for the atomic data and a bo
 
 Both of these are also options in the :ref:`configuration file <config-components>`. The option to pass them inside ``run_tardis``
 may be removed in a future release of the code.
+
+
+File logging
+============
+
+Set ``debug.log_file`` in a configuration file to write TARDIS log records to a
+plain UTF-8 text file. The file output does not contain terminal color escape
+sequences and is produced in addition to the usual stream or widget logging.
+
+.. code-block:: yaml
+
+    debug:
+      log_file: tardis.log

--- a/tardis/io/configuration/schemas/debug.yml
+++ b/tardis/io/configuration/schemas/debug.yml
@@ -19,4 +19,6 @@ properties:
     type: boolean
     default: false
     description: Allows for logging on the specified logging levels
-
+  log_file:
+    type: string
+    description: Path to a plain-text file that receives TARDIS log records

--- a/tardis/io/configuration/tests/test_config_validator.py
+++ b/tardis/io/configuration/tests/test_config_validator.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -65,6 +66,15 @@ def test_validate_dict(tardis_config_verysimple):
     # Checks for default value when not provided
     assert config_dict_verysimple["plasma"]["initial_t_inner"] == "-1 K"
     assert config_dict_verysimple["supernova"]["luminosity_wavelength_start"] == "0 angstrom"
+
+
+def test_validate_log_file(tardis_config_verysimple: dict) -> None:
+    """Allow a log-file path in the debug configuration section."""
+    configuration = deepcopy(tardis_config_verysimple)
+    configuration["debug"] = {"log_file": "tardis.log"}
+
+    validated_configuration = validate_dict(configuration)
+    assert validated_configuration["debug"]["log_file"] == "tardis.log"
 
 
 def test_validate_yaml():

--- a/tardis/io/logger/logger.py
+++ b/tardis/io/logger/logger.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 import panel as pn
 from IPython.display import display
 import pandas as pd
@@ -199,6 +200,30 @@ class TARDISLogger:
         self.logger.addHandler(stream_handler)
         PYTHON_WARNINGS_LOGGER.addHandler(stream_handler)
 
+    def setup_file_handler(self, log_file: str | Path) -> logging.FileHandler:
+        """Write TARDIS logs to a plain UTF-8 file.
+
+        Parameters
+        ----------
+        log_file : str or pathlib.Path
+            Path to the file that receives TARDIS log records.
+
+        Returns
+        -------
+        logging.FileHandler
+            Configured handler attached to the TARDIS and warnings loggers.
+        """
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setFormatter(
+            logging.Formatter(
+                "%(name)s [%(levelname)s] %(message)s (%(filename)s:%(lineno)d)"
+            )
+        )
+
+        self.logger.addHandler(file_handler)
+        PYTHON_WARNINGS_LOGGER.addHandler(file_handler)
+        return file_handler
+
 class LogFilter:
     """Filter for controlling which log levels are displayed.
     
@@ -277,6 +302,10 @@ def logging_state(log_level, tardis_config, specific_log_level=None, display_log
 
     # Setup widget logging once after display handles are configured
     tardislogger.setup_widget_logging(display_widget=display_logging_widget)
+
+    log_file = tardis_config.get("debug", {}).get("log_file")
+    if log_file:
+        tardislogger.setup_file_handler(log_file)
     
     if use_widget:
         return log_columns, tardislogger

--- a/tardis/io/logger/tests/test_file_logging.py
+++ b/tardis/io/logger/tests/test_file_logging.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from tardis.io.logger.logger import (
+    PYTHON_WARNINGS_LOGGER,
+    TARDISLogger,
+    logging_state,
+)
+
+
+def test_file_handler_writes_plain_utf8_logs(tmp_path: Path) -> None:
+    """Write TARDIS log records to an uncolored UTF-8 file."""
+    tardis_logger = TARDISLogger()
+    log_path = tmp_path / "tardis.log"
+
+    file_handler = tardis_logger.setup_file_handler(log_path)
+    tardis_logger.logger.warning("log message written to file")
+    file_handler.close()
+
+    tardis_logger.logger.removeHandler(file_handler)
+    PYTHON_WARNINGS_LOGGER.removeHandler(file_handler)
+
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert "log message written to file" in log_contents
+    assert "\x1b" not in log_contents
+
+
+def test_logging_configuration_writes_to_log_file(tmp_path: Path) -> None:
+    """Configure file logging through the debug configuration section."""
+    log_path = tmp_path / "configured.log"
+    configuration = {"debug": {"log_file": str(log_path)}}
+
+    with (
+        patch.object(TARDISLogger, "setup_widget_logging"),
+        patch(
+            "tardis.io.logger.logger.Environment.allows_widget_display",
+            return_value=False,
+        ),
+        patch(
+            "tardis.io.logger.logger.Environment.is_notebook",
+            return_value=False,
+        ),
+        patch(
+            "tardis.io.logger.logger.Environment.is_sshjh", return_value=False
+        ),
+        patch(
+            "tardis.io.logger.logger.Environment.is_sphinx", return_value=False
+        ),
+        patch(
+            "tardis.io.logger.logger.Environment.is_vscode", return_value=False
+        ),
+        patch(
+            "tardis.io.logger.logger.Environment.is_terminal",
+            return_value=False,
+        ),
+    ):
+        _, tardis_logger = logging_state(None, configuration)
+
+    file_handler = next(
+        handler
+        for handler in tardis_logger.logger.handlers
+        if getattr(handler, "baseFilename", None) == str(log_path)
+    )
+    tardis_logger.logger.warning("configured file logging")
+    file_handler.close()
+
+    tardis_logger.logger.removeHandler(file_handler)
+    PYTHON_WARNINGS_LOGGER.removeHandler(file_handler)
+
+    assert "configured file logging" in log_path.read_text(encoding="utf-8")


### PR DESCRIPTION
### :pencil: Description

**Type:** :sparkles: `feature`

Partially addresses #1859.

Add `debug.log_file` as a validated configuration option for persistent TARDIS
logs. File output is plain UTF-8 text without terminal color escape sequences.
Configurable terminal colors remain out of scope for this PR.

### :pushpin: Resources

N/A

### :vertical_traffic_light: Testing

- [x] `conda run --no-capture-output -n tardis python -m pytest tardis/io/logger/tests/test_file_logging.py tardis/io/configuration/tests/test_config_validator.py -q` — 8 passed.
- [x] `conda run --no-capture-output -n tardis ruff check tardis/io/logger/tests/test_file_logging.py`
- [x] `conda run --no-capture-output -n tardis ruff format --check tardis/io/logger/tests/test_file_logging.py`
- [ ] Full test suite — not run.
- [ ] Documentation build/preview — not run.

The existing logger and configuration-test modules have pre-existing Ruff
violations outside this change; no unrelated reformat was included.

### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request.
- [x] I updated the documentation according to my changes.
- [ ] I built the documentation by applying the `build_docs` label.

### :robot: AI Usage Statement

OpenAI Codex was used to inspect the logging and configuration paths, draft code
and documentation changes, add targeted test coverage, and run validation
commands. The human contributor reviewed all AI-assisted changes, fully
understanding them.